### PR TITLE
Refactor: Add `using` declarations for operator overloads and update error flag methods across various classes

### DIFF
--- a/Analysis/include/QwADC18_Channel.h
+++ b/Analysis/include/QwADC18_Channel.h
@@ -133,6 +133,12 @@ class QwADC18_Channel: public VQwHardwareChannel, public MQwMockable {
   void DivideBy(const VQwHardwareChannel* valueptr);
   void ArcTan(const QwADC18_Channel &value);
 
+  using VQwHardwareChannel::operator=;
+  using VQwHardwareChannel::operator+=;
+  using VQwHardwareChannel::operator-=;
+  using VQwHardwareChannel::operator*=;
+  using VQwHardwareChannel::operator/=;
+
   QwADC18_Channel& operator+= (const QwADC18_Channel &value);
   QwADC18_Channel& operator-= (const QwADC18_Channel &value);
   QwADC18_Channel& operator*= (const QwADC18_Channel &value);
@@ -145,6 +151,13 @@ class QwADC18_Channel: public VQwHardwareChannel, public MQwMockable {
   const QwADC18_Channel operator+ (const QwADC18_Channel &value) const;
   const QwADC18_Channel operator- (const QwADC18_Channel &value) const;
   const QwADC18_Channel operator* (const QwADC18_Channel &value) const;
+
+  using VQwDataElement::Sum;
+  using VQwDataElement::Difference;
+  using VQwDataElement::Ratio;
+  using VQwHardwareChannel::Sum;
+  using VQwHardwareChannel::Difference;
+  using VQwHardwareChannel::Ratio;
   void Sum(const QwADC18_Channel &value1, const QwADC18_Channel &value2);
   void Difference(const QwADC18_Channel &value1, const QwADC18_Channel &value2);
   void Ratio(const QwADC18_Channel &numer, const QwADC18_Channel &denom);

--- a/Analysis/include/QwMollerADC_Channel.h
+++ b/Analysis/include/QwMollerADC_Channel.h
@@ -83,6 +83,7 @@ class QwMollerADC_Channel: public VQwHardwareChannel, public MQwMockable {
   };
   virtual ~QwMollerADC_Channel() { };
 
+  using VQwHardwareChannel::CopyFrom;
   void CopyFrom(const QwMollerADC_Channel& value){
     VQwHardwareChannel::CopyFrom(value);
     fBlocksPerEvent = value.fBlocksPerEvent;
@@ -149,6 +150,12 @@ class QwMollerADC_Channel: public VQwHardwareChannel, public MQwMockable {
   void DivideBy(const VQwHardwareChannel* valueptr);
   void ArcTan(const QwMollerADC_Channel &value);
 
+  using VQwHardwareChannel::operator=;
+  using VQwHardwareChannel::operator+=;
+  using VQwHardwareChannel::operator-=;
+  using VQwHardwareChannel::operator*=;
+  using VQwHardwareChannel::operator/=;
+
   QwMollerADC_Channel& operator+= (const QwMollerADC_Channel &value);
   QwMollerADC_Channel& operator-= (const QwMollerADC_Channel &value);
   QwMollerADC_Channel& operator*= (const QwMollerADC_Channel &value);
@@ -161,6 +168,13 @@ class QwMollerADC_Channel: public VQwHardwareChannel, public MQwMockable {
   const QwMollerADC_Channel operator+ (const QwMollerADC_Channel &value) const;
   const QwMollerADC_Channel operator- (const QwMollerADC_Channel &value) const;
   const QwMollerADC_Channel operator* (const QwMollerADC_Channel &value) const;
+
+  using VQwDataElement::Sum;
+  using VQwDataElement::Difference;
+  using VQwDataElement::Ratio;
+  using VQwHardwareChannel::Sum;
+  using VQwHardwareChannel::Difference;
+  using VQwHardwareChannel::Ratio;
   void Sum(const QwMollerADC_Channel &value1, const QwMollerADC_Channel &value2);
   void Difference(const QwMollerADC_Channel &value1, const QwMollerADC_Channel &value2);
   void Ratio(const QwMollerADC_Channel &numer, const QwMollerADC_Channel &denom);

--- a/Analysis/include/QwOmnivore.h
+++ b/Analysis/include/QwOmnivore.h
@@ -51,7 +51,11 @@ class QwOmnivore: public VQwSubsystem_t {
     /// Increment error counters
     void IncrementErrorCounters() { };
     /// Update error flag
+    using VQwSubsystem_t::UpdateErrorFlag;
     void UpdateErrorFlag(const VQwSubsystem*) { };
+    // FIXME (wdconinc)
+    // The using statements above should use concepts in C++20 (or SFINAE):
+    // it is not guaranteed that VQwSubsystem_t has an UpdateErrorFlag method
 
     /// Get the hit list
     //void  GetHitList(QwHitContainer& grandHitContainer) { };
@@ -91,6 +95,7 @@ class QwOmnivore: public VQwSubsystem_t {
     void  ProcessEvent() { };
 
     /// Assignment/addition/subtraction operators
+    using MQwHistograms::operator=;
     VQwSubsystem& operator=  (VQwSubsystem *value) { return *this; };
     VQwSubsystem& operator+= (VQwSubsystem *value) { return *this; };
     VQwSubsystem& operator-= (VQwSubsystem *value) { return *this; };
@@ -101,11 +106,13 @@ class QwOmnivore: public VQwSubsystem_t {
     void Scale(Double_t factor) { };
 
     /// Construct the histograms for this subsystem in a folder with a prefix
+    using VQwSubsystem::ConstructHistograms;
     void  ConstructHistograms(TDirectory *folder, TString &prefix) { };
     /// Fill the histograms for this subsystem
     void  FillHistograms() { };
 
     /// Construct the branch and tree vector
+    using VQwSubsystem::ConstructBranchAndVector;
     void ConstructBranchAndVector(TTree *tree, TString & prefix, std::vector <Double_t> &values) { };
     /// Fill the tree vector
     void FillTreeVector(std::vector<Double_t> &values) const { };

--- a/Analysis/include/QwPMT_Channel.h
+++ b/Analysis/include/QwPMT_Channel.h
@@ -62,6 +62,8 @@ class QwPMT_Channel: public VQwDataElement {
 
   void  ProcessEvent();
 
+  using MQwHistograms::operator=;
+  using VQwDataElement::operator=;
   QwPMT_Channel& operator=  (const QwPMT_Channel &value);
 
   void  ConstructHistograms(TDirectory *folder, TString &prefix);

--- a/Analysis/include/QwSIS3320_Accumulator.h
+++ b/Analysis/include/QwSIS3320_Accumulator.h
@@ -60,6 +60,10 @@ class QwSIS3320_Accumulator: public VQwDataElement {
     Int_t ProcessEvBuffer(UInt_t* buffer, UInt_t num_words_left, UInt_t subelement = 0);
     void  ProcessEvent() { };
 
+    using MQwHistograms::operator=;
+    using VQwDataElement::operator=;
+    using VQwDataElement::operator+=;
+    using VQwDataElement::operator-=;
     const QwSIS3320_Accumulator operator/ (const Double_t &value) const;
     const QwSIS3320_Accumulator operator* (const Double_t &value) const;
     const QwSIS3320_Accumulator operator+ (const Double_t &value) const;
@@ -73,6 +77,10 @@ class QwSIS3320_Accumulator: public VQwDataElement {
     QwSIS3320_Accumulator& operator=  (const QwSIS3320_Accumulator &value);
     QwSIS3320_Accumulator& operator+= (const QwSIS3320_Accumulator &value);
     QwSIS3320_Accumulator& operator-= (const QwSIS3320_Accumulator &value);
+
+    using VQwDataElement::Sum;
+    using VQwDataElement::Difference;
+    using VQwDataElement::Ratio;
     void Sum(const QwSIS3320_Accumulator &value1, const QwSIS3320_Accumulator &value2);
     void Difference(const QwSIS3320_Accumulator &value1, const QwSIS3320_Accumulator &value2);
     void Ratio(const QwSIS3320_Accumulator &numer, const QwSIS3320_Accumulator &denom);

--- a/Analysis/include/QwSIS3320_LogicalAccumulator.h
+++ b/Analysis/include/QwSIS3320_LogicalAccumulator.h
@@ -32,6 +32,10 @@ public:
   { };
   virtual ~QwSIS3320_LogicalAccumulator() { };
 
+  // FIXME (wdconinc) explicit assignment operator needed
+  using MQwHistograms::operator=;
+  using VQwDataElement::operator=;
+
   void AddAccumulatorReference( QwSIS3320_Accumulator *accum, Double_t weight);
 
   void  ProcessEvent();

--- a/Analysis/include/QwScaler_Channel.h
+++ b/Analysis/include/QwScaler_Channel.h
@@ -81,6 +81,8 @@ public:
   { }
   virtual ~VQwScaler_Channel() { };
 
+  using VQwDataElement::CopyFrom;
+  using VQwHardwareChannel::CopyFrom;
   void CopyFrom(const VQwScaler_Channel& value){
     VQwHardwareChannel::CopyFrom(value);
     fValue_Raw_Old = value.fValue_Raw_Old;
@@ -138,13 +140,22 @@ public:
   Double_t GetValueM2(size_t element) const    { return fValueM2; };
   Double_t GetValueError(size_t element) const { return fValueError; };
 
-  VQwScaler_Channel& operator=  (const VQwScaler_Channel &value);
+  using MQwHistograms::operator=;
+  using VQwDataElement::operator=;
+  using VQwHardwareChannel::operator=;
+  VQwScaler_Channel& operator=(const VQwScaler_Channel &value);
+
   void AssignScaledValue(const VQwScaler_Channel &value, Double_t scale);
   void AssignValueFrom(const VQwDataElement* valueptr);
   void AddValueFrom(const VQwHardwareChannel* valueptr);
   void SubtractValueFrom(const VQwHardwareChannel* valueptr);
   void MultiplyBy(const VQwHardwareChannel* valueptr);
   void DivideBy(const VQwHardwareChannel* valueptr);
+
+  using VQwHardwareChannel::operator+=;
+  using VQwHardwareChannel::operator-=;
+  using VQwHardwareChannel::operator*=;
+  using VQwHardwareChannel::operator/=;
 
   //  VQwHardwareChannel& operator=  (const VQwHardwareChannel &data_value);
   VQwScaler_Channel& operator+= (const VQwScaler_Channel &value);
@@ -156,6 +167,12 @@ public:
   VQwHardwareChannel& operator*=(const VQwHardwareChannel* input);
   VQwHardwareChannel& operator/=(const VQwHardwareChannel* input);
 
+  using VQwDataElement::Sum;
+  using VQwDataElement::Difference;
+  using VQwDataElement::Ratio;
+  using VQwHardwareChannel::Sum;
+  using VQwHardwareChannel::Difference;
+  using VQwHardwareChannel::Ratio;
   void Sum(VQwScaler_Channel &value1, VQwScaler_Channel &value2);
   void Difference(VQwScaler_Channel &value1, VQwScaler_Channel &value2);
   void Ratio(const VQwScaler_Channel &numer, const VQwScaler_Channel &denom);
@@ -169,6 +186,7 @@ public:
 
   Bool_t ApplySingleEventCuts();//check values read from modules are at desired level
 
+  using VQwHardwareChannel::CheckForBurpFail;
   Bool_t CheckForBurpFail(const VQwDataElement *ev_error){return kFALSE;};
 
   void IncrementErrorCounters();
@@ -255,9 +273,13 @@ class QwScaler_Channel: public VQwScaler_Channel
   QwScaler_Channel(const QwScaler_Channel& source, VQwDataElement::EDataToSave datatosave)
     : VQwScaler_Channel(source,datatosave) { };
 
-  using VQwScaler_Channel::CopyFrom;
   using VQwHardwareChannel::Clone;
   VQwHardwareChannel* Clone(VQwDataElement::EDataToSave datatosave) const;
+
+  using MQwHistograms::operator=;
+  using VQwDataElement::operator=;
+  using VQwHardwareChannel::operator=;
+  using VQwScaler_Channel::operator=;
 
   public:
 

--- a/Analysis/include/QwVQWK_Channel.h
+++ b/Analysis/include/QwVQWK_Channel.h
@@ -83,6 +83,8 @@ class QwVQWK_Channel: public VQwHardwareChannel, public MQwMockable {
   };
   virtual ~QwVQWK_Channel() { };
 
+  using VQwDataElement::CopyFrom;
+  using VQwHardwareChannel::CopyFrom;
   void CopyFrom(const QwVQWK_Channel& value){
     VQwHardwareChannel::CopyFrom(value);
     fBlocksPerEvent = value.fBlocksPerEvent;
@@ -148,6 +150,12 @@ class QwVQWK_Channel: public VQwHardwareChannel, public MQwMockable {
   void DivideBy(const VQwHardwareChannel* valueptr);
   void ArcTan(const QwVQWK_Channel &value);
 
+  using VQwHardwareChannel::operator=;
+  using VQwHardwareChannel::operator+=;
+  using VQwHardwareChannel::operator-=;
+  using VQwHardwareChannel::operator*=;
+  using VQwHardwareChannel::operator/=;
+
   QwVQWK_Channel& operator+= (const QwVQWK_Channel &value);
   QwVQWK_Channel& operator-= (const QwVQWK_Channel &value);
   QwVQWK_Channel& operator*= (const QwVQWK_Channel &value);
@@ -160,6 +168,13 @@ class QwVQWK_Channel: public VQwHardwareChannel, public MQwMockable {
   const QwVQWK_Channel operator+ (const QwVQWK_Channel &value) const;
   const QwVQWK_Channel operator- (const QwVQWK_Channel &value) const;
   const QwVQWK_Channel operator* (const QwVQWK_Channel &value) const;
+
+  using VQwDataElement::Sum;
+  using VQwDataElement::Difference;
+  using VQwDataElement::Ratio;
+  using VQwHardwareChannel::Sum;
+  using VQwHardwareChannel::Difference;
+  using VQwHardwareChannel::Ratio;
   void Sum(const QwVQWK_Channel &value1, const QwVQWK_Channel &value2);
   void Difference(const QwVQWK_Channel &value1, const QwVQWK_Channel &value2);
   void Ratio(const QwVQWK_Channel &numer, const QwVQWK_Channel &denom);

--- a/Analysis/include/VQwDataElement.h
+++ b/Analysis/include/VQwDataElement.h
@@ -54,6 +54,8 @@ class VQwDataElement: public MQwHistograms {
   /// entered in the tree
   enum EDataToSave {kRaw = 0, kDerived, kMoments};
 
+  // Bring base class virtual functions into scope to avoid hiding warnings
+  using MQwHistograms::operator=;
 
  public:
 

--- a/Analysis/include/VQwHardwareChannel.h
+++ b/Analysis/include/VQwHardwareChannel.h
@@ -33,12 +33,17 @@ class VQwHardwareChannel: public VQwDataElement {
  *         from one physical channel (such as QwVQWK_Channel,
  *         QwScaler_Channel, etc.) should inherit from this class.
  ******************************************************************/
+
+public:
+  // Bring base class virtual functions into scope to avoid hiding warnings
+
 public:
   VQwHardwareChannel();
   VQwHardwareChannel(const VQwHardwareChannel& value);
   VQwHardwareChannel(const VQwHardwareChannel& value, VQwDataElement::EDataToSave datatosave);
   virtual ~VQwHardwareChannel() { };
 
+  using VQwDataElement::CopyFrom;
   virtual void CopyFrom(const VQwHardwareChannel& value);
 
   void ProcessOptions();
@@ -96,6 +101,7 @@ public:
 
   virtual Bool_t ApplySingleEventCuts() = 0;//check values read from modules are at desired level
 
+  using VQwDataElement::CheckForBurpFail;
   virtual Bool_t CheckForBurpFail(const VQwHardwareChannel *event){
     Bool_t foundburp = kFALSE;
     if (fBurpThreshold>0){
@@ -121,6 +127,7 @@ public:
   /*! \brief Inherited from VQwDataElement to set the upper and lower 
    *         limits (fULimit and fLLimit), stability % and the 
    *         error flag on this channel */
+  using VQwDataElement::SetSingleEventCuts;
   void SetSingleEventCuts(UInt_t errorflag,Double_t min, Double_t max, Double_t stability=-1.0, Double_t BurpLevel=-1.0);
 
   Double_t GetEventCutUpperLimit() const { return fULimit; };
@@ -140,6 +147,7 @@ public:
 //   virtual void AccumulateRunningSum(const VQwHardwareChannel *value) = 0;
 
   /// Arithmetic assignment operator:  Should only copy event-based data
+  using VQwDataElement::operator=;
   virtual VQwHardwareChannel& operator=(const VQwHardwareChannel& value) {
     VQwDataElement::operator=(value);
     return *this;
@@ -148,7 +156,9 @@ public:
      AssignValueFrom(&value);
      Scale(scale);
   };
-    virtual void Ratio(const VQwHardwareChannel* numer, const VQwHardwareChannel* denom){
+
+  using VQwDataElement::Ratio;
+  virtual void Ratio(const VQwHardwareChannel* numer, const VQwHardwareChannel* denom){
     if (!IsNameEmpty()){
       this->AssignValueFrom(numer); 
       this->operator/=(denom);
@@ -160,6 +170,9 @@ public:
   }
 
   void AssignValueFrom(const VQwDataElement* valueptr) = 0;
+
+  using VQwDataElement::operator+=;
+  using VQwDataElement::operator-=;
   virtual VQwHardwareChannel& operator+=(const VQwHardwareChannel* input) = 0;
   virtual VQwHardwareChannel& operator-=(const VQwHardwareChannel* input) = 0;
   virtual VQwHardwareChannel& operator*=(const VQwHardwareChannel* input) = 0;

--- a/Analysis/include/VQwSubsystem.h
+++ b/Analysis/include/VQwSubsystem.h
@@ -273,8 +273,8 @@ class VQwSubsystem: virtual public VQwSubsystemCloneable, public MQwHistograms, 
   /// \brief Assignment
   /// Note: Must be called at the beginning of all subsystems routine
   /// call to operator=(VQwSubsystem *value) by VQwSubsystem::operator=(value)
+  using MQwHistograms::operator=;
   virtual VQwSubsystem& operator=(VQwSubsystem *value);
-
 
   virtual void PrintDetectorMaps(Bool_t status) const;
 

--- a/Parity/include/LRBCorrector.h
+++ b/Parity/include/LRBCorrector.h
@@ -28,6 +28,7 @@ class LRBCorrector : public VQwDataHandler, public MQwDataHandlerCloneable<LRBCo
 
     Int_t LoadChannelMap(const std::string& mapfile);
 
+    using VQwDataHandler::ConnectChannels;
     Int_t ConnectChannels(QwSubsystemArrayParity& asym, QwSubsystemArrayParity& diff);
     
     void ProcessData();

--- a/Parity/include/QwAlarmHandler.h
+++ b/Parity/include/QwAlarmHandler.h
@@ -35,6 +35,7 @@ class QwAlarmHandler:public VQwDataHandler, public MQwDataHandlerCloneable<QwAla
     /// \brief Connect to Channels (event only)
     //Int_t ConnectChannels(QwSubsystemArrayParity& event);
     /// \brief Connect to Channels (asymmetry/difference only)
+    using VQwDataHandler::ConnectChannels;
     Int_t ConnectChannels(
         QwSubsystemArrayParity& yield,
         QwSubsystemArrayParity& asym,

--- a/Parity/include/QwBCM.h
+++ b/Parity/include/QwBCM.h
@@ -100,11 +100,12 @@ template<typename T> class QwBCM : public VQwBCM {
     return fBeamCurrent.GetEventcutErrorFlag();
   }
 
+  using VQwBCM::UpdateErrorFlag;
   void UpdateErrorFlag(const VQwBCM *ev_error);
 
   UInt_t GetErrorCode() const {return (fBeamCurrent.GetErrorCode());}; 
 
-
+  using VQwDataElement::SetSingleEventCuts;
   Int_t SetSingleEventCuts(Double_t mean = 0, Double_t sigma = 0);//two limts and sample size
   /*! \brief Inherited from VQwDataElement to set the upper and lower limits (fULimit and fLLimit), stability % and the error flag on this channel */
   void SetSingleEventCuts(UInt_t errorflag, Double_t min = 0, Double_t max = 0, Double_t stability = 0, Double_t burplevel = 0);
@@ -118,6 +119,7 @@ template<typename T> class QwBCM : public VQwBCM {
   void PrintInfo() const;
 
 protected:
+  using VQwBCM::GetCharge;
   VQwHardwareChannel* GetCharge() {
     return &fBeamCurrent;
   };
@@ -129,6 +131,13 @@ public:
   void SetExternalClockPtr( const VQwHardwareChannel* clock) {fBeamCurrent.SetExternalClockPtr(clock);};
   void SetExternalClockName( const std::string name) { fBeamCurrent.SetExternalClockName(name);};
   Double_t GetNormClockValue() { return fBeamCurrent.GetNormClockValue();}
+
+  using MQwHistograms::operator=;
+  using VQwDataElement::operator=;
+  using VQwBCM::operator=;
+
+  using VQwDataElement::operator+=;
+  using VQwDataElement::operator-=;
 
   // Implementation of Parent class's virtual operators
   VQwBCM& operator=  (const VQwBCM &value);
@@ -146,6 +155,7 @@ public:
   QwBCM& operator=  (const QwBCM &value);
   QwBCM& operator+= (const QwBCM &value);
   QwBCM& operator-= (const QwBCM &value);
+  using VQwDataElement::Ratio;
   void Ratio(const VQwBCM &numer, const VQwBCM &denom);
   void Ratio(const QwBCM &numer, const QwBCM &denom);
   void Scale(Double_t factor);

--- a/Parity/include/QwBPMCavity.h
+++ b/Parity/include/QwBPMCavity.h
@@ -74,6 +74,7 @@ class QwBPMCavity : public VQwBPM {
   void    PrintValue() const;
   void    PrintInfo() const;
 
+  using VQwBPM::GetPosition;
   const VQwHardwareChannel* GetPosition(EBeamPositionMonitorAxis axis) const {
     if (axis<0 || axis>2){
       TString loc="QwBPMCavity::GetPosition for "
@@ -89,6 +90,7 @@ class QwBPMCavity : public VQwBPM {
 
   Bool_t  ApplyHWChecks();//Check for harware errors in the devices
   Bool_t  ApplySingleEventCuts();//Check for good events by stting limits on the devices readings
+  using VQwDataElement::SetSingleEventCuts;
   //void    SetSingleEventCuts(TString ch_name, Double_t minX, Double_t maxX);
   /*! \brief Inherited from VQwDataElement to set the upper and lower limits (fULimit and fLLimit), stability % and the error flag on this channel */
   void    SetSingleEventCuts(TString ch_name, UInt_t errorflag,Double_t minX, Double_t maxX, Double_t stability, Double_t burplevel);
@@ -98,10 +100,13 @@ class QwBPMCavity : public VQwBPM {
   UInt_t  GetEventcutErrorFlag();
   UInt_t  UpdateErrorFlag();
   void UpdateErrorFlag(const VQwBPM *ev_error);
+  // FIXME (wdconinc) doesn't avoid overloaded virtual warning
+  using VQwDataElement::UpdateErrorFlag;
 
   Bool_t  CheckForBurpFail(const VQwDataElement *ev_error);
 
   void    SetDefaultSampleSize(Int_t sample_size);
+  using VQwBPM::SetRandomEventParameters;
   void    SetRandomEventParameters(Double_t meanX, Double_t sigmaX, Double_t meanY, Double_t sigmaY);
   void    RandomizeEventData(int helicity = 0, double time = 0.0);
   void    SetEventData(Double_t* block, UInt_t sequencenumber);
@@ -109,8 +114,14 @@ class QwBPMCavity : public VQwBPM {
   void    SetSubElementPedestal(Int_t j, Double_t value);
   void    SetSubElementCalibrationFactor(Int_t j, Double_t value);
 
+  using VQwBPM::Ratio;
   void    Ratio(QwBPMCavity &numer, QwBPMCavity &denom);
   void    Scale(Double_t factor);
+
+  using MQwHistograms::operator=;
+  using VQwDataElement::operator=;
+  using VQwDataElement::operator+=;
+  using VQwDataElement::operator-=;
 
   VQwBPM& operator=  (const VQwBPM &value);
   VQwBPM& operator+= (const VQwBPM &value);

--- a/Parity/include/QwBPMStripline.h
+++ b/Parity/include/QwBPMStripline.h
@@ -112,6 +112,7 @@ class QwBPMStripline : public VQwBPM {
 
   Bool_t  ApplyHWChecks();//Check for harware errors in the devices
   Bool_t  ApplySingleEventCuts();//Check for good events by stting limits on the devices readings
+  using VQwDataElement::SetSingleEventCuts;
   //void    SetSingleEventCuts(TString ch_name, Double_t minX, Double_t maxX);
   /*   /\*! \brief Inherited from VQwDataElement to set the upper and lower limits (fULimit and fLLimit), stability % and the error flag on this channel *\/ */
   void    SetSingleEventCuts(TString ch_name, UInt_t errorflag,Double_t minX, Double_t maxX, Double_t stability, Double_t burplevel);
@@ -125,8 +126,11 @@ class QwBPMStripline : public VQwBPM {
   Bool_t  CheckForBurpFail(const VQwDataElement *ev_error);
   void    UpdateErrorFlag(const VQwBPM *ev_error);
 
+  // FIXME (wdconinc) doesn't avoid overloaded virtual warning
+  using VQwDataElement::UpdateErrorFlag;
 
   void    SetDefaultSampleSize(Int_t sample_size);
+  using VQwBPM::SetRandomEventParameters;
   void    SetRandomEventParameters(Double_t meanX, Double_t sigmaX, Double_t meanY, Double_t sigmaY);
   void    RandomizeEventData(int helicity = 0, double time = 0.0);
   void    LoadMockDataParameters(QwParameterFile &paramfile);
@@ -137,10 +141,15 @@ class QwBPMStripline : public VQwBPM {
   void    SetSubElementPedestal(Int_t j, Double_t value);
   void    SetSubElementCalibrationFactor(Int_t j, Double_t value);
 
+  using VQwDataElement::Ratio;
   void    Ratio(VQwBPM &numer, VQwBPM &denom);
   void    Ratio(QwBPMStripline &numer, QwBPMStripline &denom);
   void    Scale(Double_t factor);
 
+  using MQwHistograms::operator=;
+  using VQwDataElement::operator=;
+  using VQwDataElement::operator+=;
+  using VQwDataElement::operator-=;
   VQwBPM& operator=  (const VQwBPM &value);
   VQwBPM& operator+= (const VQwBPM &value);
   VQwBPM& operator-= (const VQwBPM &value);

--- a/Parity/include/QwBeamLine.h
+++ b/Parity/include/QwBeamLine.h
@@ -87,6 +87,7 @@ class QwBeamLine : public VQwSubsystemParity, public MQwSubsystemCloneable<QwBea
   void UpdateErrorFlag(const VQwSubsystem *ev_error);
 
   Int_t  ProcessConfigurationBuffer(const ROCID_t roc_id, const BankID_t bank_id, UInt_t* buffer, UInt_t num_words);
+  using VQwSubsystem::ProcessEvBuffer;
   Int_t  ProcessEvBuffer(const ROCID_t roc_id, const BankID_t bank_id, UInt_t* buffer, UInt_t num_words);
   void   PrintDetectorID() const;
 
@@ -103,6 +104,7 @@ class QwBeamLine : public VQwSubsystemParity, public MQwSubsystemCloneable<QwBea
   void   SetRandomEventAsymmetry(Double_t asymmetry);
   void   EncodeEventData(std::vector<UInt_t> &buffer);
 
+  using MQwHistograms::operator=;
   VQwSubsystem&  operator=  (VQwSubsystem *value);
   VQwSubsystem&  operator+= (VQwSubsystem *value);
   VQwSubsystem&  operator-= (VQwSubsystem *value);

--- a/Parity/include/QwBeamMod.h
+++ b/Parity/include/QwBeamMod.h
@@ -144,9 +144,11 @@ class QwBeamMod: public VQwSubsystemParity, public MQwSubsystemCloneable<QwBeamM
   Bool_t CheckForBurpFail(const VQwSubsystem *subsys);
 
   //update the error flag in the subsystem level from the top level routines related to stability checks. This will uniquely update the errorflag at each channel based on the error flag in the corresponding channel in the ev_error subsystem
+  using VQwSubsystemParity::UpdateErrorFlag;
   void UpdateErrorFlag(const VQwSubsystem *ev_error);
 
   Int_t ProcessConfigurationBuffer(const ROCID_t roc_id, const BankID_t bank_id, UInt_t* buffer, UInt_t num_words);
+  using VQwSubsystem::ProcessEvBuffer;
   Int_t ProcessEvBuffer(const ROCID_t roc_id, const BankID_t bank_id, UInt_t* buffer, UInt_t num_words);
 //  void  PrintDetectorID();
 
@@ -155,6 +157,7 @@ class QwBeamMod: public VQwSubsystemParity, public MQwSubsystemCloneable<QwBeamM
   void  ProcessEvent();
   void  ProcessEvent_2();
 
+  using MQwHistograms::operator=;
   VQwSubsystem&  operator=  (VQwSubsystem *value);
   VQwSubsystem&  operator+= (VQwSubsystem *value);
   VQwSubsystem&  operator-= (VQwSubsystem *value);

--- a/Parity/include/QwBlindDetectorArray.h
+++ b/Parity/include/QwBlindDetectorArray.h
@@ -57,6 +57,11 @@ class QwBlindDetectorArray:
   /// Virtual destructor
   ~QwBlindDetectorArray(){};
 
+  // FIXME (wdconinc) explicit assignment operator needed
+  using MQwHistograms::operator=;
+  using VQwSubsystem::operator=;
+  using VQwSubsystemParity::operator=;
+
   public:
 
   /// \brief Blind the asymmetry

--- a/Parity/include/QwClock.h
+++ b/Parity/include/QwClock.h
@@ -68,6 +68,7 @@ class QwClock : public VQwClock {
   Bool_t ApplySingleEventCuts();//Check for good events by stting limits on the devices readings
   void IncrementErrorCounters(){fClock.IncrementErrorCounters();}
 
+  using VQwDataElement::CheckForBurpFail;
   Bool_t CheckForBurpFail(const QwClock *ev_error){
     return fClock.CheckForBurpFail(&(ev_error->fClock));
   }
@@ -77,12 +78,14 @@ class QwClock : public VQwClock {
   UInt_t GetEventcutErrorFlag(){//return the error flag
     return fClock.GetEventcutErrorFlag();
   }
+  using VQwDataElement::UpdateErrorFlag;
   UInt_t UpdateErrorFlag() {return GetEventcutErrorFlag();};
   void UpdateErrorFlag(const QwClock *ev_error){
     fClock.UpdateErrorFlag(ev_error->fClock);
   }
 
   /*! \brief Inherited from VQwDataElement to set the upper and lower limits (fULimit and fLLimit), stability % and the error flag on this channel */
+  using VQwDataElement::SetSingleEventCuts;
   void SetSingleEventCuts(UInt_t errorflag, Double_t min = 0, Double_t max = 0, Double_t stability = 0, Double_t burplevel = 0);
 
   void SetDefaultSampleSize(Int_t sample_size);
@@ -94,6 +97,11 @@ class QwClock : public VQwClock {
   void PrintValue() const;
   void PrintInfo() const;
 
+  using MQwHistograms::operator=;
+  using VQwDataElement::operator=;
+  using VQwDataElement::operator+=;
+  using VQwDataElement::operator-=;
+
   // Implementation of Parent class's virtual operators
   VQwClock& operator=  (const VQwClock &value);
   VQwClock& operator+= (const VQwClock &value);
@@ -103,6 +111,8 @@ class QwClock : public VQwClock {
   QwClock& operator=  (const QwClock &value);
   QwClock& operator+= (const QwClock &value);
   QwClock& operator-= (const QwClock &value);
+
+  using VQwDataElement::Ratio;
   void Ratio(const VQwClock &numer, const VQwClock &denom);
   void Ratio(const QwClock &numer, const QwClock &denom);
   void Scale(Double_t factor);

--- a/Parity/include/QwCombinedBCM.h
+++ b/Parity/include/QwCombinedBCM.h
@@ -80,10 +80,14 @@ class QwCombinedBCM : public QwBCM<T> {
 
   Bool_t ApplySingleEventCuts();//Check for good events by stting limits on the devices readings
 
+  using VQwDataElement::UpdateErrorFlag;
+  using VQwBCM::UpdateErrorFlag;
   UInt_t UpdateErrorFlag();
 
 
   // Implementation of Parent class's virtual operators
+  using MQwHistograms::operator=;
+  using VQwDataElement::operator=;
   VQwBCM& operator=  (const VQwBCM &value);
   QwCombinedBCM& operator=  (const QwCombinedBCM &value);
 

--- a/Parity/include/QwCombinedBPM.h
+++ b/Parity/include/QwCombinedBPM.h
@@ -85,6 +85,7 @@ class QwCombinedBPM : public VQwBPM {
   void    PrintValue() const;
   void    PrintInfo() const;
 
+  using VQwBPM::GetPosition;
   const VQwHardwareChannel* GetPosition(EBeamPositionMonitorAxis axis) const {
     if (axis<0 || axis>2){
       TString loc="QwLinearDiodeArray::GetPosition for "
@@ -116,15 +117,23 @@ class QwCombinedBPM : public VQwBPM {
   void IncrementErrorCounters();
   void PrintErrorCounters() const;// report number of events failed due to HW and event cut faliure
   UInt_t  GetEventcutErrorFlag();
+
+  using VQwDataElement::UpdateErrorFlag;
   UInt_t  UpdateErrorFlag();
   void UpdateErrorFlag(const VQwBPM *ev_error);
 
 
   void    SetBPMForCombo(const VQwBPM* bpm, Double_t charge_weight,  Double_t x_weight, Double_t y_weight,Double_t sumqw);
 
+  using VQwDataElement::Ratio;
   void    Ratio(QwCombinedBPM &numer, QwCombinedBPM &denom);
   void    Ratio(VQwBPM &numer, VQwBPM &denom);
   void    Scale(Double_t factor);
+
+  using MQwHistograms::operator=;
+  using VQwDataElement::operator=;
+  using VQwDataElement::operator+=;
+  using VQwDataElement::operator-=;
 
   VQwBPM& operator=  (const VQwBPM &value);
   VQwBPM& operator+= (const VQwBPM &value);
@@ -150,6 +159,7 @@ class QwCombinedBPM : public VQwBPM {
 
 //------------------------------------------------------------------------------------------------
   void    RandomizeEventData(int helicity = 0, double time = 0.0);
+  using VQwBPM::SetRandomEventParameters;
   void    SetRandomEventParameters(Double_t meanX, Double_t sigmaX, Double_t meanY, Double_t sigmaY,
                                    Double_t meanXslope, Double_t sigmaXslope, Double_t meanYslope, Double_t sigmaYslope);
   void    GetProjectedPosition(VQwBPM *device);

--- a/Parity/include/QwCombinedPMT.h
+++ b/Parity/include/QwCombinedPMT.h
@@ -71,6 +71,7 @@ class QwCombinedPMT : public VQwDataElement {
   Bool_t ApplySingleEventCuts();//Check for good events by stting limits on the devices readings
   void PrintErrorCounters() const;// report number of events failed due to HW and event cut faliure
   /*! \brief Inherited from VQwDataElement to set the upper and lower limits (fULimit and fLLimit), stability % and the error flag on this channel */
+  using VQwDataElement::SetSingleEventCuts;
   void SetSingleEventCuts(UInt_t errorflag, Double_t LL, Double_t UL, Double_t stability, Double_t burplevel);
 
   void SetDefaultSampleSize(Int_t sample_size);
@@ -88,15 +89,21 @@ class QwCombinedPMT : public VQwDataElement {
 
   Bool_t CheckForBurpFail(const VQwDataElement *ev_error);
 
+  using VQwDataElement::UpdateErrorFlag;
   UInt_t UpdateErrorFlag();
   void   UpdateErrorFlag(const QwCombinedPMT *ev_error);
 
   void PrintInfo() const;
   void PrintValue() const;
 
+  using MQwHistograms::operator=;
+  using VQwDataElement::operator=;
+  using VQwDataElement::operator+=;
+  using VQwDataElement::operator-=;
   QwCombinedPMT& operator=  (const QwCombinedPMT &value);
   QwCombinedPMT& operator+= (const QwCombinedPMT &value);
   QwCombinedPMT& operator-= (const QwCombinedPMT &value);
+  using VQwDataElement::Ratio;
   void Ratio(QwCombinedPMT &numer, QwCombinedPMT &denom);
   void Scale(Double_t factor);
   void Normalize(VQwDataElement* denom);

--- a/Parity/include/QwCombiner.h
+++ b/Parity/include/QwCombiner.h
@@ -34,6 +34,7 @@ class QwCombiner:public VQwDataHandler, public MQwDataHandlerCloneable<QwCombine
     /// \brief Connect to Channels (event only)
     Int_t ConnectChannels(QwSubsystemArrayParity& event);
     /// \brief Connect to Channels (asymmetry/difference only)
+    using VQwDataHandler::ConnectChannels;
     Int_t ConnectChannels(QwSubsystemArrayParity& asym,
 			  QwSubsystemArrayParity& diff);
 

--- a/Parity/include/QwCombinerSubsystem.h
+++ b/Parity/include/QwCombinerSubsystem.h
@@ -47,6 +47,7 @@ class QwCombinerSubsystem: public VQwSubsystemParity,
       boost::shared_ptr<VQwSubsystem> GetSharedPointerToStaticObject();
 
       /// \brief Update the running sums
+      using VQwDataHandler::AccumulateRunningSum;
       void AccumulateRunningSum(VQwSubsystem* input, Int_t count=0, Int_t ErrorMask=0xFFFFFFF);
       void DeaccumulateRunningSum(VQwSubsystem* value, Int_t ErrorMask=0xFFFFFFF);
       /// \brief Calculate the average for all good events
@@ -59,6 +60,7 @@ class QwCombinerSubsystem: public VQwSubsystemParity,
       }
 
       /// \brief Overloaded Operators
+      using MQwHistograms::operator=;
       VQwSubsystem& operator=  (VQwSubsystem *value);
       VQwSubsystem& operator+= (VQwSubsystem *value);
       VQwSubsystem& operator-= (VQwSubsystem *value);
@@ -67,6 +69,7 @@ class QwCombinerSubsystem: public VQwSubsystemParity,
       void Ratio(VQwSubsystem* value1, VQwSubsystem* value2);
       void Scale(Double_t value);
 
+      using VQwSubsystem::ConstructBranchAndVector;
       void ConstructBranchAndVector(TTree *tree, TString& prefix, std::vector <Double_t> &values){
         QwCombiner::ConstructBranchAndVector(tree,prefix,values);
       }
@@ -74,6 +77,7 @@ class QwCombinerSubsystem: public VQwSubsystemParity,
         QwCombiner::FillTreeVector(values);
       }
 
+      using VQwSubsystem::ConstructHistograms;
       void ConstructHistograms(TDirectory *folder, TString &prefix);
       void FillHistograms();
       void DeleteHistograms();
@@ -85,11 +89,13 @@ class QwCombinerSubsystem: public VQwSubsystemParity,
 
       //update the error flag in the subsystem level from the top level routines related to stability checks
       // This will uniquely update the errorflag at each channel based on the error flag in the corresponding channel in the ev_error subsystem
+      using VQwSubsystemParity::UpdateErrorFlag;
       void UpdateErrorFlag(const VQwSubsystem *ev_error);
 
 
       /// \brief Derived functions
       // not sure if there should be empty definition, no definition or defined 
+      using QwCombiner::LoadChannelMap;
       Int_t LoadChannelMap(TString);
       Int_t LoadInputParameters(TString);
       Int_t LoadEventCuts(TString);
@@ -109,7 +115,8 @@ class QwCombinerSubsystem: public VQwSubsystemParity,
         */
       };
       Int_t ProcessConfigurationBuffer(const ROCID_t roc_id, const BankID_t bank_id, UInt_t* buffer, UInt_t num_words);
-	Int_t ProcessEvBuffer(const ROCID_t roc_id, const BankID_t bank_id, UInt_t* buffer, UInt_t num_words);
+      using VQwSubsystem::ProcessEvBuffer;
+    	Int_t ProcessEvBuffer(const ROCID_t roc_id, const BankID_t bank_id, UInt_t* buffer, UInt_t num_words);
       void ProcessEvent(){};
 
       Bool_t ApplySingleEventCuts();

--- a/Parity/include/QwCorrelator.h
+++ b/Parity/include/QwCorrelator.h
@@ -48,6 +48,7 @@ class QwCorrelator : public VQwDataHandler, public MQwDataHandlerCloneable<QwCor
   Int_t LoadChannelMap(const std::string& mapfile);
 
   /// \brief Connect to Channels (asymmetry/difference only)
+  using VQwDataHandler::ConnectChannels;
   Int_t ConnectChannels(QwSubsystemArrayParity& asym, QwSubsystemArrayParity& diff);
 
   void ProcessData();

--- a/Parity/include/QwDetectorArray.h
+++ b/Parity/include/QwDetectorArray.h
@@ -53,6 +53,10 @@ QwDetectorArray(const QwDetectorArray& source)
 /// Virtual destructor
 ~QwDetectorArray() {};
 
+// FIXME (wdconinc) explicit assignment operator needed
+using MQwHistograms::operator=;
+using VQwDetectorArray::operator=;
+
 };
 
 #endif

--- a/Parity/include/QwEnergyCalculator.h
+++ b/Parity/include/QwEnergyCalculator.h
@@ -76,6 +76,7 @@ class QwEnergyCalculator : public VQwDataElement{
 
     Bool_t  ApplyHWChecks();//Check for harware errors in the devices
     Bool_t  ApplySingleEventCuts();//Check for good events by stting limits on the devices readings
+    using VQwDataElement::SetSingleEventCuts;
     Int_t   SetSingleEventCuts(Double_t mean, Double_t sigma);//two limts and sample size
     /*! \brief Inherited from VQwDataElement to set the upper and lower limits (fULimit and fLLimit), stability % and the error flag on this channel */
     void    SetSingleEventCuts(UInt_t errorflag,Double_t min, Double_t max, Double_t stability, Double_t burplevel);
@@ -90,15 +91,21 @@ class QwEnergyCalculator : public VQwDataElement{
     UInt_t   GetEventcutErrorFlag(){//return the error flag
       return fEnergyChange.GetEventcutErrorFlag();
     }
+    using VQwDataElement::UpdateErrorFlag;
     UInt_t   UpdateErrorFlag();
-
     void    UpdateErrorFlag(const QwEnergyCalculator *ev_error);
   
 
     void    Set(const VQwBPM* device,TString type, TString property ,Double_t tmatrix_ratio);
+    using VQwDataElement::Ratio;
     void    Ratio(QwEnergyCalculator &numer,QwEnergyCalculator &denom);
     void    Scale(Double_t factor);
 
+    using MQwHistograms::operator=;
+    using VQwDataElement::operator=;
+    using VQwDataElement::operator+=;
+    using VQwDataElement::operator-=;
+  
     virtual QwEnergyCalculator& operator=  (const QwEnergyCalculator &value);
     virtual QwEnergyCalculator& operator+= (const QwEnergyCalculator &value);
     virtual QwEnergyCalculator& operator-= (const QwEnergyCalculator &value);

--- a/Parity/include/QwExtractor.h
+++ b/Parity/include/QwExtractor.h
@@ -24,6 +24,7 @@ class QwExtractor:public VQwDataHandler, public MQwDataHandlerCloneable<QwExtrac
     virtual ~QwExtractor();
 
     Int_t LoadChannelMap(const std::string& mapfile);
+    using VQwDataHandler::ConnectChannels;
     Int_t ConnectChannels(QwSubsystemArrayParity& event);
     void ConstructTreeBranches(
         QwRootFile *treerootfile,

--- a/Parity/include/QwFakeHelicity.h
+++ b/Parity/include/QwFakeHelicity.h
@@ -26,6 +26,10 @@ class QwFakeHelicity: public QwHelicity {
 
     virtual ~QwFakeHelicity() { };
 
+    // FIXME (wdconinc) explicit assignment operator needed
+    using MQwHistograms::operator=;
+    using QwHelicity::operator=;
+  
     void    ClearEventData();
     Bool_t  IsGoodHelicity();
     void    ProcessEvent();

--- a/Parity/include/QwHaloMonitor.h
+++ b/Parity/include/QwHaloMonitor.h
@@ -69,9 +69,17 @@ class  QwHaloMonitor : public VQwDataElement{
   Int_t ProcessEvBuffer(UInt_t* buffer, UInt_t num_words_left,UInt_t index=0);
   void  ProcessEvent();
 
+  using MQwHistograms::operator=;
+  using VQwDataElement::operator=;
+  using VQwDataElement::operator+=;
+  using VQwDataElement::operator-=;
   QwHaloMonitor& operator=  (const QwHaloMonitor &value);
   QwHaloMonitor& operator+= (const QwHaloMonitor &value);
   QwHaloMonitor& operator-= (const QwHaloMonitor &value);
+
+  using VQwDataElement::Sum;
+  using VQwDataElement::Difference;
+  using VQwDataElement::Ratio;
   void Sum(QwHaloMonitor &value1, QwHaloMonitor &value2);
   void Difference(QwHaloMonitor &value1, QwHaloMonitor &value2);
   void Ratio(QwHaloMonitor &numer, QwHaloMonitor &denom);
@@ -90,6 +98,7 @@ class  QwHaloMonitor : public VQwDataElement{
 
   Bool_t CheckForBurpFail(const VQwDataElement *ev_error);
 
+  using VQwDataElement::UpdateErrorFlag;
   UInt_t UpdateErrorFlag() {return GetEventcutErrorFlag();};
   void UpdateErrorFlag(const QwHaloMonitor *ev_error){
     fHalo_Counter.UpdateErrorFlag(ev_error->fHalo_Counter);
@@ -97,6 +106,7 @@ class  QwHaloMonitor : public VQwDataElement{
 
   void PrintErrorCounters() const;// report number of events failed due to HW and event cut faliure
   Bool_t ApplyHWChecks();
+  using VQwDataElement::SetSingleEventCuts;
   void SetSingleEventCuts(UInt_t errorflag,Double_t min, Double_t max, Double_t stability, Double_t burplevel){
     QwError<<"***************************"<<QwLog::endl;
     fHalo_Counter.SetSingleEventCuts(errorflag,min,max,stability,burplevel);

--- a/Parity/include/QwHelicity.h
+++ b/Parity/include/QwHelicity.h
@@ -51,8 +51,6 @@ class QwHelicity: public VQwSubsystemParity, public MQwSubsystemCloneable<QwHeli
   /// Virtual destructor
   virtual ~QwHelicity() { }
 
-
-
   /* derived from VQwSubsystem */
   /// \brief Define options function
 
@@ -71,6 +69,7 @@ class QwHelicity: public VQwSubsystemParity, public MQwSubsystemCloneable<QwHeli
   void PrintErrorCounters() const;// report number of events failed due to HW and event cut failure, derived from VQwSubsystemParity
   UInt_t  GetEventcutErrorFlag();//return the error flag
   //update the error flag in the subsystem level from the top level routines related to stability checks. This will uniquely update the errorflag at each channel based on the error flag in the corresponding channel in the ev_error subsystem
+  using VQwSubsystemParity::UpdateErrorFlag;
   void UpdateErrorFlag(const VQwSubsystem *ev_error){
   };
 
@@ -113,6 +112,7 @@ class QwHelicity: public VQwSubsystemParity, public MQwSubsystemCloneable<QwHeli
   void SetFirstBits(UInt_t nbits, UInt_t firstbits);
   void SetEventPatternPhase(Int_t event, Int_t pattern, Int_t phase);
 
+  using MQwHistograms::operator=;
   VQwSubsystem&  operator=  (VQwSubsystem *value);
   VQwSubsystem&  operator+=  (VQwSubsystem *value);
 

--- a/Parity/include/QwIntegratedRaster.h
+++ b/Parity/include/QwIntegratedRaster.h
@@ -72,6 +72,8 @@ class QwIntegratedRaster : public VQwSubsystemParity, public MQwSubsystemCloneab
   /// Virtual destructor
   virtual ~QwIntegratedRaster() { };
 
+  // FIXME (wdconinc) explicit assignment operator needed
+  using MQwHistograms::operator=;
 
   /* derived from VQwSubsystem */
 
@@ -93,6 +95,7 @@ class QwIntegratedRaster : public VQwSubsystemParity, public MQwSubsystemCloneab
   };
 
   //update the error flag in the subsystem level from the top level routines related to stability checks. This will uniquely update the errorflag at each channel based on the error flag in the corresponding channel in the ev_error subsystem
+  using VQwSubsystemParity::UpdateErrorFlag;
   void UpdateErrorFlag(const VQwSubsystem *ev_error){
   };
 
@@ -103,6 +106,7 @@ class QwIntegratedRaster : public VQwSubsystemParity, public MQwSubsystemCloneab
   void CalculateRunningAverage();
 
   Int_t ProcessConfigurationBuffer(const ROCID_t roc_id, const BankID_t bank_id, UInt_t* buffer, UInt_t num_words);
+  using VQwSubsystem::ProcessEvBuffer;
   Int_t ProcessEvBuffer(const ROCID_t roc_id, const BankID_t bank_id, UInt_t* buffer, UInt_t num_words);
   void  PrintDetectorID() const;
 
@@ -130,6 +134,7 @@ class QwIntegratedRaster : public VQwSubsystemParity, public MQwSubsystemCloneab
   void  ConstructHistograms(TDirectory *folder, TString &prefix);
   void  FillHistograms();
 
+  using VQwSubsystem::ConstructBranchAndVector;
   void  ConstructBranchAndVector(TTree *tree, TString &prefix, std::vector<Double_t> &values);
   void  ConstructBranch(TTree *tree, TString &prefix);
   void  ConstructBranch(TTree *tree, TString &prefix, QwParameterFile& trim_file);

--- a/Parity/include/QwIntegratedRasterChannel.h
+++ b/Parity/include/QwIntegratedRasterChannel.h
@@ -69,6 +69,7 @@ class QwIntegratedRasterChannel : public VQwDataElement{
   UInt_t GetEventcutErrorFlag(){//return the error flag
     return fTriumf_ADC.GetEventcutErrorFlag();
   }
+  using VQwDataElement::UpdateErrorFlag;
   UInt_t UpdateErrorFlag() {return GetEventcutErrorFlag();};
   void UpdateErrorFlag(const QwIntegratedRasterChannel *ev_error){
     return fTriumf_ADC.UpdateErrorFlag(ev_error->fTriumf_ADC);
@@ -87,10 +88,17 @@ class QwIntegratedRasterChannel : public VQwDataElement{
   void PrintValue() const;
   void PrintInfo() const;
 
-  
+  using MQwHistograms::operator=;
+  using VQwDataElement::operator=;
+  using VQwDataElement::operator+=;
+  using VQwDataElement::operator-=;  
   QwIntegratedRasterChannel& operator=  (const QwIntegratedRasterChannel &value);
   QwIntegratedRasterChannel& operator+= (const QwIntegratedRasterChannel &value);
   QwIntegratedRasterChannel& operator-= (const QwIntegratedRasterChannel &value);
+
+  using VQwDataElement::Sum;
+  using VQwDataElement::Difference;
+  using VQwDataElement::Ratio;
   void Sum(QwIntegratedRasterChannel &value1, QwIntegratedRasterChannel &value2);
   void Difference(QwIntegratedRasterChannel &value1, QwIntegratedRasterChannel &value2);
   void Ratio(QwIntegratedRasterChannel &numer, QwIntegratedRasterChannel &denom);

--- a/Parity/include/QwIntegrationPMT.h
+++ b/Parity/include/QwIntegrationPMT.h
@@ -97,6 +97,7 @@ void RandomizeMollerEvent(int helicity, const QwBeamCharge& charge, const QwBeam
     fTriumf_ADC.IncrementErrorCounters();
   }
   void PrintErrorCounters() const;// report number of events failed due to HW and event cut faliure
+  using VQwDataElement::SetSingleEventCuts;
   Int_t SetSingleEventCuts(Double_t, Double_t);//set two limts
   /*! \brief Inherited from VQwDataElement to set the upper and lower limits (fULimit and fLLimit), stability % and the error flag on this channel */
   void SetSingleEventCuts(UInt_t errorflag, Double_t LL, Double_t UL, Double_t stability, Double_t burplevel);
@@ -108,6 +109,7 @@ void RandomizeMollerEvent(int helicity, const QwBeamCharge& charge, const QwBeam
 
   Bool_t CheckForBurpFail(const VQwDataElement *ev_error);
   
+  using VQwDataElement::UpdateErrorFlag;
   UInt_t UpdateErrorFlag() {return GetEventcutErrorFlag();};
   void UpdateErrorFlag(const QwIntegrationPMT *ev_error);
 
@@ -130,11 +132,15 @@ void RandomizeMollerEvent(int helicity, const QwBeamCharge& charge, const QwBeam
 /*   Double_t GetRawBlockValue(size_t blocknum) */
 /*            {return fTriumf_ADC.GetRawBlockValue(blocknum);}; */
 
-
-
+  using MQwHistograms::operator=;
+  using VQwDataElement::operator=;
+  using VQwDataElement::operator+=;
+  using VQwDataElement::operator-=;
   QwIntegrationPMT& operator=  (const QwIntegrationPMT &value);
   QwIntegrationPMT& operator+= (const QwIntegrationPMT &value);
   QwIntegrationPMT& operator-= (const QwIntegrationPMT &value);
+
+  using VQwDataElement::Ratio;
   void Ratio(QwIntegrationPMT &numer, QwIntegrationPMT &denom);
   void Scale(Double_t factor);
   void Normalize(VQwDataElement* denom);

--- a/Parity/include/QwLinearDiodeArray.h
+++ b/Parity/include/QwLinearDiodeArray.h
@@ -72,6 +72,7 @@ class QwLinearDiodeArray : public VQwBPM {
   void    PrintValue() const;
   void    PrintInfo() const;
 
+  using VQwBPM::GetPosition;
   const VQwHardwareChannel* GetPosition(EBeamPositionMonitorAxis axis) const {
     if (axis<0 || axis>2){
       TString loc="QwLinearDiodeArray::GetPosition for "
@@ -88,6 +89,7 @@ class QwLinearDiodeArray : public VQwBPM {
 
   Bool_t  ApplyHWChecks();//Check for harware errors in the devices
   Bool_t  ApplySingleEventCuts();//Check for good events by stting limits on the devices readings
+  using VQwDataElement::SetSingleEventCuts;
   //void    SetSingleEventCuts(TString ch_name, Double_t minX, Double_t maxX);
   /*! \brief Inherited from VQwDataElement to set the upper and lower limits (fULimit and fLLimit), stability % and the error flag on this channel */
   void    SetSingleEventCuts(TString ch_name, UInt_t errorflag,Double_t minX, Double_t maxX, Double_t stability, Double_t burplevel);
@@ -95,12 +97,14 @@ class QwLinearDiodeArray : public VQwBPM {
   void IncrementErrorCounters();
   void PrintErrorCounters() const;// report number of events failed due to HW and event cut faliure
   UInt_t GetEventcutErrorFlag();
+  using VQwDataElement::UpdateErrorFlag;
   UInt_t UpdateErrorFlag();
   void UpdateErrorFlag(const VQwBPM *ev_error);
 
   Bool_t  CheckForBurpFail(const VQwDataElement *ev_error);
 
   void    SetDefaultSampleSize(Int_t sample_size);
+  using VQwBPM::SetRandomEventParameters;
   void    SetRandomEventParameters(Double_t meanX, Double_t sigmaX, Double_t meanY, Double_t sigmaY);
   void    RandomizeEventData(int helicity = 0, double time = 0.0);
   void    SetEventData(Double_t* block, UInt_t sequencenumber);
@@ -108,9 +112,15 @@ class QwLinearDiodeArray : public VQwBPM {
   void    SetSubElementPedestal(Int_t j, Double_t value);
   void    SetSubElementCalibrationFactor(Int_t j, Double_t value);
 
+  using VQwDataElement::Ratio;
+  using VQwBPM::Ratio;
   void    Ratio(QwLinearDiodeArray &numer, QwLinearDiodeArray &denom);
   void    Scale(Double_t factor);
 
+  using MQwHistograms::operator=;
+  using VQwDataElement::operator=;
+  using VQwDataElement::operator+=;
+  using VQwDataElement::operator-=;
 
   VQwBPM& operator=  (const VQwBPM &value);
   VQwBPM& operator+= (const VQwBPM &value);

--- a/Parity/include/QwMollerDetector.h
+++ b/Parity/include/QwMollerDetector.h
@@ -81,6 +81,9 @@ class QwMollerDetector:
     /// Virtual destructor
     virtual ~QwMollerDetector() { };
 
+    // FIXME (wdconinc) explicit assignment operator needed
+    using MQwHistograms::operator=;
+  
     /* derived from VQwSubsystem */
     void ProcessOptions(QwOptions &options); //Handle command line options
     Int_t LoadChannelMap(TString mapfile);
@@ -119,6 +122,7 @@ class QwMollerDetector:
     };
 
     //update the error flag in the subsystem level from the top level routines related to stability checks. This will uniquely update the errorflag at each channel based on the error flag in the corresponding channel in the ev_error subsystem
+    using VQwSubsystemParity::UpdateErrorFlag;
     void UpdateErrorFlag(const VQwSubsystem *ev_error){
     };
 

--- a/Parity/include/QwQPD.h
+++ b/Parity/include/QwQPD.h
@@ -74,6 +74,7 @@ class QwQPD : public VQwBPM {
 			UInt_t word_position_in_buffer,UInt_t indexnumber);
   void    ProcessEvent();
 
+  using VQwBPM::GetPosition;
   const VQwHardwareChannel* GetPosition(EBeamPositionMonitorAxis axis) const {
     if (axis<0 || axis>2){
       TString loc="QwQPD::GetPosition for "
@@ -89,6 +90,7 @@ class QwQPD : public VQwBPM {
 
   Bool_t  ApplyHWChecks();//Check for harware errors in the devices
   Bool_t  ApplySingleEventCuts();//Check for good events by stting limits on the devices readings
+  using VQwDataElement::SetSingleEventCuts;
   //void    SetSingleEventCuts(TString ch_name, Double_t minX, Double_t maxX);
   /*! \brief Inherited from VQwDataElement to set the upper and lower limits (fULimit and fLLimit), stability % and the error flag on this channel */
   void    SetSingleEventCuts(TString ch_name, UInt_t errorflag,Double_t minX, Double_t maxX, Double_t stability, Double_t burplevel);
@@ -96,12 +98,14 @@ class QwQPD : public VQwBPM {
   void IncrementErrorCounters();
   void PrintErrorCounters() const;// report number of events failed due to HW and event cut faliure
   UInt_t  GetEventcutErrorFlag();
+  using VQwDataElement::UpdateErrorFlag;
   UInt_t  UpdateErrorFlag();
   void UpdateErrorFlag(const VQwBPM *ev_error);
 
   Bool_t  CheckForBurpFail(const VQwDataElement *ev_error);
 
   void    SetDefaultSampleSize(Int_t sample_size);
+  using VQwBPM::SetRandomEventParameters;
   void    SetRandomEventParameters(Double_t meanX, Double_t sigmaX, Double_t meanY, Double_t sigmaY);
   void    RandomizeEventData(int helicity = 0, double time = 0.0);
   void    SetEventData(Double_t* block, UInt_t sequencenumber);
@@ -109,9 +113,15 @@ class QwQPD : public VQwBPM {
   void    SetSubElementPedestal(Int_t j, Double_t value);
   void    SetSubElementCalibrationFactor(Int_t j, Double_t value);
 
+  using VQwDataElement::Ratio;
+  using VQwBPM::Ratio;
   void    Ratio(QwQPD &numer, QwQPD &denom);
   void    Scale(Double_t factor);
 
+  using MQwHistograms::operator=;
+  using VQwDataElement::operator=;
+  using VQwDataElement::operator+=;
+  using VQwDataElement::operator-=;
   VQwBPM& operator=  (const VQwBPM &value);
   VQwBPM& operator+= (const VQwBPM &value);
   VQwBPM& operator-= (const VQwBPM &value);

--- a/Parity/include/QwScaler.h
+++ b/Parity/include/QwScaler.h
@@ -42,6 +42,9 @@ class QwScaler: public VQwSubsystemParity, public MQwSubsystemCloneable<QwScaler
     /// Destructor
     virtual ~QwScaler();
 
+    // FIXME (wdconinc) explicit assignment operator needed
+    using MQwHistograms::operator=;
+  
     // Handle command line options
     static void DefineOptions(QwOptions &options);
     void ProcessOptions(QwOptions &options);
@@ -52,6 +55,7 @@ class QwScaler: public VQwSubsystemParity, public MQwSubsystemCloneable<QwScaler
     void  ClearEventData();
 
     Int_t ProcessConfigurationBuffer(const ROCID_t roc_id, const BankID_t bank_id, UInt_t* buffer, UInt_t num_words);
+    using VQwSubsystem::ProcessEvBuffer;
     Int_t ProcessEvBuffer(const ROCID_t roc_id, const BankID_t bank_id, UInt_t *buffer, UInt_t num_words);
     void  ProcessEvent();
 
@@ -92,6 +96,7 @@ class QwScaler: public VQwSubsystemParity, public MQwSubsystemCloneable<QwScaler
     void PrintErrorCounters() const;
     UInt_t GetEventcutErrorFlag();
     //update the error flag in the subsystem level from the top level routines related to stability checks. This will uniquely update the errorflag at each channel based on the error flag in the corresponding channel in the ev_error subsystem
+    using VQwSubsystemParity::UpdateErrorFlag;
     void UpdateErrorFlag(const VQwSubsystem *ev_error){
     };
     

--- a/Parity/include/VQwBCM.h
+++ b/Parity/include/VQwBCM.h
@@ -54,7 +54,9 @@ public:
   virtual void  ConstructHistograms(TDirectory *folder, TString &prefix) = 0;
   virtual void  FillHistograms() = 0;
   /*! \brief Inherited from VQwDataElement to set the upper and lower limits (fULimit and fLLimit), stability % and the error flag on this channel */
+  using VQwDataElement::SetSingleEventCuts;
   virtual void SetSingleEventCuts(UInt_t errorflag,Double_t min, Double_t max, Double_t stability, Double_t burplevel) = 0;
+  using VQwDataElement::Ratio;
   virtual void Ratio( const VQwBCM &numer, const VQwBCM &denom)
     { std::cerr << "Ratio not defined! (VQwBCM)" << std::endl; }
   virtual void ClearEventData() = 0;
@@ -72,6 +74,7 @@ public:
 
   virtual void SetDefaultSampleSize(Int_t sample_size) = 0;
   virtual void SetEventCutMode(Int_t bcuts) = 0;
+  using VQwDataElement::UpdateErrorFlag;
   virtual UInt_t UpdateErrorFlag(){return this->GetEventcutErrorFlag();};
   virtual void UpdateErrorFlag(const VQwBCM *ev_error) = 0;
   virtual void SetPedestal(Double_t ped) = 0;
@@ -133,6 +136,10 @@ public:
   virtual void  AddRandomEventDriftParameters(Double_t amplitude, Double_t phase, Double_t frequency) =0;
 
   // Operators
+  using MQwHistograms::operator=;
+  using VQwDataElement::operator=;
+  using VQwDataElement::operator+=;
+  using VQwDataElement::operator-=;
   virtual VQwBCM& operator=  (const VQwBCM &value) =0;
   virtual VQwBCM& operator+= (const VQwBCM &value) =0;
   virtual VQwBCM& operator-= (const VQwBCM &value) =0;

--- a/Parity/include/VQwBPM.h
+++ b/Parity/include/VQwBPM.h
@@ -89,8 +89,10 @@ class VQwBPM : public VQwDataElement {
   void   SetRotation(Double_t);
   void   SetRotationOff();
 
+  using VQwDataElement::SetSingleEventCuts;
   void    SetSingleEventCuts(TString, Double_t, Double_t);
   void    SetSingleEventCuts(TString, UInt_t, Double_t, Double_t, Double_t, Double_t);
+  using VQwDataElement::UpdateErrorFlag;
   virtual UInt_t UpdateErrorFlag() = 0;
   virtual void UpdateErrorFlag(const VQwBPM *ev_error) = 0;
 
@@ -98,6 +100,11 @@ class VQwBPM : public VQwDataElement {
     std::cerr << "Scale for VQwBPM not implemented!\n";
   }
   void SetGains(TString pos, Double_t value);
+
+  using MQwHistograms::operator=;
+  using VQwDataElement::operator=;
+  using VQwDataElement::operator+=;
+  using VQwDataElement::operator-=;
 
   // Operators subclasses MUST support!
   virtual VQwBPM& operator=  (const VQwBPM &value) =0;
@@ -180,6 +187,7 @@ public:
   virtual std::vector<QwErrDBInterface> GetErrDBEntry() = 0;
 #endif // __USE_DATABASE__
 
+  using VQwDataElement::Ratio;
   virtual void Ratio(VQwBPM &numer, VQwBPM &denom) {
     std::cerr << "Ratio() is not defined for BPM named="<<GetElementName()<<"\n";
   }

--- a/Parity/include/VQwClock.h
+++ b/Parity/include/VQwClock.h
@@ -49,7 +49,9 @@ public:
   virtual void  ConstructHistograms(TDirectory *folder, TString &prefix) = 0;
   virtual void  FillHistograms() = 0;
   /*! \brief Inherited from VQwDataElement to set the upper and lower limits (fULimit and fLLimit), stability % and the error flag on this channel */
+  using VQwDataElement::SetSingleEventCuts;
   virtual void SetSingleEventCuts(UInt_t errorflag,Double_t min, Double_t max, Double_t stability, Double_t burplevel) = 0;
+  using VQwDataElement::Ratio;
   virtual void Ratio( const VQwClock &numer, const VQwClock &denom)
     { std::cerr << "Ratio not defined! (VQwClock)" << std::endl; }
   virtual void ClearEventData() = 0;
@@ -79,6 +81,10 @@ public:
 #endif // __USE_DATABASE__
 
   // Operators
+  using VQwDataElement::operator=;
+  using VQwDataElement::operator+=;
+  using VQwDataElement::operator-=;
+
   virtual VQwClock& operator=  (const VQwClock &value) =0;
   virtual VQwClock& operator+= (const VQwClock &value) =0;
   virtual VQwClock& operator-= (const VQwClock &value) =0;

--- a/Parity/include/VQwDetectorArray.h
+++ b/Parity/include/VQwDetectorArray.h
@@ -112,10 +112,12 @@ class VQwDetectorArray: virtual public VQwSubsystemParity {
     UInt_t GetEventcutErrorFlag();//return the error flag
 
     //update the error flag in the subsystem level from the top level routines related to stability checks. This will uniquely update the errorflag at each channel based on the error flag in the corresponding channel in the ev_error subsystem
+    using VQwSubsystemParity::UpdateErrorFlag;
     void UpdateErrorFlag(const VQwSubsystem *ev_error);
 
 
     Int_t ProcessConfigurationBuffer(const ROCID_t roc_id, const BankID_t bank_id, UInt_t* buffer, UInt_t num_words);
+    using VQwSubsystem::ProcessEvBuffer;
     Int_t ProcessEvBuffer(const ROCID_t roc_id, const BankID_t bank_id, UInt_t* buffer, UInt_t num_words);
 
     void  ClearEventData();
@@ -157,7 +159,7 @@ class VQwDetectorArray: virtual public VQwSubsystemParity {
 
     Bool_t Compare(VQwSubsystem* source);
 
-
+    using MQwHistograms::operator=;
     VQwSubsystem&  operator=  ( VQwSubsystem *value);
     VQwSubsystem&  operator+= ( VQwSubsystem *value);
     VQwSubsystem&  operator-= ( VQwSubsystem *value);

--- a/Parity/include/VQwSubsystemParity.h
+++ b/Parity/include/VQwSubsystemParity.h
@@ -58,8 +58,9 @@ class VQwSubsystemParity: virtual public VQwSubsystem {
     /// \brief Fill the database
     virtual void FillDB(QwParityDB *db, TString type) { };
     virtual void FillErrDB(QwParityDB *db, TString type) { };
-
+  
     // VQwSubsystem routine is overridden. Call it at the beginning by VQwSubsystem::operator=(value)
+    using MQwHistograms::operator=;
     virtual VQwSubsystem& operator=  (VQwSubsystem *value) = 0;
     virtual VQwSubsystem& operator+= (VQwSubsystem *value) = 0;
     virtual VQwSubsystem& operator-= (VQwSubsystem *value) = 0;


### PR DESCRIPTION
This PR reduces the amount of compiler warnings due to `-Woverload-virtual`, from O(5000) lines of compiler warnings to O(500) lines of compiler warnings.

## What is the reason for the `-Woverload-virtual` warnings?
The recurring underlying issue here is caused by inheritance structures like:
```
class MQwHistograms {
public:
    virtual MQwHistograms& operator=(const MQwHistograms& value);  // Base version
};

class VQwDataElement : public MQwHistograms {
public:
    virtual VQwDataElement& operator=(const VQwDataElement& value);  // Derived version
};
```
The base class `operator=` is not inherited (as the `virtual` would seem to indicate) but an `operator=` with a different signature is introduced in the derived class. This hides **all** base class methods with the same name, and that's the overloaded virtual method hiding that the warning complains about.

## How do we remove the warnings?

The code compiles with the hidden virtual methods in the base class, so it must be that the code throughout is able to use the overloading methods in the derived classes. These will necessarily be more specific, so even if we add the base class methods as candidates in the name resolution they should not get picked over the specific cases. I.e. if `a = b` is called with `VQwDataElement a` and `VQwDataElement b`, then the more specific version in the derived class will be used. We would have to explicitly direct the compiler to use the newly visible `MQwHistograms::operator=`.

We can make the hidden base class methods visible by using `using`:
```
class VQwDataElement : public MQwHistograms {
public:
    using MQwHistograms::operator=;
    virtual VQwDataElement& operator=(const VQwDataElement& value);  // Derived version
};
```
Applying this approach throughout the code base is therefore a reasonably safe way to hide the warnings.

## How did we end up here?

There are likely a couple of reasons for this situation, given the age of this code base and the lack of warnings with older compiler versions:
- There is natural evolution of the code base where the derived method signatures were changed to add functionality. That caused them to become overloads instead of implementations. The use of explicit `override` keywords is intended to address this. A newly appearing overload warning would also have alerted that this was happening.
- There are also cases where we probably do not need to implement the base class methods as virtual. The example above is one of them. It is unlikely that we need to make `operator=` virtual since we will necessarily implement (even by default) assignment operators with the derived types. However, simply changing the base class methods away from virtual is more likely to lead to changes in behavior.

So, this PR address the warnings, but the changes here need to be re-evaluated and it makes sense that (nearly?) all the `using` statements get removed by considering the specific context.

## What's include here?

- Introduced using declarations for assignment operators and other relevant methods in multiple classes to enhance code clarity and maintainability.
- Updated error flag handling methods to ensure consistency in error reporting across subsystems.
- Ensured that the ProcessEvBuffer and ProcessConfigurationBuffer methods are properly inherited where applicable.
- Added comments to highlight areas needing explicit assignment operators.
- Improved overall structure and readability of the codebase by organizing method declarations.