### PR TITLE
Avoid typeid on calls with possible side-effects

### DIFF
--- a/Analysis/src/QwSubsystemArray.cc
+++ b/Analysis/src/QwSubsystemArray.cc
@@ -80,13 +80,14 @@ QwSubsystemArray& QwSubsystemArray::operator=(const QwSubsystemArray& source)
         } else {
           VQwSubsystem *ptr1 =
             dynamic_cast<VQwSubsystem*>(this->at(i).get());
-          if (typeid(*ptr1)==typeid(*(source.at(i).get()))){
+          VQwSubsystem *ptr2 = source.at(i).get();
+          if (typeid(*ptr1)==typeid(*(ptr2))){
             *(ptr1) = source.at(i).get();
           } else {
             //  Subsystems don't match
             QwError << " QwSubsystemArray::operator= types do not mach" << QwLog::endl;
-            QwError << " typeid(ptr1)=" << typeid(*ptr1).name()
-                    << " but typeid(*(source.at(i).get()))=" << typeid(*(source.at(i).get())).name()
+            QwError << " typeid(*ptr1)=" << typeid(*ptr1).name()
+                    << " but typeid(*ptr2)=" << typeid(*ptr2).name()
                     << QwLog::endl;
           }
         }


### PR DESCRIPTION
When a `typeid` is called on more than a simple expression, this can have side effects (as little as just generating output to std::cout). Newer compilers warn against this (e.g. clang-22) with:
```
/home/wdconinc/git/japan-MOLLER/.worktree/sqlpp/Parity/src/QwDataHandlerArray.cc:467:30: warning: expression with side effects will be evaluated despite being used as an operand to 'typeid'
      [-Wpotentially-evaluated-expression]
  467 |           if (typeid(*ptr1)==typeid(*(source.at(i).get()))){
      |                                     ^
```
This is highlighted (I suspect) since typeid is an operator, and one could assume that it only operates on the intended output type without evaluating the expression.

This PR hides the warnings by making these calls explicit.