### PR TITLE
Re-enable TMapFile support for ROOT >= 6.32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,8 @@ target_compile_options(${PROJECT_NAME}
     ${${PROJECT_NAME_UC}_DIAG_FLAGS_LIST}
   )
 
-if(${CMAKE_CXX_STANDARD} LESS 17)
+# TMapFile is broken with C++17 or higher and ROOT < 6.32
+if(${CMAKE_CXX_STANDARD} LESS 17 OR ${ROOT_VERSION} VERSION_GREATER_EQUAL 6.32)
   target_compile_definitions(${PROJECT_NAME} PUBLIC QW_ENABLE_MAPFILE)
 endif()
 

--- a/cmake/modules/FindROOT.cmake
+++ b/cmake/modules/FindROOT.cmake
@@ -117,16 +117,18 @@ separate_arguments(ROOT_CXXFLAG_LIST)
 separate_arguments(ROOT_LIB_FLAGS)
 string(REPLACE "-l" "" ROOT_LIB_FLAGS "${ROOT_LIB_FLAGS}")
 
-# libNew is currently broken with C++17 or higher. See
-# https://root-forum.cern.ch/t/aborting-with-std-align-val-t-is-not-implemented-yet-rhel-9-2/55989/17
 string(REGEX MATCH "(^| +)-std=([^ ]*)\\+\\+(..)" _cxx_std "${ROOT_CXX_FLAGS}")
 set(uselibnew TRUE)
-if(CMAKE_MATCH_COUNT EQUAL 3)
-  if(${CMAKE_MATCH_3} GREATER_EQUAL 17)
+if(${ROOT_VERSION} VERSION_LESS 6.32)
+  if(CMAKE_MATCH_COUNT EQUAL 3)
+    # libNew is broken with C++17 or higher and ROOT < 6.32. See
+    # https://root-forum.cern.ch/t/aborting-with-std-align-val-t-is-not-implemented-yet-rhel-9-2/55989/17
+    if(${CMAKE_MATCH_3} GREATER_EQUAL 17)
+      set(uselibnew FALSE)
+    endif()
+  elseif(${CMAKE_CXX_STANDARD} GREATER_EQUAL 17)
     set(uselibnew FALSE)
   endif()
-elseif(${CMAKE_CXX_STANDARD} GREATER_EQUAL 17)
-  set(uselibnew FALSE)
 endif()
 unset(_cxx_std)
 


### PR DESCRIPTION
With version 6.32, the ROOT team has fixed the underlying issue (unimplemented overload of std::align_val_t) in libNew.