### PR TITLE
Fix constructor member initialization order warnings (-Wreorder)

### DIFF
--- a/Analysis/src/QwEventBuffer.cc
+++ b/Analysis/src/QwEventBuffer.cc
@@ -51,10 +51,10 @@ QwEventBuffer::QwEventBuffer()
        fDataFileExtension(fDefaultDataFileExtension),
        fDataDirectory(fDefaultDataDirectory),
        fEvStreamMode(fEvStreamNull),
-       fSingleFile(kFALSE),
        fEvStream(NULL),
        fCurrentRun(-1),
        fNumPhysicsEvents(0),
+       fSingleFile(kFALSE),
 			 decoder(NULL)
 {
   //  Set up the signal handler.

--- a/Parity/src/QwHelicityPattern.cc
+++ b/Parity/src/QwHelicityPattern.cc
@@ -190,7 +190,8 @@ QwHelicityPattern::QwHelicityPattern(QwSubsystemArrayParity &event, const TStrin
 
 /*****************************************************************/
 QwHelicityPattern::QwHelicityPattern(const QwHelicityPattern &source)
-: fYield(source.fYield),
+: fPatternSize(source.fPatternSize),
+  fYield(source.fYield),
   fDifference(source.fDifference),
   fAsymmetry(source.fAsymmetry),
   fEnableAlternateAsym(source.fEnableAlternateAsym),
@@ -204,7 +205,6 @@ QwHelicityPattern::QwHelicityPattern(const QwHelicityPattern &source)
   fPrintIndexFile(source.fPrintIndexFile),
   fBurstMinGoodPatterns(source.fBurstMinGoodPatterns),
   fGoodPatterns(source.fGoodPatterns),
-  fPatternSize(source.fPatternSize),
   fBurstCounter(source.fBurstCounter),
   fEnableBurstSum(source.fEnableBurstSum),
   fPrintBurstSum(source.fPrintBurstSum),


### PR DESCRIPTION
This PR fixes all `-Wreorder` compiler warnings by reordering constructor member initialization lists to match the declaration order in header files.

## Changes Made

### QwEventBuffer Constructor
- Reordered initialization list in `Analysis/src/QwEventBuffer.cc` to match header declaration order
- Fixed: `fEvStream` → `fCurrentRun` → `fNumPhysicsEvents` → `fSingleFile`

### QwHelicityPattern Copy Constructor  
- Reordered initialization list in `Parity/src/QwHelicityPattern.cc` to match header declaration order
- Fixed: `fPatternSize` moved to correct position before other members

## Testing
- ✅ Clean build with `-Wreorder` flag enabled
- ✅ No reorder warnings remain
- ✅ All executables compile and run correctly
- ✅ No functional changes, only initialization order fixes

## Technical Details
Constructor member initialization lists must follow the same order as member declarations in the class header file. The C++ standard requires this to prevent subtle initialization order bugs, and compilers warn about mismatches with `-Wreorder`.

Fixes compiler warnings:
- `QwEventBuffer::fSingleFile will be initialized after`
- `QwHelicityPattern::fGoodPatterns will be initialized after`