### PR TITLE
Fix unused private field warning in QwColor class

### DIFF
--- a/Analysis/include/QwColor.h
+++ b/Analysis/include/QwColor.h
@@ -100,8 +100,8 @@ class QwColor
   public:
 
     /// Default constructor
-    QwColor(const Qw::EQwColor f = Qw::kDefaultForeground, const Qw::EQwColor b = Qw::kDefaultBackground)
-    : foreground(f), background(b) { };
+    QwColor(const Qw::EQwColor f = Qw::kDefaultForeground, [[maybe_unused]] const Qw::EQwColor b = Qw::kDefaultBackground)
+    : foreground(f) { };
     virtual ~QwColor() { };
 
   /// \brief Output stream operator
@@ -145,7 +145,6 @@ class QwColor
   private:
 
     Qw::EQwColor foreground; ///< Foreground color
-    Qw::EQwColor background; ///< Background color (not yet supported)
 
 }; // class QwColor
 


### PR DESCRIPTION
## Problem

Clang compiler was generating a warning about an unused private field in the QwColor class:

```
/home/runner/work/japan-MOLLER/japan-MOLLER/Analysis/include/QwColor.h:148:18: warning: private field 'background' is not used [-Wunused-private-field]
    Qw::EQwColor background; ///< Background color (not yet supported)
                 ^
```

**Issue Details:**
- The `background` private field was declared but never used in the QwColor class
- The constructor accepted a background color parameter but only stored it without any functionality
- This caused compilation warnings with `-Wunused-private-field` enabled
- The background color feature appears to be incomplete/unsupported

## Solution

**1. Removed unused private field:**
```cpp
// Removed this line:
Qw::EQwColor background; ///< Background color (not yet supported)
```

**2. Updated constructor:**
- Marked the background parameter as `[[maybe_unused]]` to indicate intentional non-use
- Removed background initialization from constructor initializer list
- Preserved the API signature for backward compatibility

```cpp
// Before:
QwColor(const Qw::EQwColor f = Qw::kDefaultForeground, const Qw::EQwColor b = Qw::kDefaultBackground)
: foreground(f), background(b) { };

// After:
QwColor(const Qw::EQwColor f = Qw::kDefaultForeground, [[maybe_unused]] const Qw::EQwColor b = Qw::kDefaultBackground)
: foreground(f) { };
```

## Impact

- ✅ **Resolves compiler warning**: Eliminates `-Wunused-private-field` warning
- ✅ **Maintains API compatibility**: Constructor signature unchanged  
- ✅ **Cleaner code**: Removes dead code that served no purpose
- ✅ **Future-ready**: Background parameter preserved for potential future implementation

## Testing

- Verified compilation without warnings
- Existing QwColor functionality unchanged
- No impact on current usage patterns

## Files Modified

- `Analysis/include/QwColor.h`: Removed unused background field and updated constructor

This is a minimal, low-risk change that improves code quality by eliminating compiler warnings while maintaining full backward compatibility.