### PR TITLE
Fix new[]/delete mismatches found by clang-tidy

### DIFF
--- a/Analysis/src/QwMollerADC_Channel.cc
+++ b/Analysis/src/QwMollerADC_Channel.cc
@@ -332,7 +332,7 @@ void QwMollerADC_Channel::SetHardwareSum(Double_t hwsum, UInt_t sequencenumber)
     block[i] = hwsum / fBlocksPerEvent;
   }
   SetEventData(block);
-  delete block;
+  delete[] block;
   return;
 }
 

--- a/Analysis/src/QwVQWK_Channel.cc
+++ b/Analysis/src/QwVQWK_Channel.cc
@@ -355,7 +355,7 @@ void QwVQWK_Channel::SetHardwareSum(Double_t hwsum, UInt_t sequencenumber)
     block[i] = hwsum / fBlocksPerEvent;
   }
   SetEventData(block);
-  delete block;
+  delete[] block;
   return;
 }
 


### PR DESCRIPTION
This PR fixes critical memory management issues by correcting new[]/delete mismatches.

## Changes Made

- Analysis/src/QwMollerADC_Channel.cc: Replace delete with delete[] for array deallocation
- Analysis/src/QwVQWK_Channel.cc: Replace delete with delete[] for array deallocation

## Problem Description

Both files allocated arrays with new[] but freed them with delete instead of delete[]. This is undefined behavior that can cause crashes and memory corruption.

## Risk Assessment

Risk: Very Low - Only fixes cleanup code to be standards-compliant without changing functionality.

This addresses clang-analyzer warnings for NewDelete mismatches identified in comprehensive static analysis.