### PR TITLE
feat: CI build and test pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,7 +166,7 @@ jobs:
     - build
     strategy:
       matrix:
-        CC: [clang]
+        CC: [gcc]
         CMAKE_BUILD_TYPE: [Release]
         runs:
         - 1:1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  clang-tidy-release: dev3
+  clang-tidy-release: LCG_105
   clang-tidy-platform: x86_64-el9-clang16-opt
   clang-tidy-CC: clang
   clang-tidy-CMAKE_BUILD_TYPE: Debug
@@ -37,12 +37,12 @@ jobs:
             CC: gcc
             CXX: g++
             CMAKE_BUILD_TYPE: Debug
-          - release: dev3
+          - release: LCG_105
             platform: x86_64-el9-clang16-opt
             CC: clang
             CXX: clang++
             CMAKE_BUILD_TYPE: Release
-          - release: dev3
+          - release: LCG_105
             platform: x86_64-el9-clang16-opt
             CC: clang
             CXX: clang++

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,62 @@
+name: linux-eic-shell
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  pull_request:
+  merge_group:
+  workflow_dispatch: # allow manual triggering
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - CC: gcc
+            CXX: g++
+          - CC: clang
+            CXX: clang++
+    env:
+      PREFIX: ${{ github.workspace }}/install
+    steps:
+    - uses: actions/checkout@v4
+    - name: Prepare ccache timestamp
+      id: ccache_cache_timestamp
+      run: |
+        echo "timestamp=$(date --iso-8601=minutes)" >> $GITHUB_OUTPUT
+    - name: Retrieve ccache cache files
+      uses: actions/cache@v4
+      with:
+        path: .ccache
+        key: ccache-${{ matrix.CC }}-${{ github.ref_name }}-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+        restore-keys: |
+             ccache-${{ matrix.CC }}-${{ github.ref_name }}-
+             ccache-${{ matrix.CC }}-
+             ccache-
+    - name: Configure ccache
+      run: |
+        mkdir -p ~/.ccache/
+        echo "cache_dir=${{ github.workspace }}/.ccache" >> ~/.ccache/ccache.conf
+        echo "max_size=500MB" >> ~/.ccache/ccache.conf
+        echo "compression=true" >> ~/.ccache/ccache.conf
+    - uses: cvmfs-contrib/github-action-cvmfs@v4
+    - uses: aidasoft/run-lcg-view@v3
+      with:
+        release-platform: "LCG_105/x86_64-ubuntu2204-gcc11-opt"
+        run: |
+          CC=${{ matrix.CC }} CXX=${{ matrix.CXX }} cmake -B build -S . -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          cmake --build build -- -k -j $(getconf _NPROCESSORS_ONLN) install
+    - uses: actions/upload-artifact@v4
+      with:
+        name: build-${{ matrix.CC }}
+        path: install/
+        if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,7 +180,7 @@ jobs:
     - name: Download install directory
       uses: actions/download-artifact@v4
       with:
-        name: install-${{ matrix.CC }}-{{ matrix.CMAKE_BUILD_TYPE }}-${{ env.release }}-${{ env.platform }}
+        name: install-${{ matrix.CC }}-${{ matrix.CMAKE_BUILD_TYPE }}-${{ env.release }}-${{ env.platform }}
     - name: Uncompress install directory
       run: tar -xaf install.tar.zst
     - uses: cvmfs-contrib/github-action-cvmfs@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - CC: gcc
+          - LCG: "LCG_105/x86_64-ubuntu2204-gcc11-opt"
+            CC: gcc
             CXX: g++
-          - CC: clang
+          - LCG: "dev3/x86_64-el9-clang16-opt"
+            CC: clang
             CXX: clang++
     env:
       PREFIX: ${{ github.workspace }}/install
@@ -51,9 +53,10 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: aidasoft/run-lcg-view@v3
       with:
-        release-platform: "LCG_105/x86_64-ubuntu2204-gcc11-opt"
+        release-platform: ${{ matrix.LCG }}
         run: |
-          CC=${{ matrix.CC }} CXX=${{ matrix.CXX }} cmake -B build -S . -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          export CC=${{ matrix.CC }} CXX=${{ matrix.CXX }}
+          cmake -B build -S . -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           cmake --build build -- -k -j $(getconf _NPROCESSORS_ONLN) install
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
         release-platform: ${{ matrix.LCG }}
         run: |
           export CC=${{ matrix.CC }} CXX=${{ matrix.CXX }}
-          cmake -B build -S . -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          cmake -B build -S . -DCMAKE_INSTALL_PREFIX=install -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           cmake --build build -- -k -j $(getconf _NPROCESSORS_ONLN) install
     - name: Compress install directory
       run: tar -caf install.tar.zst install/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,9 +61,13 @@ jobs:
       uses: actions/cache@v4
       with:
         path: .ccache
-        key: ccache-${{ matrix.CC }}-${{ github.ref_name }}-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+        key: ccache-${{ matrix.CC }}-${{ matrix.release }}-${{ matrix.CMAKE_BUILD_TYPE }}-${{ github.event.pull_request.head.ref || github.ref_name }}-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
         restore-keys: |
