### PR TITLE
Enhance data handling using std::valarray in MQwMockable and QwMollerADC_Channel classes

### DIFF
--- a/Analysis/include/MQwMockable.h
+++ b/Analysis/include/MQwMockable.h
@@ -8,6 +8,9 @@
 #ifndef __MQWMOCKABLE__
 #define __MQWMOCKABLE__
 
+// System headers
+#include <valarray>
+
 // Boost math library for random number generation
 #include "boost/random.hpp"
 
@@ -62,6 +65,9 @@ public:
   /// external Random Variable.
   Double_t GetRandomValue();
 
+  /// Return a valarray of random values of the specified length
+  std::valarray<Double_t> GetRandomValue(size_t length);
+
   /// Internally generate random event data
   virtual void  RandomizeEventData(int helicity = 0, double time = 0.0) = 0;
 
@@ -80,6 +86,11 @@ public:
   void  SetExternalRandomVariable(Double_t random_variable) {
     fUseExternalRandomVariable = true;
     fExternalRandomVariable = random_variable;
+  };
+  /// Set the externally provided random variable array
+  void  SetExternalRandomVariable(const std::valarray<Double_t>& random_variable_array) {
+    fUseExternalRandomVariable = true;
+    fExternalRandomVariableArray = random_variable_array;
   };
 
   // Default the mock data to be calculated with a zero-mean.
@@ -100,6 +111,8 @@ public:
   bool fUseExternalRandomVariable;
   /// Externally provided normal random variable
   double  fExternalRandomVariable;
+  /// Externally provided normal random variable array
+  std::valarray<Double_t> fExternalRandomVariableArray;
 
   bool fCalcMockDataAsDiff;
 

--- a/Analysis/include/QwMollerADC_Channel.h
+++ b/Analysis/include/QwMollerADC_Channel.h
@@ -9,6 +9,7 @@
 #define __QwMollerADC_CHANNEL__
 
 // System headers
+#include <valarray>
 #include <vector>
 
 // ROOT headers
@@ -308,17 +309,17 @@ private:
 
   /*! \name Event data members---Raw values */
   // @{
-  Int_t fBlock_raw[4];      ///< Array of the sub-block data as read from the module
+  std::valarray<Int_t> fBlock_raw;      ///< Array of the sub-block data as read from the module
   Int_t fHardwareBlockSum_raw; ///< Module-based sum of the four sub-blocks as read from the module
   Int_t fSoftwareBlockSum_raw; ///< Sum of the data in the four sub-blocks raw
-  Long64_t fBlockSumSq_raw[5]; 
-  Int_t fBlock_min[5];
-  Int_t fBlock_max[5];
-  Short_t fBlock_numSamples[5];
+  std::valarray<Long64_t> fBlockSumSq_raw;
+  std::valarray<Int_t> fBlock_min;
+  std::valarray<Int_t> fBlock_max;
+  std::valarray<Short_t> fBlock_numSamples;
   /*! \name Event data members---Potentially calibrated values*/
   // @{
   // The following values potentially have pedestal removed  and calibration applied
-  Double_t fBlock[4];          ///< Array of the sub-block data
+  std::valarray<Double_t> fBlock;          ///< Array of the sub-block data
   Double_t fHardwareBlockSum;  ///< Module-based sum of the four sub-blocks
   // @}
 
@@ -326,8 +327,8 @@ private:
   /// \name Calculation of the statistical moments
   // @{
   // Moments of the separate blocks
-  Double_t fBlockM2[4];        ///< Second moment of the sub-block
-  Double_t fBlockError[4];     ///< Uncertainty on the sub-block
+  std::valarray<Double_t> fBlockM2;        ///< Second moment of the sub-block
+  std::valarray<Double_t> fBlockError;     ///< Uncertainty on the sub-block
   // Moments of the hardware sum
   Double_t fHardwareBlockSumM2;    ///< Second moment of the hardware sum
   Double_t fHardwareBlockSumError; ///< Uncertainty on the hardware sum

--- a/Analysis/src/MQwMockable.cc
+++ b/Analysis/src/MQwMockable.cc
@@ -96,3 +96,38 @@ Double_t MQwMockable::GetRandomValue(){
   return random_variable;
 }
 
