### PR TITLE
remove daily run to weekly for now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     types: [published]  # Triggered when a release is published
   workflow_dispatch:  # Allows manual trigger
   schedule:
-    - cron: '0 8 * * 1'  # 3:00 AM ET during Standard Time (UTC-5)
+    - cron: '0 8 * * 1'  # Monday 3:00 AM ET during Standard Time (UTC-5)
 
 jobs:
   build:


### PR DESCRIPTION
Change from daily to weekly.
Now the action runs: weekly and tag.

Thsi was done cause we hit the free limit of action on github. If this also causes an issue we will switch to JLAB gitlab build by mirror or sync to gitlab repo.