### PR TITLE
Fix array out of bounds error in QwHelicity::SetFirstBits

### DIFF
--- a/Parity/src/QwHelicity.cc
+++ b/Parity/src/QwHelicity.cc
@@ -1126,7 +1126,7 @@ void QwHelicity::SetFirstBits(UInt_t nbits, UInt_t seed)
 	throw std::invalid_argument("SetFirstBits currently only supports 24 bits.");
   // Allocate nbits+1 elements as GetRandomSeed expects Fortran indexing (1-nbits)
   UShort_t firstbits[nbits+1];  // NB firstbits[0] is never used
-  for (unsigned int i = 0; i < nbits; i++) firstbits[i+1] = (seed >> i) & 0x1;
+  for (unsigned int i = 0; i < nbits+1; i++) firstbits[i] = (seed >> i) & 0x1;
   // Set delayed seed
   iseed_Delayed = GetRandomSeed(firstbits);
   // Progress actual seed by the helicity delay


### PR DESCRIPTION
`QwHelicity::SetFirstBits` calls `QwHelicity::GetRandomSeed`, which (a) only works with an input array of size 25 (24 words actually used) and (b) uses Fortran indexing into the input array (1-24). The original code apparently mixed up C and Fortran indexing, causing an out of bounds array access in `GetRandomSeed`. This is fixed here by shifting the input array indexing by one, as was probably intended. Additionally, an exception in thrown if the number of bits requested is not equal to 24, since 24 is the only value currently supported. To lift this limit, GetRandomSeed would need to be modified.

`QwHelicity::SetFirstBits` is only called from exactly one place in this package, viz. QwMockDataGenerator.cc:194, with nbits=24, so the exception should never trigger. However, the results could be different since the original buggy code copied the bits of the seed argument into the wrong elements of the array.

Someone with a deeper understanding of the seed generation logic should review this.