-             ccache-${{ matrix.CC }}-${{ github.ref_name }}-
+             ccache-${{ matrix.CC }}-${{ matrix.release }}-${{ matrix.CMAKE_BUILD_TYPE }}-${{ github.ref_name }}-
+             ccache-${{ matrix.CC }}-${{ matrix.release }}-${{ matrix.CMAKE_BUILD_TYPE }}-${{ github.event.pull_request.head.ref }}-
+             ccache-${{ matrix.CC }}-${{ matrix.release }}-${{ matrix.CMAKE_BUILD_TYPE }}-${{ github.event.pull_request.base.ref }}-
+             ccache-${{ matrix.CC }}-${{ matrix.release }}-${{ matrix.CMAKE_BUILD_TYPE }}-
+             ccache-${{ matrix.CC }}-${{ matrix.release }}-
              ccache-${{ matrix.CC }}-
              ccache-
     - name: Configure ccache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  clang-tidy-LCG: dev3/x86_64-el9-clang16-opt
+  clang-tidy-CC: clang
+  clang-tidy-CMAKE_BUILD_TYPE: Debug
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -24,13 +29,25 @@ jobs:
           - LCG: "LCG_105/x86_64-ubuntu2204-gcc11-opt"
             CC: gcc
             CXX: g++
+            CMAKE_BUILD_TYPE: Release
+          - LCG: "LCG_105/x86_64-ubuntu2204-gcc11-opt"
+            CC: gcc
+            CXX: g++
+            CMAKE_BUILD_TYPE: Debug
           - LCG: "dev3/x86_64-el9-clang16-opt"
             CC: clang
             CXX: clang++
+            CMAKE_BUILD_TYPE: Release
+          - LCG: "dev3/x86_64-el9-clang16-opt"
+            CC: clang
+            CXX: clang++
+            CMAKE_BUILD_TYPE: Debug
     env:
       PREFIX: ${{ github.workspace }}/install
     steps:
     - uses: actions/checkout@v4
+      with:
+        filter: "tree:0"
     - name: Prepare ccache timestamp
       id: ccache_cache_timestamp
       run: |
@@ -58,8 +75,65 @@ jobs:
           export CC=${{ matrix.CC }} CXX=${{ matrix.CXX }}
           cmake -B build -S . -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           cmake --build build -- -k -j $(getconf _NPROCESSORS_ONLN) install
-    - uses: actions/upload-artifact@v4
+    - name: Compress install directory
+      run: tar -caf install.tar.zst install/
+    - name: Upload install directory
+      uses: actions/upload-artifact@v4
       with:
-        name: build-${{ matrix.CC }}
-        path: install/
+        name: install-${{ matrix.CC }}-${{ matrix.CMAKE_BUILD_TYPE }}-${{ matrix.LCG }}
+        path: install.tar.zst
         if-no-files-found: error
+    - name: Compress build directory
+      if: matrix.LCG == env.clang-tidy-LCG && matrix.CC == env.clang-tidy-CC && matrix.CMAKE_BUILD_TYPE == env.clang-tidy-CMAKE_BUILD_TYPE
+      run: tar -caf build.tar.zst build/
+    - name: Upload build directory
+      if: matrix.LCG == env.clang-tidy-LCG && matrix.CC == env.clang-tidy-CC && matrix.CMAKE_BUILD_TYPE == env.clang-tidy-CMAKE_BUILD_TYPE
+      uses: actions/upload-artifact@v4
+      with:
+        name: build-${{ matrix.CC }}-eic-shell-${{ matrix.CMAKE_BUILD_TYPE }}-${{ env.platform }}-${{ matrix.release }}
+        path: build.tar.zst
+        if-no-files-found: error
+
+  clang-tidy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        filter: "tree:0"
+    - uses: cvmfs-contrib/github-action-cvmfs@v4
+    - name: Download build artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: build-${{ env.clang-tidy-CC }}-eic-shell-${{ env.clang-tidy-CMAKE_BUILD_TYPE }}-${{ env.platform }}-${{ env.release }}
+        path: .
+    - name: Uncompress build artifact
+      run: tar -xaf build.tar.zst
+    - name: Run clang-tidy on changed files
+      uses: aidasoft/run-lcg-view@v3
+      if: ${{ github.event_name == 'pull_request' }}
+      with:
+        platform-release: "${{ env.platform }}:${{ env.release }}"
+        run: |
+          git diff ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }} | clang-tidy-diff -p 1 -path build -quiet -export-fixes clang_tidy_fixes.yml -extra-arg='-std=c++20' -checks='-*,bugprone-*,-bugprone-narrowing-conversions,-bugprone-macro-parentheses' -clang-tidy-binary run-clang-tidy
+    - name: Run clang-tidy on all files
+      uses: aidasoft/run-lcg-view@v3
+      if: ${{ github.event_name == 'push' }}
+      with:
+        platform-release: "${{ env.platform }}:${{ env.release }}"
+        run: |
+          run-clang-tidy -p build -export-fixes clang_tidy_fixes.yml -extra-arg='-std=c++20'
+    - name: Upload clang-tidy fixes as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: clang-tidy-fixes.yml
+        path: clang_tidy_fixes.yml
+        if-no-files-found: ignore
+    - name: Suggest clang-tidy fixes as PR comments
+      uses: platisd/clang-tidy-pr-comments@v1.5.0
+      if: ${{ github.event_name == 'pull_request' }}
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        clang_tidy_fixes: clang_tidy_fixes.yml
+        request_changes: true
+        suggestions_per_comment: 10

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
       uses: aidasoft/run-lcg-view@v3
       if: ${{ github.event_name == 'push' }}
       with:
