### PR TITLE
Fix uninitialized variables found by clang-tidy

### DIFF
--- a/Analysis/src/QwHistogramHelper.cc
+++ b/Analysis/src/QwHistogramHelper.cc
@@ -179,8 +179,8 @@ void  QwHistogramHelper::LoadTreeParamsFromFile(const std::string& filename)
   TString devicename;
   TString moduletype;
   TString subsystemname;
-  QwParameterFile *section;
-  QwParameterFile *module;
+  QwParameterFile *section = nullptr;
+  QwParameterFile *module = nullptr;
   std::vector<TString> TrimmedList;//stores the list of elements for each module
   std::vector<std::vector<TString> > ModulebyTrimmedList;//stores the list of elements for each module
   std::vector<TString> ModuleList;//stores the list of modules for each subsystem

--- a/Parity/src/QwSubsystemArrayParity.cc
+++ b/Parity/src/QwSubsystemArrayParity.cc
@@ -465,7 +465,7 @@ Bool_t QwSubsystemArrayParity::ApplySingleEventCuts(){
   if( CheckBadEventRange() )
     fErrorFlag |=kBadEventRangeError;
   
-  VQwSubsystemParity *subsys_parity;
+  VQwSubsystemParity *subsys_parity = nullptr;
   CountFalse=0;
   if (!empty()){
     for (iterator subsys = begin(); subsys != end(); ++subsys){
@@ -500,7 +500,7 @@ Bool_t QwSubsystemArrayParity::ApplySingleEventCuts(){
 
 void QwSubsystemArrayParity::IncrementErrorCounters()
 {
-  VQwSubsystemParity *subsys_parity;
+  VQwSubsystemParity *subsys_parity = nullptr;
   if (!empty()){
     for (iterator subsys = begin(); subsys != end(); ++subsys){
       subsys_parity=dynamic_cast<VQwSubsystemParity*>((subsys)->get());
@@ -538,7 +538,7 @@ Bool_t QwSubsystemArrayParity::CheckForBurpFail(QwSubsystemArrayParity &event)
 
 
 void QwSubsystemArrayParity::PrintErrorCounters() const{// report number of events failed due to HW and event cut faliure
-  const VQwSubsystemParity *subsys_parity;
+  const VQwSubsystemParity *subsys_parity = nullptr;
   if (!empty()){
     for (const_iterator subsys = begin(); subsys != end(); ++subsys){
       subsys_parity=dynamic_cast<const VQwSubsystemParity*>((subsys)->get());
@@ -591,7 +591,7 @@ void QwSubsystemArrayParity::UpdateErrorFlag() {
   if( CheckBadEventRange() )
     fErrorFlag |=kBadEventRangeError;
 
-  VQwSubsystemParity *subsys_parity;
+  VQwSubsystemParity *subsys_parity = nullptr;
   if (!empty()){
     for (iterator subsys = begin(); subsys != end(); ++subsys){
       subsys_parity=dynamic_cast<VQwSubsystemParity*>((subsys)->get());
@@ -649,12 +649,12 @@ void QwSubsystemArrayParity::LoadMockDataParameters(std::string mapfile)
   // }
   QwParameterFile detectors(mapfile);
     // This is how this should work
-  QwParameterFile* preamble;
+  QwParameterFile* preamble = nullptr;
   preamble = detectors.ReadSectionPreamble();
   // Process preamble
   QwVerbose << "Preamble:" << QwLog::endl;
   QwVerbose << *preamble << QwLog::endl;
-  double window_period;
+  double window_period = 0.0;
   if (preamble->FileHasVariablePair("=","window_period",window_period)){
     fWindowPeriod = window_period * Qw::sec;
   }else{
@@ -666,7 +666,7 @@ void QwSubsystemArrayParity::LoadMockDataParameters(std::string mapfile)
     
   if (preamble) delete preamble;
 
-  QwParameterFile* section;
+  QwParameterFile* section = nullptr;
   std::string section_name;
   while ((section = detectors.ReadNextSection(section_name))) {
 

--- a/Parity/src/VQwDataHandler.cc
+++ b/Parity/src/VQwDataHandler.cc
@@ -368,7 +368,7 @@ Bool_t VQwDataHandler::PublishInternalValues() const
 {
   // Publish variables
   Bool_t status = kTRUE;
-  VQwHardwareChannel* tmp_channel;
+  VQwHardwareChannel* tmp_channel = nullptr;
   
   // Publish variables through map file
   for (size_t pp = 0; pp < fPublishList.size(); pp++) {


### PR DESCRIPTION
This PR addresses critical safety issues by initializing variables that were flagged by clang-tidy's `cppcoreguidelines-init-variables` check.

## Changes Made

### Files Modified:
- **Analysis/src/QwHistogramHelper.cc**: Initialize  and  pointers to 
- **Parity/src/VQwDataHandler.cc**: Initialize  pointer to   
- **Parity/src/QwSubsystemArrayParity.cc**: Initialize multiple variables:
  -  pointers to  (4 instances)
  -  pointer to 
  -  to 
  -  pointer to 

## Why This Matters

Uninitialized variables can lead to:
- **Undefined behavior** when dereferencing uninitialized pointers
- **Unpredictable program behavior** when using uninitialized numeric values
- **Potential crashes** in production code
- **Security vulnerabilities** in some contexts

## Static Analysis Context

These fixes are part of a comprehensive static analysis of the codebase using clang-tidy. A full report of 944+ issues was filed in issue #56, with these uninitialized variables being among the highest priority fixes.

## Testing

These changes maintain existing functionality while eliminating undefined behavior. All modified variables:
- Were previously uninitialized at declaration
- Are assigned values later in their respective functions
- Now have safe default values that prevent undefined behavior if accessed before assignment

The fixes use appropriate default values:
-  for pointer variables  
-  for numeric variables

## Risk Assessment

**Risk**: Very Low
- Changes only add initialization of variables that were previously uninitialized
- No changes to program logic or control flow
- Default values are safe and appropriate for each variable type