### PR TITLE
Run mock data analysis with MPS tree disabled and upload as artifact

### DIFF
--- a/.github/workflows/build-lcg-cvmfs.yml
+++ b/.github/workflows/build-lcg-cvmfs.yml
@@ -70,9 +70,9 @@ jobs:
             build/qwmockdatagenerator -r 4 -e 1:20000 --config qwparity_simple.conf --detectors mock_newdets.map --data .
             echo "::endgroup::"
             
-            echo "::group::Mock data analysis"
-            # Analyze the generated mock data
-            build/qwparity -r 4 --config qwparity_simple.conf --detectors mock_newdets.map --datahandlers mock_datahandlers.map --data . --rootfiles . --write-promptsummary
+            echo "::group::Mock data analysis (MPS tree disabled)"
+            # Analyze the generated mock data with MPS tree disabled
+            build/qwparity -r 4 --config qwparity_simple.conf --detectors mock_newdets.map --datahandlers mock_datahandlers.map --data . --rootfiles . --write-promptsummary --disable-mps-tree
             echo "::endgroup::"
 
       - name: Upload prompt summary
@@ -83,3 +83,13 @@ jobs:
             summary_*.txt
           retention-days: 7
           if-no-files-found: error
+
+      - name: Upload mock data analysis artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: mock-analysis-output-${{ matrix.release }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.compiler }}
+          path: |
+            *.root
+          retention-days: 7
+          if-no-files-found: warn


### PR DESCRIPTION
Depends:
- [ ] #59 

This PR adds functionality to run mock data analysis with the MPS tree disabled and upload the results as artifacts for CI/CD workflows. This reduces uploaded file size from 1.6 GB to 380 MB. For future pull request validation efforts, the remaining trees are sufficient.

Changes include:
- Mock data analysis execution with MPS tree disabled
- Artifact upload functionality for analysis results

This enables better testing and validation of the analysis pipeline in automated builds.