### PR TITLE
ci: avoid clang-tidy-diff; use xargs -n run-clang-tidy instead

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,7 @@ jobs:
       with:
         release-platform: ${{ env.clang-tidy-release }}/${{ env.clang-tidy-platform }}
         run: |
-          git diff --name-only ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }} | xargs -n run-clang-tidy -p build -export-fixes clang_tidy_fixes.yml -extra-arg=-std=c++20 -extra-arg=--gcc-toolchain=${COMPILER_PATH} -checks='-*,bugprone-*,-bugprone-narrowing-conversions,-bugprone-macro-parentheses'
+          git diff --name-only ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }} | xargs -n 1000 run-clang-tidy -p build -export-fixes clang_tidy_fixes.yml -extra-arg=-std=c++20 -extra-arg=--gcc-toolchain=${COMPILER_PATH} -checks='-*,bugprone-*,-bugprone-narrowing-conversions,-bugprone-macro-parentheses'
     - name: Run clang-tidy on all files
       uses: aidasoft/run-lcg-view@v3
       if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,7 @@ jobs:
       with:
         release-platform: ${{ env.clang-tidy-release }}/${{ env.clang-tidy-platform }}
         run: |
-          git diff ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }} | clang-tidy-diff -p 1 -path build -quiet -export-fixes clang_tidy_fixes.yml -extra-arg=-std=c++20 -extra-arg=--gcc-toolchain=${COMPILER_PATH} -checks='-*,bugprone-*,-bugprone-narrowing-conversions,-bugprone-macro-parentheses' -clang-tidy-binary run-clang-tidy
+          git diff --name-only ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }} | xargs -n run-clang-tidy -p build -export-fixes clang_tidy_fixes.yml -extra-arg=-std=c++20 -extra-arg=--gcc-toolchain=${COMPILER_PATH} -checks='-*,bugprone-*,-bugprone-narrowing-conversions,-bugprone-macro-parentheses'
     - name: Run clang-tidy on all files
       uses: aidasoft/run-lcg-view@v3
       if: ${{ github.event_name == 'push' }}

--- a/Parity/src/QwBeamMod.cc
+++ b/Parity/src/QwBeamMod.cc
@@ -775,6 +775,18 @@ void  QwBeamMod::FillHistograms()
   
   if (pattern < 0 || pattern > 4) return;
 
+  // Fill histograms for all BPMs and each of the modulation patterns
+  //
+  // Due to the the way the ADC averages the ramp signal we want to filter
+  // out events at the edged of the signal.
+  //
+  // Seperated the ramp cut here because it is ridiculously long... 
+  //
+
+  Double_t ramp_block_41 = fModChannel[fRampChannelIndex]->GetValue(4) + fModChannel[fRampChannelIndex]->GetValue(1); 
+  Double_t ramp_block_32 = fModChannel[fRampChannelIndex]->GetValue(3) + fModChannel[fRampChannelIndex]->GetValue(2);
+  Double_t ramp_block    = ramp_block_41 - ramp_block_32;  
+
 }
 
 

--- a/Parity/src/QwBeamMod.cc
+++ b/Parity/src/QwBeamMod.cc
@@ -775,18 +775,6 @@ void  QwBeamMod::FillHistograms()
   
   if (pattern < 0 || pattern > 4) return;
 
-  // Fill histograms for all BPMs and each of the modulation patterns
-  //
-  // Due to the the way the ADC averages the ramp signal we want to filter
-  // out events at the edged of the signal.
-  //
-  // Seperated the ramp cut here because it is ridiculously long... 
-  //
-
-  Double_t ramp_block_41 = fModChannel[fRampChannelIndex]->GetValue(4) + fModChannel[fRampChannelIndex]->GetValue(1); 
-  Double_t ramp_block_32 = fModChannel[fRampChannelIndex]->GetValue(3) + fModChannel[fRampChannelIndex]->GetValue(2);
-  Double_t ramp_block    = ramp_block_41 - ramp_block_32;  
-
 }
 
 


### PR DESCRIPTION
`clang-tidy-diff` is not installed in lcg views. This PR replaces the use of `clang-tidy-diff` with `run-clang-tidy` on a `git diff --name-only`.