### PR TITLE
Avoid possible undefined behavior in increment operation in for loop

### DIFF
--- a/Parity/src/QwEventRing.cc
+++ b/Parity/src/QwEventRing.cc
@@ -196,7 +196,7 @@ void QwEventRing::CheckBurpCut(Int_t thisevent)
   if (bRING_READY || thisevent>fBurpExtent){
     if (fBurpAvg.CheckForBurpFail(fEvent_Ring[thisevent])){
       Int_t precut_start = (thisevent+fRING_SIZE-fBurpPrecut)%fRING_SIZE;
-      for(Int_t i=precut_start;i!=(thisevent+1)%fRING_SIZE;i=(++i)%fRING_SIZE){
+      for(Int_t i=precut_start;i!=(thisevent+1)%fRING_SIZE;i=(i+1)%fRING_SIZE){
 	      fEvent_Ring[i].UpdateErrorFlag(fBurpAvg);
 	      fEvent_Ring[i].UpdateErrorFlag();
       }


### PR DESCRIPTION
Performing a pre-increment and assignment operation in the same line may result in undefined behavior and is warned about.
```
  /home/runner/work/japan-MOLLER/japan-MOLLER/Parity/src/QwEventRing.cc: In member function 'void QwEventRing::CheckBurpCut(Int_t)':
  /home/runner/work/japan-MOLLER/japan-MOLLER/Parity/src/QwEventRing.cc:199:61: warning: operation on 'i' may be undefined [-Wsequence-point]
    199 |       for(Int_t i=precut_start;i!=(thisevent+1)%fRING_SIZE;i=(++i)%fRING_SIZE){
        |                                                            ~^~~~~~~~~~~~~~~~~
  /home/runner/work/japan-MOLLER/japan-MOLLER/Parity/src/QwEventRing.cc:199:61: warning: operation on 'i' may be undefined [-Wsequence-point]
```

This PR modifies the update expression to be valid and in line with ring buffer indexing.