+std::valarray<Double_t> MQwMockable::GetRandomValue(size_t length){
+  std::valarray<Double_t> random_values(length);
+  if (fUseExternalRandomVariable) {
+    // Check if we have an external random variable array set
+    if (fExternalRandomVariableArray.size() > 0) {
+      // Use external random variable array
+      if (fExternalRandomVariableArray.size() >= length) {
+        // Array has enough elements, use a slice of the specified length
+        random_values = fExternalRandomVariableArray[std::slice(0, length, 1)];
+      } else {
+        // Array is smaller than requested length, copy what we have and repeat the last value
+        for (size_t i = 0; i < length; ++i) {
+          if (i < fExternalRandomVariableArray.size()) {
+            random_values[i] = fExternalRandomVariableArray[i];
+          } else {
+            random_values[i] = fExternalRandomVariableArray[fExternalRandomVariableArray.size() - 1];
+          }
+        }
+      }
+    } else {
+      // Fall back to generating independent random values for each element
+      // instead of using the same scalar value for all elements
+      for (size_t i = 0; i < length; ++i) {
+        random_values[i] = fNormalRandomVariable();
+      }
+    }
+  } else {
+    // Generate independent random values for each element
+    for (size_t i = 0; i < length; ++i) {
+      random_values[i] = fNormalRandomVariable();
+    }
+  }
+  return random_values;
+}
+

--- a/Analysis/src/QwMollerADC_Channel.cc
+++ b/Analysis/src/QwMollerADC_Channel.cc
@@ -2,6 +2,7 @@
  
 // System headers
 #include <stdexcept>
+#include <algorithm>
 
 // Qweak headers
 #include "QwLog.h"
@@ -167,6 +168,16 @@ void QwMollerADC_Channel::InitializeChannel(TString name, TString datatosave)
 
   fBlocksPerEvent      = 4;
 
+  // Initialize valarrays with proper sizes
+  fBlock_raw.resize(fBlocksPerEvent);
+  fBlock.resize(fBlocksPerEvent);
+  fBlockM2.resize(fBlocksPerEvent);
+  fBlockError.resize(fBlocksPerEvent);
+  fBlockSumSq_raw.resize(fBlocksPerEvent + 1);  // blocks + 1 sum
+  fBlock_min.resize(fBlocksPerEvent + 1);
+  fBlock_max.resize(fBlocksPerEvent + 1);
+  fBlock_numSamples.resize(fBlocksPerEvent + 1);
+
   fTreeArrayIndex      = 0;
   fTreeArrayNumEntries = 0;
 
