### PR TITLE
Avoid header use of static instantiated elsewhere

### DIFF
--- a/Parity/include/QwCombinedBCM.h
+++ b/Parity/include/QwCombinedBCM.h
@@ -131,7 +131,7 @@ class QwCombinedBCM : public QwBCM<T> {
   static boost::variate_generator
     < boost::mt19937, boost::random::uniform_real_distribution<double> > fRandomVariable;
 public: 
-  static void SetTripSeed(uint seedval){fRandomVariable.engine().seed(seedval);}
+  static void SetTripSeed(uint seedval);
   // @}
 };
 

--- a/Parity/src/QwCombinedBCM.cc
+++ b/Parity/src/QwCombinedBCM.cc
@@ -39,9 +39,11 @@ template<typename T> boost::random::uniform_real_distribution<double> QwCombined
 template<typename T> boost::variate_generator < boost::mt19937, boost::random::uniform_real_distribution<double> >
   QwCombinedBCM<T>::fRandomVariable(fRandomnessGenerator, fDistribution);
 
-
-
-
+template<typename T>
+void QwCombinedBCM<T>::SetTripSeed(uint seedval)
+{
+  fRandomVariable.engine().seed(seedval);
+}
 
 /********************************************************/
 


### PR DESCRIPTION
The use of static variables in a header when these static variables are only instantiated in a separate source file leads to compiler warnings.

This is the case for QWCombinedBCM::SetTripSeed, which relies on fRandomVariable, which is only instantiated in QwCombinedBCM.cc.

This PR simply moves the function implementation to the source file.