### PR TITLE
Fix unused parameter compiler warnings throughout framework

### DIFF
--- a/Analysis/include/MQwHistograms.h
+++ b/Analysis/include/MQwHistograms.h
@@ -31,10 +31,7 @@ class MQwHistograms {
 
     /// Arithmetic assignment operator:  Should only copy event-based data.
     /// In this particular class, there is no event-based data.
-    virtual MQwHistograms& operator=(const MQwHistograms& value) {
-      if (this != &value) {
-        // No event-based data to copy in this class
-      }
+    virtual MQwHistograms& operator=(const MQwHistograms& /*value*/) {
       return *this;
     }
 

--- a/Analysis/include/QwPromptSummary.h
+++ b/Analysis/include/QwPromptSummary.h
@@ -64,7 +64,7 @@ class PromptSummaryElement :  public TObject
   void SetDifferenceUnit       (const TString  in) { fAsymDiffUnit=in; };
 
   // Yield 
-  const Double_t GetNumGoodEvents ()    {
+  Double_t GetNumGoodEvents ()    {
     //  Returns the number of entries corresponding to the asymmetry error/width ratio
     if(fAsymDiffError!=0){
       Double_t temp = (fAsymDiffWidth/fAsymDiffError);
@@ -74,23 +74,23 @@ class PromptSummaryElement :  public TObject
     }
   };
     
-  const Double_t GetYield         () { return fYield; };
-  const Double_t GetYieldError    () { return fYieldError; };
-  const Double_t GetYieldWidth    () { return fYieldWidth; };
-  const TString  GetYieldUnit     () { return  fYieldUnit; };
+  Double_t GetYield         () { return fYield; };
+  Double_t GetYieldError    () { return fYieldError; };
+  Double_t GetYieldWidth    () { return fYieldWidth; };
+  TString  GetYieldUnit     () { return  fYieldUnit; };
 
   // Asymmetry : 
-  const Double_t GetAsymmetry     () { return fAsymDiff; };
-  const Double_t GetAsymmetryError() { return fAsymDiffError; };
-  const Double_t GetAsymmetryWidth() { return fAsymDiffWidth; };
-  const TString  GetAsymmetryUnit () { return fAsymDiffUnit; };
+  Double_t GetAsymmetry     () { return fAsymDiff; };
+  Double_t GetAsymmetryError() { return fAsymDiffError; };
+  Double_t GetAsymmetryWidth() { return fAsymDiffWidth; };
+  TString  GetAsymmetryUnit () { return fAsymDiffUnit; };
 
 
   // Difference : 
-  const Double_t GetDifference     () { return fAsymDiff; };
-  const Double_t GetDifferenceError() { return fAsymDiffError; };
-  const Double_t GetDifferenceWidth() { return fAsymDiffWidth; };
-  const TString  GetDifferenceUnit () { return fAsymDiffUnit; };
+  Double_t GetDifference     () { return fAsymDiff; };
+  Double_t GetDifferenceError() { return fAsymDiffError; };
+  Double_t GetDifferenceWidth() { return fAsymDiffWidth; };
+  TString  GetDifferenceUnit () { return fAsymDiffUnit; };
 
   void Set(TString type, const Double_t a, const Double_t a_err, const Double_t a_width);
 
@@ -144,13 +144,13 @@ class QwPromptSummary  :  public TObject
   std::vector<PromptSummaryElement*> fElementList; 
 
   void SetRunNumber(const Int_t in) {fRunNumber = in;};
-  const Int_t GetRunNumber() {return fRunNumber;};
+  Int_t GetRunNumber() {return fRunNumber;};
   
   void SetRunletNumber(const Int_t in) {fRunletNumber = in;};
-  const Int_t GetRunletNumber() {return fRunletNumber;};
+  Int_t GetRunletNumber() {return fRunletNumber;};
 
   void SetPatternSize(const Int_t in) { fPatternSize=in; };
-  const Int_t GetPatternSize() { return fPatternSize; };
+  Int_t GetPatternSize() { return fPatternSize; };
 
   void AddElement(PromptSummaryElement *in);
   PromptSummaryElement* GetElementByName(TString name);

--- a/Analysis/include/QwScaler_Channel.h
+++ b/Analysis/include/QwScaler_Channel.h
@@ -101,7 +101,7 @@ public:
   /// \brief Initialize the fields in this object
   void  InitializeChannel(TString subsystem, TString instrumenttype, TString name, TString datatosave);
 
-  void SetDefaultSampleSize(size_t NumberOfSamples_map) {
+  void SetDefaultSampleSize(size_t /*NumberOfSamples_map*/) {
     //std::cerr << "QwScaler_Channel SetDefaultSampleSize does nothing!"
     //    << std::endl;
   }
@@ -133,10 +133,10 @@ public:
 
   void  ProcessEvent();
 
-  Int_t GetRawValue(size_t element) const      { return fValue_Raw; };
-  Double_t GetValue(size_t element) const      { return fValue; };
-  Double_t GetValueM2(size_t element) const    { return fValueM2; };
-  Double_t GetValueError(size_t element) const { return fValueError; };
+  Int_t GetRawValue(size_t /*element*/) const      { return fValue_Raw; };
+  Double_t GetValue(size_t /*element*/) const      { return fValue; };
+  Double_t GetValueM2(size_t /*element*/) const    { return fValueM2; };
+  Double_t GetValueError(size_t /*element*/) const { return fValueError; };
 
   VQwScaler_Channel& operator=  (const VQwScaler_Channel &value);
   void AssignScaledValue(const VQwScaler_Channel &value, Double_t scale);
@@ -169,7 +169,7 @@ public:
 
   Bool_t ApplySingleEventCuts();//check values read from modules are at desired level
 
-  Bool_t CheckForBurpFail(const VQwDataElement *ev_error){return kFALSE;};
+  Bool_t CheckForBurpFail(const VQwDataElement * /*ev_error*/){return kFALSE;};
 
   void IncrementErrorCounters();
 

--- a/Analysis/include/VQwDataElement.h
+++ b/Analysis/include/VQwDataElement.h
@@ -99,9 +99,9 @@ class VQwDataElement: public MQwHistograms {
   /*! \brief Get the name of this element */
   virtual const TString& GetElementName() const { return fElementName; }
 
-  virtual void LoadChannelParameters(QwParameterFile &paramfile){};
+  virtual void LoadChannelParameters(QwParameterFile & /*paramfile*/){};
 
-  virtual void LoadMockDataParameters(QwParameterFile &paramfile) {
+  virtual void LoadMockDataParameters(QwParameterFile & /*paramfile*/) {
   std::cerr << "LoadMockDataParameters is not defined!" << std::endl;
   };
 
@@ -118,15 +118,15 @@ class VQwDataElement: public MQwHistograms {
   UInt_t GetGoodEventCount() const { return fGoodEventCount; };
 
   
-  virtual void AssignValueFrom(const VQwDataElement* valueptr){
+  virtual void AssignValueFrom(const VQwDataElement* /*valueptr*/){
     std::cerr << "Operation AssignValueFrom not defined!" << std::endl;
   };
 
   /*! \brief Addition-assignment operator */
-  virtual VQwDataElement& operator+= (const VQwDataElement &value)
+  virtual VQwDataElement& operator+= (const VQwDataElement & /*value*/)
     { std::cerr << "Operation += not defined!" << std::endl; return *this; }
   /*! \brief Subtraction-assignment operator */
-  virtual VQwDataElement& operator-= (const VQwDataElement &value)
+  virtual VQwDataElement& operator-= (const VQwDataElement & /*value*/)
     { std::cerr << "Operation -= not defined!" << std::endl; return *this; }
 
   /*! \brief Sum operator */
@@ -144,7 +144,7 @@ class VQwDataElement: public MQwHistograms {
       *this -= value2;
     }
   /*! \brief Ratio operator */
-  virtual void Ratio(const VQwDataElement &numer, const VQwDataElement &denom)
+  virtual void Ratio(const VQwDataElement & /*numer*/, const VQwDataElement & /*denom*/)
   { std::cerr << "Ratio not defined for element"<< fElementName<< "!" << std::endl; }
 
   /*! \brief Construct the histograms for this data element */
@@ -159,11 +159,11 @@ class VQwDataElement: public MQwHistograms {
 
 
   /*! \brief set the upper and lower limits (fULimit and fLLimit), stability % and the error flag on this channel */
-  virtual void SetSingleEventCuts(UInt_t errorflag,Double_t min, Double_t max, Double_t stability){std::cerr << "SetSingleEventCuts not defined!" << std::endl; };
+  virtual void SetSingleEventCuts(UInt_t /*errorflag*/,Double_t /*min*/, Double_t /*max*/, Double_t /*stability*/){std::cerr << "SetSingleEventCuts not defined!" << std::endl; };
   /*! \brief report number of events failed due to HW and event cut failure */
   virtual void PrintErrorCounters() const {};
 
-  virtual Bool_t  CheckForBurpFail(const VQwDataElement *ev_error){
+  virtual Bool_t  CheckForBurpFail(const VQwDataElement * /*ev_error*/){
     return kFALSE;
   };
 
@@ -185,11 +185,11 @@ class VQwDataElement: public MQwHistograms {
 
   // These are related to those hardware channels that need to normalize
   // to an external clock
-  virtual void SetNeedsExternalClock(Bool_t needed) {};   // Default is No!
+  virtual void SetNeedsExternalClock(Bool_t /*needed*/) {};   // Default is No!
   virtual Bool_t NeedsExternalClock() { return kFALSE; }; // Default is No!
   virtual std::string GetExternalClockName() {  return ""; }; // Default is none
-  virtual void SetExternalClockPtr( const VQwHardwareChannel* clock) {};
-  virtual void SetExternalClockName( const std::string name) {};
+  virtual void SetExternalClockPtr( const VQwHardwareChannel* /*clock*/) {};
+  virtual void SetExternalClockName( const std::string /*name*/) {};
   virtual Double_t GetNormClockValue() { return 1.;}
 
   

--- a/Analysis/include/VQwHardwareChannel.h
+++ b/Analysis/include/VQwHardwareChannel.h
@@ -174,7 +174,7 @@ public:
   Double_t GetCalibrationFactor() const          { return fCalibrationFactor; };
 
   void AddEntriesToList(std::vector<QwDBInterface> &row_list);
-  virtual void AddErrEntriesToList(std::vector<QwErrDBInterface> &row_list) {};
+  virtual void AddErrEntriesToList(std::vector<QwErrDBInterface> & /*row_list*/) {};
 
   
   virtual void AccumulateRunningSum(const VQwHardwareChannel *value, Int_t count=0, Int_t ErrorMask=0xFFFFFFF){
@@ -198,7 +198,7 @@ public:
   void ConstructBranch(TTree *tree, TString &prefix, QwParameterFile& modulelist);
   virtual void FillTreeVector(std::vector<Double_t>& values) const = 0;
 
-  virtual void CopyParameters(const VQwHardwareChannel* valueptr){};
+  virtual void CopyParameters(const VQwHardwareChannel* /*valueptr*/){};
 
  protected:
   /*! \brief Set the number of data words in this data element */

--- a/Analysis/include/VQwSubsystem.h
+++ b/Analysis/include/VQwSubsystem.h
@@ -89,7 +89,7 @@ class VQwSubsystem: virtual public VQwSubsystemCloneable, public MQwHistograms, 
   /// \brief Define options function (note: no virtual static functions in C++)
   static void DefineOptions() { /* No default options defined */ };
   /// Process the command line options
-  virtual void ProcessOptions(QwOptions &options) { };
+  virtual void ProcessOptions(QwOptions & /*options*/) { };
 
 
   TString GetName() const {return fSystemName;};
@@ -105,7 +105,7 @@ class VQwSubsystem: virtual public VQwSubsystemCloneable, public MQwHistograms, 
   virtual std::map<TString, TString> GetDetectorMaps();
 
   /// \brief Try to publish an internal variable matching the submitted name
-  virtual Bool_t PublishByRequest(TString device_name){
+  virtual Bool_t PublishByRequest(TString /*device_name*/){
     return kFALSE; // when not implemented, this returns failure
   };
 
@@ -127,11 +127,11 @@ class VQwSubsystem: virtual public VQwSubsystemCloneable, public MQwHistograms, 
   /// Mandatory parameter file definition
   virtual Int_t LoadInputParameters(TString mapfile) = 0;
   /// Optional geometry definition
-  virtual Int_t LoadGeometryDefinition(TString mapfile) { return 0; };
+  virtual Int_t LoadGeometryDefinition(TString /*mapfile*/) { return 0; };
   /// Optional crosstalk definition
-  virtual Int_t LoadCrosstalkDefinition(TString mapfile) { return 0; };
+  virtual Int_t LoadCrosstalkDefinition(TString /*mapfile*/) { return 0; };
   /// Optional event cut file
-  virtual Int_t LoadEventCuts(TString mapfile) { return 0; };
+  virtual Int_t LoadEventCuts(TString /*mapfile*/) { return 0; };
 
   /// Set event type mask
   void SetEventTypeMask(const UInt_t mask) { fEventTypeMask = mask; };
@@ -170,8 +170,8 @@ class VQwSubsystem: virtual public VQwSubsystemCloneable, public MQwHistograms, 
 
 
   // Not all derived classes will have the following functions
-  virtual void  RandomizeEventData(int helicity = 0, double time = 0.0) { };
-  virtual void  EncodeEventData(std::vector<UInt_t> &buffer) { };
+  virtual void  RandomizeEventData(int /*helicity*/ = 0, double /*time*/ = 0.0) { };
+  virtual void  EncodeEventData(std::vector<UInt_t> & /*buffer*/) { };
 
 
   /// \name Objects construction and maintenance
@@ -191,7 +191,7 @@ class VQwSubsystem: virtual public VQwSubsystemCloneable, public MQwHistograms, 
     ConstructObjects((TDirectory*) NULL, prefix);
   };
   /// \brief Construct the objects for this subsystem in a folder with a prefix
-  virtual void  ConstructObjects(TDirectory *folder, TString &prefix) { };
+  virtual void  ConstructObjects(TDirectory * /*folder*/, TString & /*prefix*/) { };
   // @}
 
 
@@ -260,7 +260,7 @@ class VQwSubsystem: virtual public VQwSubsystemCloneable, public MQwHistograms, 
     ConstructTree((TDirectory*) NULL, prefix);
   };
   /// \brief Construct the tree for this subsystem in a folder with a prefix
-  virtual void  ConstructTree(TDirectory *folder, TString &prefix) { return; };
+  virtual void  ConstructTree(TDirectory * /*folder*/, TString & /*prefix*/) { return; };
   /// \brief Fill the tree for this subsystem
   virtual void  FillTree() { return; };
   /// \brief Delete the tree for this subsystem

--- a/Parity/include/QwSubsystemArrayParity.h
+++ b/Parity/include/QwSubsystemArrayParity.h
@@ -99,12 +99,12 @@ class QwSubsystemArrayParity: public QwSubsystemArray {
     /// \brief Blind the asymmetry of this subsystem
     void Blind(const QwBlinder* blinder);
     /// \brief Unblind the asymmetry of this subsystem
-    void UnBlind(const QwBlinder* blinder)
+    void UnBlind(const QwBlinder* /*blinder*/)
       { /* Not yet implemented */ };
     /// \brief Blind the difference of this subsystem
     void Blind(const QwBlinder* blinder, const QwSubsystemArrayParity& yield);
     /// \brief Unblind the difference of this subsystem
-    void UnBlind(const QwBlinder* blinder, const QwSubsystemArrayParity& yield)
+    void UnBlind(const QwBlinder* /*blinder*/, const QwSubsystemArrayParity& /*yield*/)
       { /* Not yet implemented */ };
 
 

--- a/Parity/include/VQwBCM.h
+++ b/Parity/include/VQwBCM.h
@@ -44,7 +44,7 @@ class VQwBCM : public VQwDataElement {
 
 protected:
   VQwBCM(VQwDataElement& beamcurrent): fBeamCurrent_ref(beamcurrent) { };
-  VQwBCM(VQwDataElement& beamcurrent, TString name): fBeamCurrent_ref(beamcurrent) { };
+  VQwBCM(VQwDataElement& beamcurrent, TString /*name*/): fBeamCurrent_ref(beamcurrent) { };
 
 public:
   virtual ~VQwBCM() { };
@@ -55,7 +55,7 @@ public:
   virtual void  FillHistograms() = 0;
   /*! \brief Inherited from VQwDataElement to set the upper and lower limits (fULimit and fLLimit), stability % and the error flag on this channel */
   virtual void SetSingleEventCuts(UInt_t errorflag,Double_t min, Double_t max, Double_t stability, Double_t burplevel) = 0;
-  virtual void Ratio( const VQwBCM &numer, const VQwBCM &denom)
+  virtual void Ratio( const VQwBCM &/*numer*/, const VQwBCM &/*denom*/)
     { std::cerr << "Ratio not defined! (VQwBCM)" << std::endl; }
   virtual void ClearEventData() = 0;
 
@@ -95,9 +95,9 @@ public:
     {std::cerr << "ApplyResolutionSmearing is undefined!!!\n";}
   virtual void    FillRawEventData()
     {std::cerr << "FillRawEventData for VQwBPM not implemented!\n";};
-  virtual void GetProjectedCharge(VQwBCM *device){};
+  virtual void GetProjectedCharge(VQwBCM */*device*/){};
   virtual size_t GetNumberOfElements(){return size_t(1);}
-  virtual TString GetSubElementName(Int_t subindex) 
+  virtual TString GetSubElementName(Int_t /*subindex*/) 
   {
     std::cerr << "GetSubElementName()  is not implemented!! for device: " << GetElementName() << "\n";
     return TString("OBJECT_UNDEFINED"); // Return an erroneous TString

--- a/Parity/include/VQwBPM.h
+++ b/Parity/include/VQwBPM.h
@@ -58,7 +58,7 @@ class VQwBPM : public VQwDataElement {
  public:
   // Default constructor
   VQwBPM() {InitializeChannel_base();};
-  VQwBPM(TString& name) {InitializeChannel_base();};
+  VQwBPM(TString& /*name*/) {InitializeChannel_base();};
   VQwBPM(const VQwBPM& source)
   : VQwDataElement(source),
     bRotated(source.bRotated),
@@ -77,7 +77,7 @@ class VQwBPM : public VQwDataElement {
 
 //-------------------------------------------------------------------------------------
 
-  virtual  void    GetProjectedPosition(VQwBPM *device){}; // The base class function GetProjectedPosition is defined to have no effect.
+  virtual  void    GetProjectedPosition(VQwBPM * /*device*/){}; // The base class function GetProjectedPosition is defined to have no effect.
   virtual  size_t  GetNumberOfElements(){return size_t(1);}
   virtual  void    FillRawEventData() 
     {std::cerr << "FillRawEventData for VQwBPM not implemented for device " << GetElementName() << "!\n";};
@@ -94,7 +94,7 @@ class VQwBPM : public VQwDataElement {
   virtual UInt_t UpdateErrorFlag() = 0;
   virtual void UpdateErrorFlag(const VQwBPM *ev_error) = 0;
 
-  virtual void Scale(Double_t factor) {
+  virtual void Scale(Double_t /*factor*/) {
     std::cerr << "Scale for VQwBPM not implemented!\n";
   }
   void SetGains(TString pos, Double_t value);
@@ -159,7 +159,7 @@ public:
 /*   void PrintValue() const; */
 /*   void PrintInfo() const; */
   virtual void CalculateRunningAverage() = 0;
-  virtual void AccumulateRunningSum(const VQwBPM& value, Int_t count=0, Int_t ErrorMask=0xFFFFFFF) {
+  virtual void AccumulateRunningSum(const VQwBPM& /*value*/, Int_t /*count*/=0, Int_t /*ErrorMask*/=0xFFFFFFF) {
     std::cerr << "AccumulateRunningSum not implemented for BPM named="
       <<GetElementName()<<"\n";
   };
@@ -180,7 +180,7 @@ public:
   virtual std::vector<QwErrDBInterface> GetErrDBEntry() = 0;
 #endif // __USE_DATABASE__
 
-  virtual void Ratio(VQwBPM &numer, VQwBPM &denom) {
+  virtual void Ratio(VQwBPM & /*numer*/, VQwBPM & /*denom*/) {
     std::cerr << "Ratio() is not defined for BPM named="<<GetElementName()<<"\n";
   }
 
@@ -190,7 +190,7 @@ public:
 /*       <<GetElementName()<< "!!\n"; */
 /*     return 0; */
 /*   } */
-  virtual TString GetSubElementName(Int_t subindex) {
+  virtual TString GetSubElementName(Int_t /*subindex*/) {
     std::cerr << "GetSubElementName()  is not implemented!! for device: " << GetElementName() << "\n";
     return TString("OBJECT_UNDEFINED"); // Return an erroneous TString
   }
@@ -216,13 +216,13 @@ public:
       "used in a CombinedBPM!\n";
     return 0;
   }
-  virtual void SetBPMForCombo(const VQwBPM* bpm, Double_t charge_weight,
-      Double_t x_weight, Double_t y_weight,Double_t sumqw) {
+  virtual void SetBPMForCombo(const VQwBPM* /*bpm*/, Double_t /*charge_weight*/,
+      Double_t /*x_weight*/, Double_t /*y_weight*/,Double_t /*sumqw*/) {
     std::cerr << "VQwBPM::SetBPMForCombo only defined for CombinedBPM's!!!\n";
   }
 
 
-  virtual void SetDefaultSampleSize(Int_t sample_size) {
+  virtual void SetDefaultSampleSize(Int_t /*sample_size*/) {
     std::cerr << "SetDefaultSampleSize() is undefined!!!\n";
   }
 
@@ -231,31 +231,31 @@ public:
     fResolution[kYAxis] = resolutionY;
   }
 
-  virtual void SetRandomEventParameters(Double_t meanX, Double_t sigmaX, Double_t meanY, Double_t sigmaY) {
+  virtual void SetRandomEventParameters(Double_t /*meanX*/, Double_t /*sigmaX*/, Double_t /*meanY*/, Double_t /*sigmaY*/) {
     std::cerr<< "SetRandomEventParameters undefined!!\n";
   }
-  virtual void SetRandomEventParameters(Double_t meanX, Double_t sigmaX, Double_t meanY, Double_t sigmaY,Double_t meanXslope, Double_t sigmaXslope, Double_t meanYslope, Double_t sigmaYslope) {
+  virtual void SetRandomEventParameters(Double_t /*meanX*/, Double_t /*sigmaX*/, Double_t /*meanY*/, Double_t /*sigmaY*/,Double_t /*meanXslope*/, Double_t /*sigmaXslope*/, Double_t /*meanYslope*/, Double_t /*sigmaYslope*/) {
     std::cerr<< "SetRandomEventParameters undefined!!\n";
   }
-  virtual void SetRandomEventAsymmetry(Double_t asymmetry) {
+  virtual void SetRandomEventAsymmetry(Double_t /*asymmetry*/) {
     std::cerr<< "SetRandomEventAsymmetry undefined!!\n";
   }
-  virtual void RandomizeEventData(int helicity = 0, double time = 0.0) {
+  virtual void RandomizeEventData(int /*helicity*/ = 0, double /*time*/ = 0.0) {
     std::cerr << "RandomizeEventData is undefined for device" << GetElementName() << "!!!\n";
   }
   virtual void ApplyResolutionSmearing(){
     std::cerr << "ApplyResolutionSmearing is undefined" << GetElementName() << "!!!\n";
   }
-  virtual void ApplyResolutionSmearing(EBeamPositionMonitorAxis iaxis){
+  virtual void ApplyResolutionSmearing(EBeamPositionMonitorAxis /*iaxis*/){
     std::cerr << "ApplyResolutionSmearing(EBeamPositionMonitorAxis iaxis) is undefined!!!\n";
   }
-  virtual void EncodeEventData(std::vector<UInt_t> &buffer) {
+  virtual void EncodeEventData(std::vector<UInt_t> & /*buffer*/) {
     std::cerr << "EncodeEventData is undefined!!!\n";
   }
-  virtual void SetSubElementPedestal(Int_t j, Double_t value) {
+  virtual void SetSubElementPedestal(Int_t /*j*/, Double_t /*value*/) {
     std::cerr << "SetSubElementPedestal is undefined!!!\n";
   }
-  virtual void SetSubElementCalibrationFactor(Int_t j, Double_t value) {
+  virtual void SetSubElementCalibrationFactor(Int_t /*j*/, Double_t /*value*/) {
     std::cerr << "SetSubElementCalibrationFactor is undefined!!!\n";
   }
   virtual void PrintInfo() const { 

--- a/Parity/include/VQwClock.h
+++ b/Parity/include/VQwClock.h
@@ -50,7 +50,7 @@ public:
   virtual void  FillHistograms() = 0;
   /*! \brief Inherited from VQwDataElement to set the upper and lower limits (fULimit and fLLimit), stability % and the error flag on this channel */
   virtual void SetSingleEventCuts(UInt_t errorflag,Double_t min, Double_t max, Double_t stability, Double_t burplevel) = 0;
-  virtual void Ratio( const VQwClock &numer, const VQwClock &denom)
+  virtual void Ratio( const VQwClock &/*numer*/, const VQwClock &/*denom*/)
     { std::cerr << "Ratio not defined! (VQwClock)" << std::endl; }
   virtual void ClearEventData() = 0;
 

--- a/Parity/include/VQwDataHandler.h
+++ b/Parity/include/VQwDataHandler.h
@@ -51,12 +51,12 @@ class VQwDataHandler:  virtual public VQwDataHandlerCloneable, public MQwPublish
       fErrorFlagPtr = ptr->GetEventcutErrorFlagPointer();
     };
 
-    virtual Int_t ConnectChannels(QwSubsystemArrayParity& yield, QwSubsystemArrayParity& asym, QwSubsystemArrayParity& diff){
+    virtual Int_t ConnectChannels(QwSubsystemArrayParity& /*yield*/, QwSubsystemArrayParity& asym, QwSubsystemArrayParity& diff){
       return this->ConnectChannels(asym, diff);
     }
 
     // Subsystems with support for subsystem arrays should override this
-    virtual Int_t ConnectChannels(QwSubsystemArrayParity& detectors) { return 0; }
+    virtual Int_t ConnectChannels(QwSubsystemArrayParity& /*detectors*/) { return 0; }
 
     Int_t ConnectChannels(QwHelicityPattern& helicitypattern) {
       return this->ConnectChannels(
@@ -84,7 +84,7 @@ class VQwDataHandler:  virtual public VQwDataHandlerCloneable, public MQwPublish
     virtual void AccumulateRunningSum(VQwDataHandler &value, Int_t count = 0, Int_t ErrorMask = 0xFFFFFFF);
     void CalculateRunningAverage();
     void PrintValue() const;
-    void FillDB(QwParityDB *db, TString datatype){};
+    void FillDB(QwParityDB * /*db*/, TString /*datatype*/){};
 
     void WritePromptSummary(QwPromptSummary *ps, TString type);
 
@@ -95,7 +95,7 @@ class VQwDataHandler:  virtual public VQwDataHandlerCloneable, public MQwPublish
     virtual void FillTreeBranches(QwRootFile *treerootfile);
 
     /// \brief Construct the histograms in a folder with a prefix
-    virtual void  ConstructHistograms(TDirectory *folder, TString &prefix) { };
+    virtual void  ConstructHistograms(TDirectory * /*folder*/, TString & /*prefix*/) { };
     /// \brief Fill the histograms
     virtual void  FillHistograms() { };
 
@@ -109,7 +109,7 @@ class VQwDataHandler:  virtual public VQwDataHandlerCloneable, public MQwPublish
     }
 
     Int_t LoadChannelMap(){return this->LoadChannelMap(fMapFile);}
-    virtual Int_t LoadChannelMap(const std::string& mapfile){return 0;};
+    virtual Int_t LoadChannelMap(const std::string& /*mapfile*/){return 0;};
 
     /// \brief Publish all variables of the subsystem
     virtual Bool_t PublishInternalValues() const;

--- a/Parity/include/VQwSubsystemParity.h
+++ b/Parity/include/VQwSubsystemParity.h
@@ -54,10 +54,10 @@ class VQwSubsystemParity: virtual public VQwSubsystem {
 
     /// \brief Fill the database with MPS-based variables
     ///        Note that most subsystems don't need to do this.
-    virtual void FillDB_MPS(QwParityDB *db, TString type) {};
+    virtual void FillDB_MPS(QwParityDB * /*db*/, TString /*type*/) {};
     /// \brief Fill the database
-    virtual void FillDB(QwParityDB *db, TString type) { };
-    virtual void FillErrDB(QwParityDB *db, TString type) { };
+    virtual void FillDB(QwParityDB * /*db*/, TString /*type*/) { };
+    virtual void FillErrDB(QwParityDB * /*db*/, TString /*type*/) { };
 
     // VQwSubsystem routine is overridden. Call it at the beginning by VQwSubsystem::operator=(value)
     virtual VQwSubsystem& operator=  (VQwSubsystem *value) = 0;
@@ -117,8 +117,8 @@ class VQwSubsystemParity: virtual public VQwSubsystem {
       return 0;
     };
     virtual void LoadEventCuts_Init() {};
-    virtual void LoadEventCuts_Line(QwParameterFile &mapstr, TString &varvalue, Int_t &eventcut_flag) {};
-    virtual void LoadEventCuts_Fin(Int_t &eventcut_flag) {};
+    virtual void LoadEventCuts_Line(QwParameterFile & /*mapstr*/, TString & /*varvalue*/, Int_t & /*eventcut_flag*/) {};
+    virtual void LoadEventCuts_Fin(Int_t & /*eventcut_flag*/) {};
     /// \brief Apply the single event cuts
     virtual Bool_t ApplySingleEventCuts() = 0;
     /// \brief Report the number of events failed due to HW and event cut failures
@@ -141,19 +141,19 @@ class VQwSubsystemParity: virtual public VQwSubsystem {
 
 
     /// \brief Blind the asymmetry of this subsystem
-    virtual void Blind(const QwBlinder *blinder) { return; };
+    virtual void Blind(const QwBlinder * /*blinder*/) { return; };
     /// \brief Blind the difference of this subsystem
-    virtual void Blind(const QwBlinder *blinder, const VQwSubsystemParity* subsys) { return; };
+    virtual void Blind(const QwBlinder * /*blinder*/, const VQwSubsystemParity* /*subsys*/) { return; };
 
     /// \brief Print values of all channels
     virtual void PrintValue() const { };
 
-    virtual void WritePromptSummary(QwPromptSummary *ps, TString type) {};
+    virtual void WritePromptSummary(QwPromptSummary * /*ps*/, TString /*type*/) {};
 
 
     virtual Bool_t CheckForEndOfBurst() const {return kFALSE;};
 
-    virtual void LoadMockDataParameters(TString mapfile) {};
+    virtual void LoadMockDataParameters(TString /*mapfile*/) {};
 	
 }; // class VQwSubsystemParity
 

--- a/Parity/src/QwScaler.cc
+++ b/Parity/src/QwScaler.cc
@@ -17,7 +17,7 @@ void QwScaler::DefineOptions(QwOptions &options)
   // Define command line options
 }
 
-void QwScaler::ProcessOptions(QwOptions &options)
+void QwScaler::ProcessOptions(QwOptions &/*options*/)
 {
   // Handle command line options
 }
@@ -279,7 +279,7 @@ void QwScaler::ClearEventData()
  * @param num_words Number of words left in buffer
  * @return Number of words read
  */
-Int_t QwScaler::ProcessConfigurationBuffer(const ROCID_t roc_id, const BankID_t bank_id, UInt_t* buffer, UInt_t num_words)
+Int_t QwScaler::ProcessConfigurationBuffer(const ROCID_t /*roc_id*/, const BankID_t /*bank_id*/, UInt_t* /*buffer*/, UInt_t /*num_words*/)
 {
   return 0;
 }
@@ -482,7 +482,7 @@ void QwScaler::CalculateRunningAverage()
   }
 }
 
-Int_t QwScaler::LoadEventCuts(TString filename)
+Int_t QwScaler::LoadEventCuts(TString /*filename*/)
 {
   return 0;
 }


### PR DESCRIPTION
## Overview
This PR systematically addresses unused parameter warnings in virtual methods throughout the JAPAN-MOLLER analysis framework. All changes preserve interface compatibility while eliminating compiler warnings.

## Changes Made
- **Virtual method parameters**: Commented out unused parameters with `/* parameter */` syntax
- **Type qualifiers**: Removed unnecessary `const` return types in QwPromptSummary
- **Framework coverage**: Fixed warnings in 12 header files and 1 source file

## Files Modified
### Analysis Framework
- `Analysis/include/VQwDataElement.h` - Base data element interface
- `Analysis/include/VQwHardwareChannel.h` - Hardware channel base class
- `Analysis/include/VQwSubsystem.h` - Subsystem base class
- `Analysis/include/MQwHistograms.h` - Histogram management
- `Analysis/include/QwScaler_Channel.h` - Scaler channel implementation
- `Analysis/include/QwPromptSummary.h` - Type qualifier fixes

### Parity Analysis Components
- `Parity/include/VQwBPM.h` - Beam position monitor interface
- `Parity/include/VQwBCM.h` - Beam current monitor interface
- `Parity/include/VQwClock.h` - Clock interface
- `Parity/include/VQwDataHandler.h` - Data handler interface
- `Parity/include/VQwSubsystemParity.h` - Parity subsystem interface
- `Parity/include/QwSubsystemArrayParity.h` - Subsystem array for parity
- `Parity/src/QwScaler.cc` - Scaler implementation

## Technical Details
- **Polymorphism preserved**: All virtual function signatures maintained for inheritance
- **No functional changes**: Pure code quality improvements
- **Enhanced compiler compatibility**: Eliminates warnings with `-Wall -Wextra -Wundef`
- **Method coverage**: Fixed `LoadChannelParameters`, operator overloads, `SetSingleEventCuts`, `CheckForBurpFail`, and other virtual methods

## Testing
- Code compiles successfully with enhanced warning flags
- No functional regressions - all existing functionality preserved
- Virtual method polymorphism verified intact

## Benefits
- Cleaner builds with enhanced compiler warnings enabled
- Improved code quality and maintainability
- Foundation for more comprehensive static analysis
- Better development experience with fewer false-positive warnings

This is a pure code quality improvement with zero functional impact.