@@ -241,15 +252,15 @@ void QwMollerADC_Channel::LoadChannelParameters(QwParameterFile &paramfile){
 
 void QwMollerADC_Channel::ClearEventData()
 {
-  for (Int_t i = 0; i < fBlocksPerEvent; i++) {
-    fBlock_raw[i] = 0;
-    fBlockSumSq_raw[i] = 0;
-    fBlock_min[i] = 0;
-    fBlock_max[i] = 0;
-    fBlock[i] = 0.0;
-    fBlockM2[i] = 0.0;
-    fBlockError[i] = 0.0;
-  }
+  // Clear all valarrays in one operation
+  fBlock_raw = 0;
+  fBlock = 0.0;
+  fBlockM2 = 0.0;
+  fBlockError = 0.0;
+  fBlockSumSq_raw = 0;
+  fBlock_min = 0;
+  fBlock_max = 0;
+  
   fHardwareBlockSum_raw = 0;
   fSoftwareBlockSum_raw = 0;
   fHardwareBlockSum   = 0.0;
@@ -280,25 +291,29 @@ void QwMollerADC_Channel::RandomizeEventData(int helicity, double time)
   // Calculate signal
   fHardwareBlockSum = 0.0;
   fHardwareBlockSumM2 = 0.0; // second moment is zero for single events
-  fBlock_max[4] = kMinInt;
-  fBlock_min[4] = kMaxInt;
+  fBlock_max[fBlocksPerEvent] = kMinInt;
+  fBlock_min[fBlocksPerEvent] = kMaxInt;
 
-  for (Int_t i = 0; i < fBlocksPerEvent; i++) {
-    double tmpvar = GetRandomValue();
-
-    fBlock[i] = fMockGaussianMean + drift;
-
-    if (fCalcMockDataAsDiff) {
-      fBlock[i] += helicity*fMockAsymmetry;
-    } else {
-      fBlock[i] *= 1.0 + helicity*fMockAsymmetry;
-    }
-    fBlock[i] += fMockGaussianSigma*tmpvar*sqrt(fBlocksPerEvent);
-    fBlockM2[i] = 0.0; // second moment is zero for single events
-    fHardwareBlockSum += fBlock[i];
-
+  // Generate all random values at once using valarray
+  std::valarray<Double_t> randomValues = GetRandomValue(fBlocksPerEvent);
+  
+  // Use valarray operations to set all blocks at once
+  fBlock = fMockGaussianMean + drift; // Set all elements to base value
+  
+  if (fCalcMockDataAsDiff) {
+    fBlock += helicity*fMockAsymmetry; // Add asymmetry to all elements
+  } else {
+    fBlock *= 1.0 + helicity*fMockAsymmetry; // Scale all elements by asymmetry
   }
-  fHardwareBlockSum /= fBlocksPerEvent;
+  
+  // Add random noise to all elements
+  fBlock += fMockGaussianSigma * randomValues * sqrt(fBlocksPerEvent);
+  
+  // Clear second moments for all elements (single events)
+  fBlockM2 = 0.0;
+  
+  // Calculate hardware sum using valarray sum() function
+  fHardwareBlockSum = fBlock.sum() / fBlocksPerEvent;
   fSequenceNumber = 0;
   fNumberOfSamples = fNumberOfSamples_map;
   //  SetEventData(block);
@@ -310,15 +325,18 @@ void QwMollerADC_Channel::SmearByResolution(double resolution){
 
   fHardwareBlockSum   = 0.0;
   fHardwareBlockSumM2 = 0.0; // second moment is zero for single events
-  for (Int_t i = 0; i < fBlocksPerEvent; i++) {
-
-    fBlock[i] += resolution*sqrt(fBlocksPerEvent) * GetRandomValue();
- 
-    fBlockM2[i] = 0.0; // second moment is zero for single events
-    fHardwareBlockSum += fBlock[i];
-  }
-  // std::cout << std::endl;
-  fHardwareBlockSum /= fBlocksPerEvent;
+  
+  // Generate all random values at once using valarray
+  std::valarray<Double_t> randomValues = GetRandomValue(fBlocksPerEvent);
+  
+  // Use valarray operations to add resolution smearing to all elements
+  fBlock += resolution*sqrt(fBlocksPerEvent) * randomValues;
+  
+  // Clear second moments for all elements (single events)
+  fBlockM2 = 0.0;
+  
+  // Calculate hardware sum using valarray sum() function
+  fHardwareBlockSum = fBlock.sum() / fBlocksPerEvent;
 
   fNumberOfSamples = fNumberOfSamples_map;
   // SetRawEventData();
@@ -378,9 +396,9 @@ void QwMollerADC_Channel::SetRawEventData(){
     fBlock_min[i] = (block - 3.0 * sigma) * double_t(fNumberOfSamples_map) / (fBlocksPerEvent * 1.0);
     fBlock_max[i] = (block + 3.0 * sigma) * double_t(fNumberOfSamples_map) / (fBlocksPerEvent * 1.0);
     
-    fBlockSumSq_raw[4] += fBlockSumSq_raw[i];
-    fBlock_min[4] = TMath::Min(fBlock_min[i],fBlock_min[4]);
-    fBlock_max[4] = TMath::Max(fBlock_max[i],fBlock_max[4]);
+    fBlockSumSq_raw[fBlocksPerEvent] += fBlockSumSq_raw[i];
+    fBlock_min[fBlocksPerEvent] = TMath::Min(fBlock_min[i],fBlock_min[fBlocksPerEvent]);
+    fBlock_max[fBlocksPerEvent] = TMath::Max(fBlock_max[i],fBlock_max[fBlocksPerEvent]);
     }
 
 
@@ -399,7 +417,7 @@ void QwMollerADC_Channel::EncodeEventData(std::vector<UInt_t> &buffer)
     //  Skip over this data.
   } else {
     //    localbuf[4] = 0;
-    for (Int_t i = 0; i < 4; i++) {
+    for (Int_t i = 0; i < fBlocksPerEvent; i++) {
       localbuf[i*5] = fBlock_raw[i];
       localbuf[i*5+1] = fBlockSumSq_raw[i] & 0xffffffff;
       localbuf[i*5+2] = fBlockSumSq_raw[i] >> 32;
@@ -411,10 +429,10 @@ void QwMollerADC_Channel::EncodeEventData(std::vector<UInt_t> &buffer)
     // The following causes many rounding errors and skips due to the check
     // that fHardwareBlockSum_raw == fSoftwareBlockSum_raw in IsGoodEvent().
     localbuf[20] = fHardwareBlockSum_raw;
-    localbuf[21] = fBlockSumSq_raw[4] & 0xffffffff;
-    localbuf[22] = fBlockSumSq_raw[4] >> 32;
-    localbuf[23] = fBlock_min[4];
-    localbuf[24] = fBlock_max[4];
+    localbuf[21] = fBlockSumSq_raw[fBlocksPerEvent] & 0xffffffff;
+    localbuf[22] = fBlockSumSq_raw[fBlocksPerEvent] >> 32;
+    localbuf[23] = fBlock_min[fBlocksPerEvent];
+    localbuf[24] = fBlock_max[fBlocksPerEvent];
     localbuf[25] = (fNumberOfSamples << 16 & 0xFFFF0000)
                 | (fSequenceNumber  << 8  & 0x0000FF00);
 
@@ -482,10 +500,8 @@ void QwMollerADC_Channel::ProcessEvent()
   if (fNumberOfSamples == 0 && fHardwareBlockSum_raw == 0) {
     //  There isn't valid data for this channel.  Just flag it and
     //  move on.
-    for (Int_t i = 0; i < fBlocksPerEvent; i++) {
-      fBlock[i] = 0.0;
-      fBlockM2[i] = 0.0;
-    }
+    fBlock = 0.0;   // Use valarray assignment
+    fBlockM2 = 0.0; // Use valarray assignment
     fHardwareBlockSum = 0.0;
     fHardwareBlockSumM2 = 0.0;
     fErrorFlag |= kErrorFlag_sample;
@@ -496,18 +512,19 @@ void QwMollerADC_Channel::ProcessEvent()
               << " has fNumberOfSamples==0 but has valid data in the hardware sum.  "
               << "Flag this as an error."
               << QwLog::endl;
-    for (Int_t i = 0; i < fBlocksPerEvent; i++) {
-      fBlock[i] = 0.0;
-      fBlockM2[i] = 0.0;
-    }
+    fBlock = 0.0;   // Use valarray assignment
+    fBlockM2 = 0.0; // Use valarray assignment
     fHardwareBlockSum = 0.0;
     fHardwareBlockSumM2 = 0.0;
     fErrorFlag|=kErrorFlag_sample;
   } else {
-    for (Int_t i = 0; i < fBlocksPerEvent; i++) {
-      fBlock[i] = fCalibrationFactor * ( (1.0 * fBlock_raw[i] * fBlocksPerEvent / fNumberOfSamples) - fPedestal );
-      fBlockM2[i] = 0.0; // second moment is zero for single events
-    }
+    // Calculate calibrated values using valarray operations with explicit casting
+    // Create a lambda for type conversion and use apply
+    std::valarray<Double_t> temp_raw(fBlock_raw.size());
+    std::transform(std::begin(fBlock_raw), std::end(fBlock_raw), std::begin(temp_raw),
+                   [](Int_t val) { return static_cast<Double_t>(val); });
+    fBlock = fCalibrationFactor * ((temp_raw * static_cast<Double_t>(fBlocksPerEvent) / static_cast<Double_t>(fNumberOfSamples)) - fPedestal);
+    fBlockM2 = 0.0; // Use valarray assignment for second moments
     fHardwareBlockSum = fCalibrationFactor * ( (1.0 * fHardwareBlockSum_raw / fNumberOfSamples) - fPedestal );
     fHardwareBlockSumM2 = 0.0; // second moment is zero for single events
   }
@@ -728,7 +745,7 @@ void  QwMollerADC_Channel::ConstructBranchAndVector(TTree *tree, TString &prefix
       list += ":block3_raw/D";
     }
 
-    for(int i = 0; i < 4; i++){
+    for(int i = 0; i < fBlocksPerEvent; i++){
      if (bBlock_raw) {
       values.push_back(0.0);
       list += Form(":SumSq1_%d/D",i);
@@ -861,14 +878,14 @@ QwMollerADC_Channel& QwMollerADC_Channel::operator= (const QwMollerADC_Channel &
 
   if (!IsNameEmpty()) {
     VQwHardwareChannel::operator=(value);
-    for (Int_t i=0; i<fBlocksPerEvent; i++){
-      this->fBlock_raw[i] = value.fBlock_raw[i];
-      this->fBlock[i]     = value.fBlock[i];
-      this->fBlockM2[i]   = value.fBlockM2[i];
-      this->fBlockSumSq_raw[i] = value.fBlockSumSq_raw[i];
-      this->fBlock_min[i]     = value.fBlock_min[i];
-      this->fBlock_max[i]     = value.fBlock_max[i];
-    }
+    // Use valarray assignment for bulk operations
+    fBlock_raw = value.fBlock_raw;
+    fBlock = value.fBlock;
+    fBlockM2 = value.fBlockM2;
+    fBlockSumSq_raw = value.fBlockSumSq_raw;
+    fBlock_min = value.fBlock_min;
+    fBlock_max = value.fBlock_max;
+    
     this->fHardwareBlockSum_raw = value.fHardwareBlockSum_raw;
     this->fSoftwareBlockSum_raw = value.fSoftwareBlockSum_raw;
     this->fHardwareBlockSum = value.fHardwareBlockSum;
@@ -888,15 +905,14 @@ void QwMollerADC_Channel::AssignScaledValue(const QwMollerADC_Channel &value,
   if(this == &value) return;
 
   if (!IsNameEmpty()) {
-    for (Int_t i=0; i<fBlocksPerEvent; i++){
-      this->fBlock_raw[i] = value.fBlock_raw[i];   // Keep this?
-      this->fBlock[i]   = value.fBlock[i]   * scale;
-      this->fBlockM2[i] = value.fBlockM2[i] * scale * scale;
-      this->fBlockSumSq_raw[i] = value.fBlockSumSq_raw[i];
-      this->fBlock_min[i]     = value.fBlock_min[i];
-      this->fBlock_max[i]     = value.fBlock_max[i];
+    // Use valarray operations for scaling
+    this->fBlock_raw = value.fBlock_raw;   // Keep this?
+    this->fBlock = value.fBlock * scale;
+    this->fBlockM2 = value.fBlockM2 * scale * scale;
+    this->fBlockSumSq_raw = value.fBlockSumSq_raw;
+    this->fBlock_min = value.fBlock_min;
+    this->fBlock_max = value.fBlock_max;
 
-    }
     this->fHardwareBlockSum_raw = value.fHardwareBlockSum_raw;  // Keep this?
     this->fSoftwareBlockSum_raw = value.fSoftwareBlockSum_raw;  // Keep this?
     this->fHardwareBlockSum   = value.fHardwareBlockSum * scale;
@@ -982,15 +998,20 @@ QwMollerADC_Channel& QwMollerADC_Channel::operator+= (const QwMollerADC_Channel 
 {
 
   if (!IsNameEmpty()) {
+    // Use valarray arithmetic operations
+    this->fBlock += value.fBlock;
+    this->fBlock_raw += value.fBlock_raw;
+    this->fBlockSumSq_raw += value.fBlockSumSq_raw;
+    
+    // Element-wise min/max need manual loop (no direct valarray support for element-wise min/max)
     for (Int_t i = 0; i < fBlocksPerEvent; i++) {
-      this->fBlock[i] += value.fBlock[i];
-      this->fBlock_raw[i] += value.fBlock_raw[i];
-
       this->fBlock_min[i] = TMath::Min(fBlock_min[i],value.fBlock_min[i]);
       this->fBlock_max[i] = TMath::Max(fBlock_max[i],value.fBlock_max[i]);    
-      this->fBlockSumSq_raw[i] += value.fBlockSumSq_raw[i];
-      this->fBlockM2[i] = 0.0;
     }
+    
+    // Clear second moments since they can't be simply added
+    this->fBlockM2 = 0.0;
+    
     this->fHardwareBlockSum_raw = value.fHardwareBlockSum_raw;
     this->fSoftwareBlockSum_raw = value.fSoftwareBlockSum_raw;
     this->fHardwareBlockSum    += value.fHardwareBlockSum;
@@ -1014,14 +1035,18 @@ const QwMollerADC_Channel QwMollerADC_Channel::operator- (const QwMollerADC_Chan
 QwMollerADC_Channel& QwMollerADC_Channel::operator-= (const QwMollerADC_Channel &value)
 {
   if (!IsNameEmpty()){
+    // Use valarray arithmetic operations
+    this->fBlock -= value.fBlock;
+    this->fBlock_raw = 0;  // Set all to 0
+    this->fBlockSumSq_raw = value.fBlockSumSq_raw;
+    this->fBlockM2 = 0.0;
+    
+    // Element-wise min/max need manual loop (no direct valarray support for element-wise min/max)
     for (Int_t i=0; i<fBlocksPerEvent; i++){
-      this->fBlock[i] -= value.fBlock[i];
-      this->fBlock_raw[i] = 0;
-      this->fBlockSumSq_raw[i] = value.fBlockSumSq_raw[i];
       this->fBlock_min[i] = TMath::Min(fBlock_min[i],value.fBlock_min[i]);
       this->fBlock_max[i] = TMath::Max(fBlock_max[i],value.fBlock_max[i]);  
-      this->fBlockM2[i] = 0.0;
     }
+    
     this->fHardwareBlockSum_raw = 0;
     this->fSoftwareBlockSum_raw = 0;
     this->fHardwareBlockSum    -= value.fHardwareBlockSum;
@@ -1044,9 +1069,13 @@ const QwMollerADC_Channel QwMollerADC_Channel::operator* (const QwMollerADC_Chan
 QwMollerADC_Channel& QwMollerADC_Channel::operator*= (const QwMollerADC_Channel &value)
 {
   if (!IsNameEmpty()){
+    // Use valarray arithmetic operations
+    this->fBlock *= value.fBlock;
+    this->fBlock_raw *= value.fBlock_raw;
+    this->fBlockM2 = 0.0;
+    
+    // Handle conditional logic for sumSq, min, max arrays manually since they have different logic
     for (Int_t i=0; i<fBlocksPerEvent; i++){
-      this->fBlock[i] *= value.fBlock[i];
-      this->fBlock_raw[i] *= value.fBlock_raw[i];
       if(fBlockSumSq_raw[i] != 0){
         this->fBlockSumSq_raw[i] *= value.fBlockSumSq_raw[i];
         this->fBlock_min[i] *= value.fBlock_min[i];
@@ -1056,8 +1085,21 @@ QwMollerADC_Channel& QwMollerADC_Channel::operator*= (const QwMollerADC_Channel 
         this->fBlock_min[i] = value.fBlock_min[i];
         this->fBlock_max[i] = value.fBlock_max[i];
       }
-      this->fBlockM2[i] = 0.0;
     }
+    
+    // Handle conditional operations element-wise
+    for (Int_t i=0; i<fBlocksPerEvent; i++){
+      if(fBlockSumSq_raw[i] != 0){
+        this->fBlockSumSq_raw[i] *= value.fBlockSumSq_raw[i];
+        this->fBlock_min[i] *= value.fBlock_min[i];
+        this->fBlock_max[i] *= value.fBlock_max[i];
+      } else {
+        this->fBlockSumSq_raw[i] = value.fBlockSumSq_raw[i];
+        this->fBlock_min[i] = value.fBlock_min[i];
+        this->fBlock_max[i] = value.fBlock_max[i];
+      }
+    }
+    
     this->fHardwareBlockSum_raw *= value.fHardwareBlockSum_raw;
     this->fSoftwareBlockSum_raw *= value.fSoftwareBlockSum_raw;
     this->fHardwareBlockSum     *= value.fHardwareBlockSum;
@@ -1272,8 +1314,7 @@ void QwMollerADC_Channel::AddChannelOffset(Double_t offset)
 {
   if (!IsNameEmpty()){
     fHardwareBlockSum += offset;
-    for (Int_t i=0; i<fBlocksPerEvent; i++) 
-      fBlock[i] += offset;
+    fBlock += offset; // Use valarray operation
   }
   return;
 }
@@ -1281,10 +1322,9 @@ void QwMollerADC_Channel::AddChannelOffset(Double_t offset)
 void QwMollerADC_Channel::Scale(Double_t scale)
 {
   if (!IsNameEmpty()){
-      for (Int_t i = 0; i < fBlocksPerEvent; i++) {
-        fBlock[i] *= scale;
-        fBlockM2[i] *= scale * scale;
-      }
+      // Use valarray operations for scaling
+      fBlock *= scale;
+      fBlockM2 *= scale * scale;
       fHardwareBlockSum *= scale;
       fHardwareBlockSumM2 *= scale * scale;
     }
@@ -1421,7 +1461,7 @@ void QwMollerADC_Channel::AccumulateRunningSum(const QwMollerADC_Channel& value,
       fHardwareBlockSumM2 -= (M12 - M11)
         * (M12 - fHardwareBlockSum); // note: using updated mean
       // and for individual blocks
-      for (Int_t i = 0; i < 4; i++) {
+      for (Int_t i = 0; i < fBlocksPerEvent; i++) {
         M11 = fBlock[i];
         M12 = value.fBlock[i];
         M22 = value.fBlockM2[i];
@@ -1473,7 +1513,7 @@ void QwMollerADC_Channel::AccumulateRunningSum(const QwMollerADC_Channel& value,
     fHardwareBlockSumM2 += (M12 - M11)
          * (M12 - fHardwareBlockSum); // note: using updated mean
     // and for individual blocks
-    for (Int_t i = 0; i < 4; i++) {
+    for (Int_t i = 0; i < fBlocksPerEvent; i++) {
       M11 = fBlock[i];
       M12 = value.fBlock[i];
       M22 = value.fBlockM2[i];
@@ -1486,7 +1526,7 @@ void QwMollerADC_Channel::AccumulateRunningSum(const QwMollerADC_Channel& value,
     fHardwareBlockSum += n2 * (M12 - M11) / n;
     fHardwareBlockSumM2 += M22 + n1 * n2 * (M12 - M11) * (M12 - M11) / n;
     // and for individual blocks
-    for (Int_t i = 0; i < 4; i++) {
+    for (Int_t i = 0; i < fBlocksPerEvent; i++) {
       M11 = fBlock[i];
       M12 = value.fBlock[i];
       M22 = value.fBlockM2[i];
@@ -1505,9 +1545,8 @@ void QwMollerADC_Channel::CalculateRunningAverage()
 {
   if (fGoodEventCount <= 0)
     {
-      for (Int_t i = 0; i < fBlocksPerEvent; i++) {
-        fBlockError[i] = 0.0;
-      }
+      // Use valarray assignment for bulk operation
+      fBlockError = 0.0;
       fHardwareBlockSumError = 0.0;
     }
   else
@@ -1518,8 +1557,9 @@ void QwMollerADC_Channel::CalculateRunningAverage()
       // Note we want to calculate the error here, not sigma:
       //    sigma = sqrt(M2 / n);
       //    error = sigma / sqrt (n) = sqrt(M2) / n;
-      for (Int_t i = 0; i < fBlocksPerEvent; i++)
-        fBlockError[i] = sqrt(fBlockM2[i]) / fGoodEventCount;
+      
+      // Use valarray sqrt function for element-wise calculation
+      fBlockError = sqrt(fBlockM2) / fGoodEventCount;
       fHardwareBlockSumError = sqrt(fHardwareBlockSumM2) / fGoodEventCount;
 
       // Stability check 83951872


### PR DESCRIPTION
This PR modifies subblock handling to using `std::valarray`. That's a vector type that overloads common math operators with element-wise operations, and is intended to generate vectorized code.

This PR mainly adds readability and introduces a vectorization concept that can be pushed further by combining channels as a next step. At this point the vectorization of loops of 4 is not going to lead to noticeable speed increases.