-        platform-release: ${{ env.clang-tidy-platform }}/${{ env.clang-tidy-release }}
+        release-platform: ${{ env.clang-tidy-release }}/${{ env.clang-tidy-platform }}
         run: |
           run-clang-tidy -p build -export-fixes clang_tidy_fixes.yml -extra-arg='-std=c++20'
     - name: Upload clang-tidy fixes as artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,8 +175,6 @@ jobs:
     steps:
     - name: Checkout .github
       uses: actions/checkout@v4
-      with:
-        sparse-checkout: .github
     - name: Download install directory
       uses: actions/download-artifact@v4
       with:
@@ -190,6 +188,7 @@ jobs:
         release-platform: ${{ env.release }}/${{ env.platform }}
         run: |
           mkdir -p data/
+          export QW_PRMINPUT=Parity/prminput
           install/bin/qwmockdatagenerator -r ${{ matrix.runs }} -e ${{ matrix.events }} --config qwparity_simple.conf --detectors mock_newdets.map --data data/
     - name: Upload mock data
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,27 +182,21 @@ jobs:
     - name: Uncompress install directory
       run: tar -xaf install.tar.zst
     - uses: cvmfs-contrib/github-action-cvmfs@v4
-    - name: Run mock data generator
+    - name: Run mock data generator and analysis
       uses: aidasoft/run-lcg-view@v3
       with:
         release-platform: ${{ env.release }}/${{ env.platform }}
         run: |
           mkdir -p data/
-          export QW_PRMINPUT=Parity/prminput
           install/bin/qwmockdatagenerator -r ${{ matrix.runs }} -e ${{ matrix.events }} --config qwparity_simple.conf --detectors mock_newdets.map --data data/
