### PR TITLE
fix: add eviowrapper library to executable target link libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,6 +224,7 @@ foreach(file ${exefiles})
 
   target_link_libraries(${filelower}
     PRIVATE
+      eviowrapper
       ${PROJECT_NAME}
   )
   target_compile_options(${filelower}


### PR DESCRIPTION
#### Problem

The build was [failing](https://github.com/JeffersonLab/japan-MOLLER/runs/49984362565?check_suite_focus=true) due to linker errors related to missing symbols from the `libeviowrapper.so` shared library:
```
undefined reference to symbol '_ZTI11THaCodaData'
error adding symbols: DSO missing from command line
clang-16: error: linker command failed with exit code 1
```
This occurs when the shared object depends on symbols from another library (likely the Hall A Analyzer or ROOT), but the required library was not included in the linking process for the executables (`qwparity`, `qwmockdatagenerator`).

#### Solution

- Update the target link libraries in your CMake configuration to explicitly include the library that provides `THaCodaData` (e.g., `HallAAnalyzer`).
- Ensure CMake can locate the relevant library and header files.
- Clean and rebuild the project to apply changes.

**Example CMakeLists.txt adjustment:**
```cmakefailing
target_link_libraries(qwparity
    PRIVATE
    eviowrapper
    # ...other libraries
)
```

#### Additional Notes

- Numerous warnings about overloaded virtual functions (e.g., `UpdateErrorFlag`) are present but do not cause the build to fail. These should be addressed separately for code clarity.
- See failing job logs for detailed error messages: [ref: c9e8faa2bc99aeaf724a204f4d27be6a93f0aec1](https://github.com/JeffersonLab/japan-MOLLER/runs/49984362565?check_suite_focus=true)

#### References

- [Build LCG on CVMFS Workflow File](https://github.com/JeffersonLab/japan-MOLLER/blob/c9e8faa2bc99aeaf724a204f4d27be6a93f0aec1/.github/workflows/build-lcg-cvmfs.yml)
- [Job Logs](https://github.com/JeffersonLab/japan-MOLLER/runs/49984362565?check_suite_focus=true)

---
**Summary:**  
Explicitly link the missing dependency in CMake to resolve the linker errors. This will allow the build to complete successfully.