### PR TITLE
Simplify RangeCheck by removing impossible lower bound check

### DIFF
--- a/Analysis/include/VQwHardwareChannel.h
+++ b/Analysis/include/VQwHardwareChannel.h
@@ -236,7 +236,7 @@ public:
    *         used in accesses to subelements similar to
    *         std::vector::at(). */
   void RangeCheck(size_t element) const {
-    if (element<0 || element >= fNumberOfSubElements){
+    if (element >= fNumberOfSubElements){
       TString loc="VQwDataElement::RangeCheck for "
 	+this->GetElementName()+" failed for subelement "+Form("%zu",element);
       throw std::out_of_range(loc.Data());


### PR DESCRIPTION
`RangeCheck(element)` used unsigned int element, so element < 0 is never possible.