### PR TITLE
Make {VQwDataElement, VQwHardwareChannel}::operator= non-virtual

### DIFF
--- a/Analysis/include/QwMollerADC_Channel.h
+++ b/Analysis/include/QwMollerADC_Channel.h
@@ -140,7 +140,6 @@ class QwMollerADC_Channel: public VQwHardwareChannel, public MQwMockable {
 
 
   QwMollerADC_Channel& operator=  (const QwMollerADC_Channel &value);
-  //  VQwHardwareChannel& operator=  (const VQwHardwareChannel &value);
   void AssignScaledValue(const QwMollerADC_Channel &value, Double_t scale);
   void AssignValueFrom(const VQwDataElement* valueptr);
   void AddValueFrom(const VQwHardwareChannel* valueptr);

--- a/Analysis/include/QwScaler_Channel.h
+++ b/Analysis/include/QwScaler_Channel.h
@@ -146,7 +146,6 @@ public:
   void MultiplyBy(const VQwHardwareChannel* valueptr);
   void DivideBy(const VQwHardwareChannel* valueptr);
 
-  //  VQwHardwareChannel& operator=  (const VQwHardwareChannel &data_value);
   VQwScaler_Channel& operator+= (const VQwScaler_Channel &value);
   VQwScaler_Channel& operator-= (const VQwScaler_Channel &value);
   VQwScaler_Channel& operator*= (const VQwScaler_Channel &value);

--- a/Analysis/include/QwVQWK_Channel.h
+++ b/Analysis/include/QwVQWK_Channel.h
@@ -138,8 +138,7 @@ class QwVQWK_Channel: public VQwHardwareChannel, public MQwMockable {
   void  ProcessEvent();
 
 
-  QwVQWK_Channel& operator=  (const QwVQWK_Channel &value);
-  //  VQwHardwareChannel& operator=  (const VQwHardwareChannel &value);
+  QwVQWK_Channel& operator=(const QwVQWK_Channel &value);
   void AssignScaledValue(const QwVQWK_Channel &value, Double_t scale);
   void AssignValueFrom(const VQwDataElement* valueptr);
   void AddValueFrom(const VQwHardwareChannel* valueptr);

--- a/Analysis/include/VQwDataElement.h
+++ b/Analysis/include/VQwDataElement.h
@@ -219,7 +219,7 @@ class VQwDataElement: public MQwHistograms {
   void SetNumberOfDataWords(const UInt_t &numwords) {fNumberOfDataWords = numwords;}
 
   /// Arithmetic assignment operator:  Should only copy event-based data
-  virtual VQwDataElement& operator=(const VQwDataElement& value) {
+  VQwDataElement& operator=(const VQwDataElement& value) {
     if(this != &value){
       MQwHistograms::operator=(value);
       fGoodEventCount    = value.fGoodEventCount;

--- a/Analysis/include/VQwHardwareChannel.h
+++ b/Analysis/include/VQwHardwareChannel.h
@@ -140,8 +140,10 @@ public:
 //   virtual void AccumulateRunningSum(const VQwHardwareChannel *value) = 0;
 
   /// Arithmetic assignment operator:  Should only copy event-based data
-  virtual VQwHardwareChannel& operator=(const VQwHardwareChannel& value) {
-    VQwDataElement::operator=(value);
+  VQwHardwareChannel& operator=(const VQwHardwareChannel& value) {
+    if (this != &value) {
+      VQwDataElement::operator=(value);
+    }
     return *this;
   }
   void AssignScaledValue(const VQwHardwareChannel &value, Double_t scale){

--- a/Analysis/src/QwPMT_Channel.cc
+++ b/Analysis/src/QwPMT_Channel.cc
@@ -135,6 +135,7 @@ void  QwPMT_Channel::FillTreeVector(std::vector<Double_t> &values) const
 QwPMT_Channel& QwPMT_Channel::operator= (const QwPMT_Channel &value){
   if (this != &value) {
     if (GetElementName()!=""){
+      VQwDataElement::operator=(value);
       this->fValue  = value.fValue;
     }
   }

--- a/Analysis/src/QwSIS3320_Accumulator.cc
+++ b/Analysis/src/QwSIS3320_Accumulator.cc
@@ -182,9 +182,12 @@ const QwSIS3320_Accumulator QwSIS3320_Accumulator::operator- (const QwSIS3320_Ac
  */
 QwSIS3320_Accumulator& QwSIS3320_Accumulator::operator= (const QwSIS3320_Accumulator &value)
 {
-  if (!IsNameEmpty()) {
-    this->fAccumulatorSum = value.fAccumulatorSum;
-    this->fNumberOfSamples = value.fNumberOfSamples;
+  if (this != &value) {
+    if (!IsNameEmpty()) {
+      VQwDataElement::operator=(value);
+      this->fAccumulatorSum = value.fAccumulatorSum;
+      this->fNumberOfSamples = value.fNumberOfSamples;
+    }
   }
   return *this;
 }


### PR DESCRIPTION
This PR makes `VQwDataElement::operator=` and  `VQwHardwareChannel::operator=` non-virtual since they are not ever expected to be implemented by any derived class, and it only leads to overloaded virtual warnings. All derived class assignment operators properly call base class assignment operator.