### PR TITLE
CMake: Fix build error due to missing gitinfo.cc

### DIFF
--- a/cmake/modules/CMakeGitInfo.cmake
+++ b/cmake/modules/CMakeGitInfo.cmake
@@ -242,7 +242,7 @@ function(Main)
         # Check if the repo has changed.
         # If so, run the change action.
         CheckGit("${GIT_WORKING_DIR}" did_change state)
-        if(did_change)
+        if(did_change OR NOT EXISTS ${POST_CONFIGURE_FILE})
             message(STATUS "Git status has changed")
             GitStateChangedAction("${state}")
         else()


### PR DESCRIPTION
gitinfo.cc gets removed by "make clean" but not regenerated afterwards if there are no changes to the git status.