### PR TITLE
Injector mock data fix

### DIFF
--- a/Parity/prminput/mock_data_parameters.map
+++ b/Parity/prminput/mock_data_parameters.map
@@ -79,3 +79,24 @@ energycalculator, target_energy,  0.0e-5,       0.0e-3,      1.0e-6 !1.0e-6
 energycalculator, target_energy,  drift         1.0e-5,        0.0,          43.0 !1.0e-5
 
 
+bpmstripline,     bpm0i01a       1.0e-3,       6.0,          3.0e-3,       1.0e-3,       -1.5,         4.0e-3
+bpmstripline,     bpm0i01        1.0e-3,       6.0,          3.0e-3,       1.0e-3,       -1.5,         4.0e-3
+bpmstripline,     bpm0i02a       1.0e-3,       6.0,          3.0e-3,       1.0e-3,       -1.5,         4.0e-3
+bpmstripline,     bpm0i02        1.0e-3,       6.0,          3.0e-3,       1.0e-3,       -1.5,         4.0e-3
+bpmstripline,     bpm0i05        1.0e-3,       6.0,          3.0e-3,       1.0e-3,       -1.5,         4.0e-3
+bpmstripline,     bpm0i07        1.0e-3,       6.0,          3.0e-3,       1.0e-3,       -1.5,         4.0e-3
+bpmstripline,     bpm0l01        1.0e-3,       6.0,          3.0e-3,       1.0e-3,       -1.5,         4.0e-3
+bpmstripline,     bpm0l02        1.0e-3,       6.0,          3.0e-3,       1.0e-3,       -1.5,         4.0e-3
+bpmstripline,     bpm0l03        1.0e-3,       6.0,          3.0e-3,       1.0e-3,       -1.5,         4.0e-3
+bpmstripline,     bpm0l04        1.0e-3,       6.0,          3.0e-3,       1.0e-3,       -1.5,         4.0e-3
+bpmstripline,     bpm0l05        1.0e-3,       6.0,          3.0e-3,       1.0e-3,       -1.5,         4.0e-3
+bpmstripline,     bpm0l06        1.0e-3,       6.0,          3.0e-3,       1.0e-3,       -1.5,         4.0e-3
+bpmstripline,     bpm0l07        1.0e-3,       6.0,          3.0e-3,       1.0e-3,       -1.5,         4.0e-3
+bpmstripline,     bpm0l08        1.0e-3,       6.0,          3.0e-3,       1.0e-3,       -1.5,         4.0e-3
+bpmstripline,     bpm0l09        1.0e-3,       6.0,          3.0e-3,       1.0e-3,       -1.5,         4.0e-3
+bpmstripline,     bpm0l10        1.0e-3,       6.0,          3.0e-3,       1.0e-3,       -1.5,         4.0e-3
+bpmstripline,     bpm1i02        1.0e-3,       6.0,          3.0e-3,       1.0e-3,       -1.5,         4.0e-3
+bpmstripline,     bpm1i04        1.0e-3,       6.0,          3.0e-3,       1.0e-3,       -1.5,         4.0e-3
+bpmstripline,     bpm1i06        1.0e-3,       6.0,          3.0e-3,       1.0e-3,       -1.5,         4.0e-3
+bpmstripline,     bpm2i01        1.0e-3,       6.0,          3.0e-3,       1.0e-3,       -1.5,         4.0e-3
+bpmstripline,     bpm2i02        1.0e-3,       6.0,          3.0e-3,       1.0e-3,       -1.5,         4.0e-3

--- a/Parity/prminput/mollinj_beamline.map
+++ b/Parity/prminput/mollinj_beamline.map
@@ -1,6 +1,6 @@
 
 ROC=24
-Bank=0x02
+Bank=0x2400
 vqwk_buffer_offset=1
 
 !same sample size for ADCs in a given bank


### PR DESCRIPTION
I fixed the milling_beamline.map file, changing the hex number on the "Bank" variable. This made injector mock data non-zero.