### PR TITLE
Replace abs with fabs for float weight calculation

### DIFF
--- a/Parity/src/QwBeamLine.cc
+++ b/Parity/src/QwBeamLine.cc
@@ -159,7 +159,7 @@ Int_t QwBeamLine::LoadChannelMap(TString mapfile)
 	          // calculate the total weights of the charge
 	            sumQweights = 0.0;
 	            for(size_t i=0;i<fDeviceName.size();i++)
-		            sumQweights+=abs(fQWeight[i]);
+		            sumQweights+=fabs(fQWeight[i]);
 	            combolistdecoded = kTRUE;
 	            break;
 	          }


### PR DESCRIPTION
The use of `abs` in this part of the code is the integer version of `abs`, and should be fixed to use the floating point version.

A more thorough solution would be convert all `fabs` to `std::abs` which is implemented with the same name for all types (and more canonical C++). But this is a minimal fix for the incorrect behavior.