+          mkdir -p rootfiles/
+          install/bin/qwparity -r ${{ matrix.runs }} --config qwparity_simple.conf --detectors mock_newdets.map --data-handler mock_datahandlers.map --data data/ --rootfiles rootfiles/
     - name: Upload mock data
       uses: actions/upload-artifact@v4
       with:
         name: QwMock.log
         path: data/*.log
         if-no-files-found: error
-    - name: Run mock data analysis
-      uses: aidasoft/run-lcg-view@v3
-      with:
-        release-platform: ${{ env.release }}/${{ env.platform }}
-        run: |
-          mkdir -p rootfiles/
-          install/bin/qwparity -r ${{ matrix.runs }} --config qwparity_simple.conf --detectors mock_newdets.map --data-handler mock_datahandlers.map --data data/ --rootfiles rootfiles/
     - name: Upload analysis
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  clang-tidy-release: LCG_105
+  clang-tidy-release: dev3
   clang-tidy-platform: x86_64-el9-clang16-opt
   clang-tidy-CC: clang
   clang-tidy-CMAKE_BUILD_TYPE: Debug
@@ -37,12 +37,12 @@ jobs:
             CC: gcc
             CXX: g++
             CMAKE_BUILD_TYPE: Debug
-          - release: LCG_105
+          - release: dev3
             platform: x86_64-el9-clang16-opt
             CC: clang
             CXX: clang++
             CMAKE_BUILD_TYPE: Release
-          - release: LCG_105
+          - release: dev3
             platform: x86_64-el9-clang16-opt
             CC: clang
             CXX: clang++

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
         release-platform: ${{ matrix.LCG }}
         run: |
           export CC=${{ matrix.CC }} CXX=${{ matrix.CXX }}
-          cmake -B build -S . -DCMAKE_INSTALL_PREFIX=install -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          cmake -B build -S . -DCMAKE_INSTALL_PREFIX=install -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           cmake --build build -- -k -j $(getconf _NPROCESSORS_ONLN) install
     - name: Compress install directory
       run: tar -caf install.tar.zst install/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
         release-platform: ${{ matrix.release }}/${{ matrix.platform }}
         run: |
           export CC=${{ matrix.CC }} CXX=${{ matrix.CXX }}
-          cmake -B build -S . -DCMAKE_INSTALL_PREFIX=install -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          cmake -B build -S . -DCMAKE_INSTALL_PREFIX=install -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }} -DCMAKE_CXX_STANDARD=20 -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           cmake --build build -- -k -j $(getconf _NPROCESSORS_ONLN) install
     - name: Compress install directory
       run: tar -caf install.tar.zst install/
@@ -137,14 +137,14 @@ jobs:
       with:
         release-platform: ${{ env.clang-tidy-release }}/${{ env.clang-tidy-platform }}
         run: |
-          git diff ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }} | clang-tidy-diff -p 1 -path build -quiet -export-fixes clang_tidy_fixes.yml -extra-arg='-std=c++20' -checks='-*,bugprone-*,-bugprone-narrowing-conversions,-bugprone-macro-parentheses' -clang-tidy-binary run-clang-tidy
+          git diff ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }} | clang-tidy-diff -p 1 -path build -quiet -export-fixes clang_tidy_fixes.yml -extra-arg="-std=c++20 -I${COMPILER_PATH}" -checks='-*,bugprone-*,-bugprone-narrowing-conversions,-bugprone-macro-parentheses' -clang-tidy-binary run-clang-tidy
     - name: Run clang-tidy on all files
       uses: aidasoft/run-lcg-view@v3
       if: ${{ github.event_name == 'push' }}
       with:
         release-platform: ${{ env.clang-tidy-release }}/${{ env.clang-tidy-platform }}
         run: |
-          run-clang-tidy -p build -export-fixes clang_tidy_fixes.yml -extra-arg='-std=c++20'
+          run-clang-tidy -p build -export-fixes clang_tidy_fixes.yml -extra-arg="-std=c++20 -I${COMPILER_PATH}"
     - name: Upload clang-tidy fixes as artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  clang-tidy-LCG: dev3/x86_64-el9-clang16-opt
+  clang-tidy-release: dev3
+  clang-tidy-platform: x86_64-el9-clang16-opt
   clang-tidy-CC: clang
   clang-tidy-CMAKE_BUILD_TYPE: Debug
 
@@ -26,19 +27,23 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - LCG: "LCG_105/x86_64-ubuntu2204-gcc11-opt"
+          - release: LCG_105
+            platform: x86_64-ubuntu2204-gcc11-opt
             CC: gcc
             CXX: g++
             CMAKE_BUILD_TYPE: Release
-          - LCG: "LCG_105/x86_64-ubuntu2204-gcc11-opt"
+          - release: LCG_105
+            platform: x86_64-ubuntu2204-gcc11-opt
             CC: gcc
             CXX: g++
             CMAKE_BUILD_TYPE: Debug
-          - LCG: "dev3/x86_64-el9-clang16-opt"
+          - release: dev3
+            platform: x86_64-el9-clang16-opt
             CC: clang
             CXX: clang++
             CMAKE_BUILD_TYPE: Release
-          - LCG: "dev3/x86_64-el9-clang16-opt"
+          - release: dev3
+            platform: x86_64-el9-clang16-opt
             CC: clang
             CXX: clang++
             CMAKE_BUILD_TYPE: Debug
@@ -70,7 +75,7 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: aidasoft/run-lcg-view@v3
       with:
-        release-platform: ${{ matrix.LCG }}
+        release-platform: ${{ matrix.release }}/${{ matrix.platform }}
         run: |
           export CC=${{ matrix.CC }} CXX=${{ matrix.CXX }}
           cmake -B build -S . -DCMAKE_INSTALL_PREFIX=install -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
@@ -80,17 +85,17 @@ jobs:
     - name: Upload install directory
       uses: actions/upload-artifact@v4
       with:
-        name: install-${{ matrix.CC }}-${{ matrix.CMAKE_BUILD_TYPE }}-${{ matrix.LCG }}
+        name: install-${{ matrix.CC }}-${{ matrix.CMAKE_BUILD_TYPE }}-${{ matrix.release }}-${{ matrix.platform }}
         path: install.tar.zst
         if-no-files-found: error
     - name: Compress build directory
-      if: matrix.LCG == env.clang-tidy-LCG && matrix.CC == env.clang-tidy-CC && matrix.CMAKE_BUILD_TYPE == env.clang-tidy-CMAKE_BUILD_TYPE
+      if: matrix.release == env.clang-tidy-release && matrix.platform == env.clang-tidy-platform && matrix.CC == env.clang-tidy-CC && matrix.CMAKE_BUILD_TYPE == env.clang-tidy-CMAKE_BUILD_TYPE
       run: tar -caf build.tar.zst build/
     - name: Upload build directory
-      if: matrix.LCG == env.clang-tidy-LCG && matrix.CC == env.clang-tidy-CC && matrix.CMAKE_BUILD_TYPE == env.clang-tidy-CMAKE_BUILD_TYPE
+      if: matrix.release == env.clang-tidy-release && matrix.platform == env.clang-tidy-platform && matrix.CC == env.clang-tidy-CC && matrix.CMAKE_BUILD_TYPE == env.clang-tidy-CMAKE_BUILD_TYPE
       uses: actions/upload-artifact@v4
       with:
-        name: build-${{ matrix.CC }}-eic-shell-${{ matrix.CMAKE_BUILD_TYPE }}-${{ env.platform }}-${{ matrix.release }}
+        name: build-${{ matrix.CC }}-${{ matrix.CMAKE_BUILD_TYPE }}-${{ matrix.platform }}-${{ matrix.release }}
         path: build.tar.zst
         if-no-files-found: error
 
@@ -105,7 +110,7 @@ jobs:
     - name: Download build artifact
       uses: actions/download-artifact@v4
       with:
-        name: build-${{ env.clang-tidy-CC }}-eic-shell-${{ env.clang-tidy-CMAKE_BUILD_TYPE }}-${{ env.platform }}-${{ env.release }}
+        name: build-${{ env.clang-tidy-CC }}-${{ env.clang-tidy-CMAKE_BUILD_TYPE }}-${{ env.clang-tidy-platform }}-${{ env.clang-tidy-release }}
         path: .
     - name: Uncompress build artifact
       run: tar -xaf build.tar.zst
@@ -113,14 +118,14 @@ jobs:
       uses: aidasoft/run-lcg-view@v3
       if: ${{ github.event_name == 'pull_request' }}
       with:
-        platform-release: "${{ env.platform }}:${{ env.release }}"
+        platform-release: ${{ env.clang-tidy-platform }}/${{ env.clang-tidy-release }}
         run: |
           git diff ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }} | clang-tidy-diff -p 1 -path build -quiet -export-fixes clang_tidy_fixes.yml -extra-arg='-std=c++20' -checks='-*,bugprone-*,-bugprone-narrowing-conversions,-bugprone-macro-parentheses' -clang-tidy-binary run-clang-tidy
     - name: Run clang-tidy on all files
       uses: aidasoft/run-lcg-view@v3
       if: ${{ github.event_name == 'push' }}
       with:
-        platform-release: "${{ env.platform }}:${{ env.release }}"
+        platform-release: ${{ env.clang-tidy-platform }}/${{ env.clang-tidy-release }}
         run: |
           run-clang-tidy -p build -export-fixes clang_tidy_fixes.yml -extra-arg='-std=c++20'
     - name: Upload clang-tidy fixes as artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
       uses: aidasoft/run-lcg-view@v3
       if: ${{ github.event_name == 'pull_request' }}
       with:
-        platform-release: ${{ env.clang-tidy-platform }}/${{ env.clang-tidy-release }}
+        release-platform: ${{ env.clang-tidy-release }}/${{ env.clang-tidy-platform }}
         run: |
           git diff ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }} | clang-tidy-diff -p 1 -path build -quiet -export-fixes clang_tidy_fixes.yml -extra-arg='-std=c++20' -checks='-*,bugprone-*,-bugprone-narrowing-conversions,-bugprone-macro-parentheses' -clang-tidy-binary run-clang-tidy
     - name: Run clang-tidy on all files

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,13 +8,20 @@ on:
       - '*'
   pull_request:
   merge_group:
-  workflow_dispatch: # allow manual triggering
+  workflow_dispatch:
+    inputs:
+      release-platform:
+        description: 'LCG release-platform'
+        default: 'LCG_105/x86_64-ubuntu2204-gcc11-opt'
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:
+  release-platform: ${{ inputs.platform || 'LCG_105/x86_64-ubuntu2204-gcc11-opt' }}
   clang-tidy-release: dev3
   clang-tidy-platform: x86_64-el9-clang16-opt
   clang-tidy-CC: clang
@@ -146,3 +153,52 @@ jobs:
         clang_tidy_fixes: clang_tidy_fixes.yml
         request_changes: true
         suggestions_per_comment: 10
+
+  mock:
+    runs-on: ubuntu-latest
+    needs:
+    - build
+    strategy:
+      matrix:
+        CC: [clang]
+        CMAKE_BUILD_TYPE: [Release]
+        runs:
+        - 1:1
+        events:
+        - 1:20000
+    steps:
+    - name: Checkout .github
+      uses: actions/checkout@v4
+      with:
+        sparse-checkout: .github
+    - name: Download install directory
+      uses: actions/download-artifact@v4
+      with:
+        name: install-${{ matrix.CC }}-{{ matrix.CMAKE_BUILD_TYPE }}-${{ env.release-platform }}
+    - name: Uncompress install directory
+      run: tar -xaf install.tar.zst
+    - uses: cvmfs-contrib/github-action-cvmfs@v4
+    - name: Run mock data generator
+      uses: aidasoft/run-lcg-view@v3
+      with:
+        run: |
+          mkdir -p data/
+          install/bin/qwmockdatagenerator -r ${{ matrix.runs }} -e ${{ matrix.events }} --config qwparity_simple.conf --detectors mock_newdets.map --data data/
+    - name: Upload mock data
+      uses: actions/upload-artifact@v4
+      with:
+        name: QwMock.log
+        path: data/*.log
+        if-no-files-found: error
+    - name: Run mock data analysis
+      uses: aidasoft/run-lcg-view@v3
+      with:
+        run: |
+          mkdir -p rootfiles/
+          install/bin/qwparity -r ${{ matrix.runs }} --config qwparity_simple.conf --detectors mock_newdets.map --data-handler mock_datahandlers.map --data data/ --rootfiles rootfiles/
+    - name: Upload analysis
+      uses: actions/upload-artifact@v4
+      with:
+        name: QwMock.root
+        path: rootfiles/*.root
+        if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,9 +10,14 @@ on:
   merge_group:
   workflow_dispatch:
     inputs:
-      release-platform:
-        description: 'LCG release-platform'
-        default: 'LCG_105/x86_64-ubuntu2204-gcc11-opt'
+      release:
+        description: 'Default LCG release'
+        default: 'LCG_105'
+        required: false
+        type: string
+      platform:
+        description: 'Default LCG platform'
+        default: 'x86_64-ubuntu2204-gcc11-opt'
         required: false
         type: string
 
@@ -21,7 +26,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  release-platform: ${{ inputs.platform || 'LCG_105/x86_64-ubuntu2204-gcc11-opt' }}
+  release: ${{ inputs.release || 'LCG_105' }}
+  platform: ${{ inputs.platform || 'x86_64-ubuntu2204-gcc11-opt' }}
   clang-tidy-release: dev3
   clang-tidy-platform: x86_64-el9-clang16-opt
   clang-tidy-CC: clang
@@ -174,13 +180,14 @@ jobs:
     - name: Download install directory
       uses: actions/download-artifact@v4
       with:
-        name: install-${{ matrix.CC }}-{{ matrix.CMAKE_BUILD_TYPE }}-${{ env.release-platform }}
+        name: install-${{ matrix.CC }}-{{ matrix.CMAKE_BUILD_TYPE }}-${{ env.release }}-${{ env.platform }}
     - name: Uncompress install directory
       run: tar -xaf install.tar.zst
     - uses: cvmfs-contrib/github-action-cvmfs@v4
     - name: Run mock data generator
       uses: aidasoft/run-lcg-view@v3
       with:
+        release-platform: ${{ env.release }}/${{ env.platform }}
         run: |
           mkdir -p data/
           install/bin/qwmockdatagenerator -r ${{ matrix.runs }} -e ${{ matrix.events }} --config qwparity_simple.conf --detectors mock_newdets.map --data data/
@@ -193,6 +200,7 @@ jobs:
     - name: Run mock data analysis
       uses: aidasoft/run-lcg-view@v3
       with:
+        release-platform: ${{ env.release }}/${{ env.platform }}
         run: |
           mkdir -p rootfiles/
           install/bin/qwparity -r ${{ matrix.runs }} --config qwparity_simple.conf --detectors mock_newdets.map --data-handler mock_datahandlers.map --data data/ --rootfiles rootfiles/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,14 +137,14 @@ jobs:
       with:
         release-platform: ${{ env.clang-tidy-release }}/${{ env.clang-tidy-platform }}
         run: |
-          git diff ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }} | clang-tidy-diff -p 1 -path build -quiet -export-fixes clang_tidy_fixes.yml -extra-arg="-std=c++20 -I${COMPILER_PATH}" -checks='-*,bugprone-*,-bugprone-narrowing-conversions,-bugprone-macro-parentheses' -clang-tidy-binary run-clang-tidy
+          git diff ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }} | clang-tidy-diff -p 1 -path build -quiet -export-fixes clang_tidy_fixes.yml -extra-arg=-std=c++20 -extra-arg=--gcc-toolchain=${COMPILER_PATH} -checks='-*,bugprone-*,-bugprone-narrowing-conversions,-bugprone-macro-parentheses' -clang-tidy-binary run-clang-tidy
     - name: Run clang-tidy on all files
       uses: aidasoft/run-lcg-view@v3
       if: ${{ github.event_name == 'push' }}
       with:
         release-platform: ${{ env.clang-tidy-release }}/${{ env.clang-tidy-platform }}
         run: |
-          run-clang-tidy -p build -export-fixes clang_tidy_fixes.yml -extra-arg="-std=c++20 -I${COMPILER_PATH}"
+          run-clang-tidy -p build -export-fixes clang_tidy_fixes.yml -extra-arg=-std=c++20 -extra-arg=--gcc-toolchain=${COMPILER_PATH}
     - name: Upload clang-tidy fixes as artifact
       uses: actions/upload-artifact@v4
       with:

--- a/Analysis/include/QwParameterFile.h
+++ b/Analysis/include/QwParameterFile.h
@@ -30,7 +30,6 @@
 // Boost headers
 #include "boost/lexical_cast.hpp"
 #include "boost/filesystem/operations.hpp"
-#include "boost/filesystem/convenience.hpp"
 #include "boost/filesystem/path.hpp"
 namespace bfs = boost::filesystem;
 using boost::lexical_cast;

--- a/Analysis/include/QwParameterFile.h
+++ b/Analysis/include/QwParameterFile.h
@@ -29,6 +29,7 @@
 
 // Boost headers
 #include "boost/lexical_cast.hpp"
+#include "boost/filesystem/directory.hpp"
 #include "boost/filesystem/operations.hpp"
 #include "boost/filesystem/path.hpp"
 namespace bfs = boost::filesystem;

--- a/Analysis/src/QwParameterFile.cc
+++ b/Analysis/src/QwParameterFile.cc
@@ -282,7 +282,7 @@ int QwParameterFile::FindFile(
 
   // Loop over all files in the directory
   // note: default iterator constructor yields past-the-end
-  bfs::directory_iterator end_iterator;
+  bfs::directory_iterator end_iterator = bfs::directory_iterator();
   for (bfs::directory_iterator file_iterator(directory);
        file_iterator != end_iterator;
        file_iterator++) {

--- a/Analysis/src/QwParameterFile.cc
+++ b/Analysis/src/QwParameterFile.cc
@@ -10,7 +10,6 @@
 
 #ifndef BOOST_VERSION
 #include "boost/version.hpp"
-#include "boost/filesystem/directory.hpp"
 #endif
 
 // Qweak headers
@@ -283,7 +282,7 @@ int QwParameterFile::FindFile(
 
   // Loop over all files in the directory
   // note: default iterator constructor yields past-the-end
-  bfs::directory_iterator end_iterator;
+  bfs::directory_iterator end_iterator();
   for (bfs::directory_iterator file_iterator(directory);
        file_iterator != end_iterator;
        file_iterator++) {

--- a/Analysis/src/QwParameterFile.cc
+++ b/Analysis/src/QwParameterFile.cc
@@ -282,7 +282,7 @@ int QwParameterFile::FindFile(
 
   // Loop over all files in the directory
   // note: default iterator constructor yields past-the-end
-  bfs::directory_iterator end_iterator();
+  bfs::directory_iterator end_iterator;
   for (bfs::directory_iterator file_iterator(directory);
        file_iterator != end_iterator;
        file_iterator++) {

--- a/Analysis/src/QwParameterFile.cc
+++ b/Analysis/src/QwParameterFile.cc
@@ -10,6 +10,7 @@
 
 #ifndef BOOST_VERSION
 #include "boost/version.hpp"
+#include "boost/filesystem/directory.hpp"
 #endif
 
 // Qweak headers

--- a/Analysis/src/QwParameterFile.cc
+++ b/Analysis/src/QwParameterFile.cc
@@ -282,7 +282,7 @@ int QwParameterFile::FindFile(
 
   // Loop over all files in the directory
   // note: default iterator constructor yields past-the-end
-  bfs::directory_iterator end_iterator = bfs::directory_iterator();
+  bfs::directory_iterator end_iterator;
   for (bfs::directory_iterator file_iterator(directory);
        file_iterator != end_iterator;
        file_iterator++) {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,14 +21,25 @@ include(CMakeEnv)
 include(GNUInstallDirs)
 set(INSTALL_CONFIGDIR "${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}")
 
+# Use, i.e. don't skip the full RPATH for the build tree, and use relative paths
+# for relocatable build products
+set(CMAKE_SKIP_BUILD_RPATH FALSE)
+set(CMAKE_BUILD_RPATH_USE_ORIGIN TRUE)
+
+# When building, don't use the install RPATH already (but later on when
+# installing)
+set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+set(CMAKE_SKIP_INSTALL_RPATH FALSE)
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+
+# Add the automatically determined parts of the RPATH which point to directories
+# outside the build tree to the install RPATH
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
 # Mac support
 message(STATUS "System name ${CMAKE_SYSTEM_NAME}")
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(CMAKE_MACOSX_RPATH ON)
-    set(CMAKE_SKIP_BUILD_RPATH FALSE)
-    set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
-    set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
     list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
     if("${isSystemDir}" STREQUAL "-1")
         set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,8 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     endif()
 endif()
 
+# Export compile commands as json for run-clang-tidy
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 #----------------------------------------------------------------------------
 # Sources and headers

--- a/Parity/include/QwBeamMod.h
+++ b/Parity/include/QwBeamMod.h
@@ -34,7 +34,49 @@
 
 // this emun vector needs to be coherent with the DetectorTypes declaration in the QwBeamLine constructor
 
-class QwModChannelID;
+
+
+/*****************************************************************
+*  Class:
+******************************************************************/
+class QwModChannelID
+{
+ public:
+
+  QwModChannelID(Int_t subbankid, Int_t wordssofar,TString name,
+                   TString modtype ,QwBeamMod * obj);
+
+   QwModChannelID(Int_t subbankid, QwParameterFile &paramfile);
+
+
+
+/*     QwModChannelID):fSubbankIndex(-1),fWordInSubbank(-1),fTypeID(-1),fIndex(-1), */
+/*     fSubelement(999999),fmoduletype(""),fmodulename("") */
+/*     {}; */
+
+  Int_t fSubbankIndex;        //Generated from ROCID(readout CPU) & BankID(corespondes to internal headers to ID differnt types of data..ex. F1TDC)
+  Int_t fWordInSubbank;
+  //first word reported for this channel in the subbank
+  //(eg VQWK channel report 6 words for each event, scalers oly report one word per event)
+
+  // The first word of the subbank gets fWordInSubbank=0
+
+  TString fmoduletype; // eg: VQWK, SCALER
+  TString fmodulename;
+  Int_t modnum;
+  Int_t channum;
+
+  // TString fdetectortype;
+
+  Int_t  kUnknownDeviceType;
+  Int_t  fTypeID;           // type of detector eg: lumi or stripline, etc..
+  Int_t  fIndex;            // index of this detector in the vector containing all the detector of same type
+
+  void Print();
+
+};
+
+
 
 /*****************************************************************
 *  Class:
@@ -173,46 +215,5 @@ class QwBeamMod: public VQwSubsystemParity, public MQwSubsystemCloneable<QwBeamM
  UInt_t fBmwObj_ErrorFlag;
 
 };
-
-
-
-class QwModChannelID
-{
- public:
-
-  QwModChannelID(Int_t subbankid, Int_t wordssofar,TString name,
-		   TString modtype ,QwBeamMod * obj);
-
-   QwModChannelID(Int_t subbankid, QwParameterFile &paramfile);
-  
-
-
-/*     QwModChannelID):fSubbankIndex(-1),fWordInSubbank(-1),fTypeID(-1),fIndex(-1), */
-/*     fSubelement(999999),fmoduletype(""),fmodulename("") */
-/*     {}; */
-
-  Int_t fSubbankIndex;        //Generated from ROCID(readout CPU) & BankID(corespondes to internal headers to ID differnt types of data..ex. F1TDC)
-  Int_t fWordInSubbank;
-  //first word reported for this channel in the subbank
-  //(eg VQWK channel report 6 words for each event, scalers oly report one word per event)
-
-  // The first word of the subbank gets fWordInSubbank=0
-
-  TString fmoduletype; // eg: VQWK, SCALER
-  TString fmodulename;
-  Int_t modnum;
-  Int_t channum;
-  
-  // TString fdetectortype;
-
-  Int_t  kUnknownDeviceType;
-  Int_t  fTypeID;           // type of detector eg: lumi or stripline, etc..
-  Int_t  fIndex;            // index of this detector in the vector containing all the detector of same type
-
-  void Print();
-
-};
-
-
 
 #endif

