### PR TITLE
CMake: Don't hardcode site-specific path to Boost installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,6 @@ project(QwAnalysis VERSION 0.1 LANGUAGES CXX)
 
 # Local path for cmake modules
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/modules/")
-list(APPEND CMAKE_PREFIX_PATH "/work/halla/moller12gev/pking/local_devel/boost_1_82_0")
 
 # Default install path is the source directory
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)


### PR DESCRIPTION
Hardcoding application paths breaks compilation for everyone else who doesn't use the same environment on JLab machines.