--- a/Parity/include/QwBeamMod.h
+++ b/Parity/include/QwBeamMod.h
@@ -25,7 +25,8 @@
 #include "QwVQWK_Channel.h"
 #include "QwWord.h"
 
-
+// Forward declarations
+class QwBeamMod;
 
 //enum EBeamInstrumentType{kBPMStripline = 0,
 //			 kBCM,

--- a/Parity/include/VQwDetectorArray.h
+++ b/Parity/include/VQwDetectorArray.h
@@ -20,8 +20,34 @@
 #include "QwCombinedPMT.h"
 
 
-// Forward declarations
-class QwDetectorArrayID;
+class QwDetectorArrayID {
+
+ public:
+
+    QwDetectorArrayID():fSubbankIndex(-1),fWordInSubbank(-1),
+     fTypeID(kQwUnknownPMT),fIndex(-1),
+     fSubelement(kInvalidSubelementIndex),fmoduletype(""),fdetectorname("") {};
+
+    int fSubbankIndex;
+    int fWordInSubbank; //first word reported for this channel in the subbank
+                        //(eg VQWK channel report 6 words for each event, scalers oly report one word per event)
+                        // The first word of the subbank gets fWordInSubbank=0
+
+    EQwPMTInstrumentType fTypeID;     // type of detector
+    int fIndex;      // index of this detector in the vector containing all the detector of same type
+    UInt_t fSubelement; // some detectors have many subelements (eg stripline have 4 antenas)
+                        // some have only one sub element(eg lumis have one channel)
+
+    TString fmoduletype; // eg: VQWK, SCALER
+    TString fdetectorname;
+    TString fdetectortype; // stripline, IntegrationPMT, ... this string is encoded by fTypeID
+
+    std::vector<TString> fCombinedChannelNames;
+    std::vector<Double_t> fWeight;
+
+    void Print() const;
+
+};
 
 
 class VQwDetectorArray: virtual public VQwSubsystemParity {
@@ -217,36 +243,6 @@ class VQwDetectorArray: virtual public VQwSubsystemParity {
 
   static const Bool_t bDEBUG=kFALSE;
   Int_t fMainDetErrorCount;
-
-};
-
-
-class QwDetectorArrayID {
-
- public:
-    
-    QwDetectorArrayID():fSubbankIndex(-1),fWordInSubbank(-1),
-     fTypeID(kQwUnknownPMT),fIndex(-1),
-     fSubelement(kInvalidSubelementIndex),fmoduletype(""),fdetectorname("") {};
-
-    int fSubbankIndex;
-    int fWordInSubbank; //first word reported for this channel in the subbank
-                        //(eg VQWK channel report 6 words for each event, scalers oly report one word per event)
-                        // The first word of the subbank gets fWordInSubbank=0
-
-    EQwPMTInstrumentType fTypeID;     // type of detector
-    int fIndex;      // index of this detector in the vector containing all the detector of same type
-    UInt_t fSubelement; // some detectors have many subelements (eg stripline have 4 antenas)
-                        // some have only one sub element(eg lumis have one channel)
-
-    TString fmoduletype; // eg: VQWK, SCALER
-    TString fdetectorname;
-    TString fdetectortype; // stripline, IntegrationPMT, ... this string is encoded by fTypeID
-
-    std::vector<TString> fCombinedChannelNames;
-    std::vector<Double_t> fWeight;
-
-    void Print() const;
 
 };
 


### PR DESCRIPTION
This PR adds a build and testing pipeline, using both gcc and clang as reference compilers. It runs the mock data generator and subsequent analysis. No validation on the analysis results is performed. This PR also adds a clang-tidy analysis for modified code segments (presumably some suggestions will appear on this PR).

TODO:
- [ ] merge #13 and rebase, as this PR is built on top of it.