### PR TITLE
Convert to operator?=(const VQwHardwareChannel&) by reference

### DIFF
--- a/Analysis/include/QwADC18_Channel.h
+++ b/Analysis/include/QwADC18_Channel.h
@@ -137,10 +137,10 @@ class QwADC18_Channel: public VQwHardwareChannel, public MQwMockable {
   QwADC18_Channel& operator-= (const QwADC18_Channel &value);
   QwADC18_Channel& operator*= (const QwADC18_Channel &value);
 
-  VQwHardwareChannel& operator+=(const VQwHardwareChannel* input);
-  VQwHardwareChannel& operator-=(const VQwHardwareChannel* input);
-  VQwHardwareChannel& operator*=(const VQwHardwareChannel* input);
-  VQwHardwareChannel& operator/=(const VQwHardwareChannel* input);
+  VQwHardwareChannel& operator+=(const VQwHardwareChannel& input) override;
+  VQwHardwareChannel& operator-=(const VQwHardwareChannel& input) override;
+  VQwHardwareChannel& operator*=(const VQwHardwareChannel& input) override;
+  VQwHardwareChannel& operator/=(const VQwHardwareChannel& input) override;
 
   const QwADC18_Channel operator+ (const QwADC18_Channel &value) const;
   const QwADC18_Channel operator- (const QwADC18_Channel &value) const;

--- a/Analysis/include/QwMollerADC_Channel.h
+++ b/Analysis/include/QwMollerADC_Channel.h
@@ -153,10 +153,10 @@ class QwMollerADC_Channel: public VQwHardwareChannel, public MQwMockable {
   QwMollerADC_Channel& operator-= (const QwMollerADC_Channel &value);
   QwMollerADC_Channel& operator*= (const QwMollerADC_Channel &value);
 
-  VQwHardwareChannel& operator+=(const VQwHardwareChannel* input);
-  VQwHardwareChannel& operator-=(const VQwHardwareChannel* input);
-  VQwHardwareChannel& operator*=(const VQwHardwareChannel* input);
-  VQwHardwareChannel& operator/=(const VQwHardwareChannel* input);
+  VQwHardwareChannel& operator+=(const VQwHardwareChannel& input) override;
+  VQwHardwareChannel& operator-=(const VQwHardwareChannel& input) override;
+  VQwHardwareChannel& operator*=(const VQwHardwareChannel& input) override;
+  VQwHardwareChannel& operator/=(const VQwHardwareChannel& input) override;
 
   const QwMollerADC_Channel operator+ (const QwMollerADC_Channel &value) const;
   const QwMollerADC_Channel operator- (const QwMollerADC_Channel &value) const;

--- a/Analysis/include/QwScaler_Channel.h
+++ b/Analysis/include/QwScaler_Channel.h
@@ -151,10 +151,10 @@ public:
   VQwScaler_Channel& operator-= (const VQwScaler_Channel &value);
   VQwScaler_Channel& operator*= (const VQwScaler_Channel &value);
 
-  VQwHardwareChannel& operator+=(const VQwHardwareChannel* input);
-  VQwHardwareChannel& operator-=(const VQwHardwareChannel* input);
-  VQwHardwareChannel& operator*=(const VQwHardwareChannel* input);
-  VQwHardwareChannel& operator/=(const VQwHardwareChannel* input);
+  VQwHardwareChannel& operator+=(const VQwHardwareChannel& input) override;
+  VQwHardwareChannel& operator-=(const VQwHardwareChannel& input) override;
+  VQwHardwareChannel& operator*=(const VQwHardwareChannel& input) override;
+  VQwHardwareChannel& operator/=(const VQwHardwareChannel& input) override;
 
   void Sum(VQwScaler_Channel &value1, VQwScaler_Channel &value2);
   void Difference(VQwScaler_Channel &value1, VQwScaler_Channel &value2);

--- a/Analysis/include/QwVQWK_Channel.h
+++ b/Analysis/include/QwVQWK_Channel.h
@@ -152,10 +152,10 @@ class QwVQWK_Channel: public VQwHardwareChannel, public MQwMockable {
   QwVQWK_Channel& operator-= (const QwVQWK_Channel &value);
   QwVQWK_Channel& operator*= (const QwVQWK_Channel &value);
 
-  VQwHardwareChannel& operator+=(const VQwHardwareChannel* input);
-  VQwHardwareChannel& operator-=(const VQwHardwareChannel* input);
-  VQwHardwareChannel& operator*=(const VQwHardwareChannel* input);
-  VQwHardwareChannel& operator/=(const VQwHardwareChannel* input);
+  VQwHardwareChannel& operator+=(const VQwHardwareChannel& input) override;
+  VQwHardwareChannel& operator-=(const VQwHardwareChannel& input) override;
+  VQwHardwareChannel& operator*=(const VQwHardwareChannel& input) override;
+  VQwHardwareChannel& operator/=(const VQwHardwareChannel& input) override;
 
   const QwVQWK_Channel operator+ (const QwVQWK_Channel &value) const;
   const QwVQWK_Channel operator- (const QwVQWK_Channel &value) const;

--- a/Analysis/include/VQwHardwareChannel.h
+++ b/Analysis/include/VQwHardwareChannel.h
@@ -151,7 +151,7 @@ public:
     virtual void Ratio(const VQwHardwareChannel* numer, const VQwHardwareChannel* denom){
     if (!IsNameEmpty()){
       this->AssignValueFrom(numer); 
-      this->operator/=(denom);
+      this->operator/=(*denom);
        
         // Remaining variables
     fGoodEventCount  = denom->fGoodEventCount;

--- a/Analysis/include/VQwHardwareChannel.h
+++ b/Analysis/include/VQwHardwareChannel.h
@@ -160,10 +160,10 @@ public:
   }
 
   void AssignValueFrom(const VQwDataElement* valueptr) = 0;
-  virtual VQwHardwareChannel& operator+=(const VQwHardwareChannel* input) = 0;
-  virtual VQwHardwareChannel& operator-=(const VQwHardwareChannel* input) = 0;
-  virtual VQwHardwareChannel& operator*=(const VQwHardwareChannel* input) = 0;
-  virtual VQwHardwareChannel& operator/=(const VQwHardwareChannel* input) = 0;
+  virtual VQwHardwareChannel& operator+=(const VQwHardwareChannel& input) = 0;
+  virtual VQwHardwareChannel& operator-=(const VQwHardwareChannel& input) = 0;
+  virtual VQwHardwareChannel& operator*=(const VQwHardwareChannel& input) = 0;
+  virtual VQwHardwareChannel& operator/=(const VQwHardwareChannel& input) = 0;
 
 
   virtual void ScaledAdd(Double_t scale, const VQwHardwareChannel *value) = 0;

--- a/Analysis/src/QwADC18_Channel.cc
+++ b/Analysis/src/QwADC18_Channel.cc
@@ -804,10 +804,10 @@ QwADC18_Channel& QwADC18_Channel::operator*= (const QwADC18_Channel &value)
   return *this;
 }
 
-VQwHardwareChannel& QwADC18_Channel::operator+=(const VQwHardwareChannel *source)
+VQwHardwareChannel& QwADC18_Channel::operator+=(const VQwHardwareChannel &source)
 {
   const QwADC18_Channel* tmpptr;
-  tmpptr = dynamic_cast<const QwADC18_Channel*>(source);
+  tmpptr = dynamic_cast<const QwADC18_Channel*>(&source);
   if (tmpptr!=NULL){
     *this += *tmpptr;
   } else {
@@ -819,10 +819,10 @@ VQwHardwareChannel& QwADC18_Channel::operator+=(const VQwHardwareChannel *source
   return *this;
 }
 
-VQwHardwareChannel& QwADC18_Channel::operator-=(const VQwHardwareChannel *source)
+VQwHardwareChannel& QwADC18_Channel::operator-=(const VQwHardwareChannel &source)
 {
   const QwADC18_Channel* tmpptr;
-  tmpptr = dynamic_cast<const QwADC18_Channel*>(source);
+  tmpptr = dynamic_cast<const QwADC18_Channel*>(&source);
   if (tmpptr!=NULL){
     *this -= *tmpptr;
   } else {
@@ -834,10 +834,10 @@ VQwHardwareChannel& QwADC18_Channel::operator-=(const VQwHardwareChannel *source
   return *this;
 }
 
-VQwHardwareChannel& QwADC18_Channel::operator*=(const VQwHardwareChannel *source)
+VQwHardwareChannel& QwADC18_Channel::operator*=(const VQwHardwareChannel &source)
 {
   const QwADC18_Channel* tmpptr;
-  tmpptr = dynamic_cast<const QwADC18_Channel*>(source);
+  tmpptr = dynamic_cast<const QwADC18_Channel*>(&source);
   if (tmpptr!=NULL){
     *this *= *tmpptr;
   } else {
@@ -849,10 +849,10 @@ VQwHardwareChannel& QwADC18_Channel::operator*=(const VQwHardwareChannel *source
   return *this;
 }
 
-VQwHardwareChannel& QwADC18_Channel::operator/=(const VQwHardwareChannel *source)
+VQwHardwareChannel& QwADC18_Channel::operator/=(const VQwHardwareChannel &source)
 {
   const QwADC18_Channel* tmpptr;
-  tmpptr = dynamic_cast<const QwADC18_Channel*>(source);
+  tmpptr = dynamic_cast<const QwADC18_Channel*>(&source);
   if (tmpptr!=NULL){
     *this /= *tmpptr;
   } else {

--- a/Analysis/src/QwADC18_Channel.cc
+++ b/Analysis/src/QwADC18_Channel.cc
@@ -812,7 +812,7 @@ VQwHardwareChannel& QwADC18_Channel::operator+=(const VQwHardwareChannel &source
     *this += *tmpptr;
   } else {
     TString loc="Standard exception from QwADC18_Channel::operator+= "
-        +source->GetElementName()+" "
+        +source.GetElementName()+" "
         +this->GetElementName()+" are not of the same type";
     throw(std::invalid_argument(loc.Data()));
   }
@@ -827,7 +827,7 @@ VQwHardwareChannel& QwADC18_Channel::operator-=(const VQwHardwareChannel &source
     *this -= *tmpptr;
   } else {
     TString loc="Standard exception from QwADC18_Channel::operator-= "
-        +source->GetElementName()+" "
+        +source.GetElementName()+" "
         +this->GetElementName()+" are not of the same type";
     throw(std::invalid_argument(loc.Data()));
   }
@@ -842,7 +842,7 @@ VQwHardwareChannel& QwADC18_Channel::operator*=(const VQwHardwareChannel &source
     *this *= *tmpptr;
   } else {
     TString loc="Standard exception from QwADC18_Channel::operator*= "
-        +source->GetElementName()+" "
+        +source.GetElementName()+" "
         +this->GetElementName()+" are not of the same type";
     throw(std::invalid_argument(loc.Data()));
   }
@@ -857,7 +857,7 @@ VQwHardwareChannel& QwADC18_Channel::operator/=(const VQwHardwareChannel &source
     *this /= *tmpptr;
   } else {
     TString loc="Standard exception from QwADC18_Channel::operator/= "
-        +source->GetElementName()+" "
+        +source.GetElementName()+" "
         +this->GetElementName()+" are not of the same type";
     throw(std::invalid_argument(loc.Data()));
   }

--- a/Analysis/src/QwMollerADC_Channel.cc
+++ b/Analysis/src/QwMollerADC_Channel.cc
@@ -1070,10 +1070,10 @@ QwMollerADC_Channel& QwMollerADC_Channel::operator*= (const QwMollerADC_Channel 
   return *this;
 }
 
-VQwHardwareChannel& QwMollerADC_Channel::operator+=(const VQwHardwareChannel *source)
+VQwHardwareChannel& QwMollerADC_Channel::operator+=(const VQwHardwareChannel &source)
 {
   const QwMollerADC_Channel* tmpptr;
-  tmpptr = dynamic_cast<const QwMollerADC_Channel*>(source);
+  tmpptr = dynamic_cast<const QwMollerADC_Channel*>(&source);
   if (tmpptr!=NULL){
     *this += *tmpptr;
   } else {
@@ -1084,10 +1084,10 @@ VQwHardwareChannel& QwMollerADC_Channel::operator+=(const VQwHardwareChannel *so
   }
   return *this;
 }
-VQwHardwareChannel& QwMollerADC_Channel::operator-=(const VQwHardwareChannel *source)
+VQwHardwareChannel& QwMollerADC_Channel::operator-=(const VQwHardwareChannel &source)
 {
   const QwMollerADC_Channel* tmpptr;
-  tmpptr = dynamic_cast<const QwMollerADC_Channel*>(source);
+  tmpptr = dynamic_cast<const QwMollerADC_Channel*>(&source);
   if (tmpptr!=NULL){
     *this -= *tmpptr;
   } else {
@@ -1098,10 +1098,10 @@ VQwHardwareChannel& QwMollerADC_Channel::operator-=(const VQwHardwareChannel *so
   }
   return *this;
 }
-VQwHardwareChannel& QwMollerADC_Channel::operator*=(const VQwHardwareChannel *source)
+VQwHardwareChannel& QwMollerADC_Channel::operator*=(const VQwHardwareChannel &source)
 {
   const QwMollerADC_Channel* tmpptr;
-  tmpptr = dynamic_cast<const QwMollerADC_Channel*>(source);
+  tmpptr = dynamic_cast<const QwMollerADC_Channel*>(&source);
   if (tmpptr!=NULL){
     *this *= *tmpptr;
   } else {
@@ -1112,10 +1112,10 @@ VQwHardwareChannel& QwMollerADC_Channel::operator*=(const VQwHardwareChannel *so
   }
   return *this;
 }
-VQwHardwareChannel& QwMollerADC_Channel::operator/=(const VQwHardwareChannel *source)
+VQwHardwareChannel& QwMollerADC_Channel::operator/=(const VQwHardwareChannel &source)
 {
   const QwMollerADC_Channel* tmpptr;
-  tmpptr = dynamic_cast<const QwMollerADC_Channel*>(source);
+  tmpptr = dynamic_cast<const QwMollerADC_Channel*>(&source);
   if (tmpptr!=NULL){
     *this /= *tmpptr;
   } else {

--- a/Analysis/src/QwMollerADC_Channel.cc
+++ b/Analysis/src/QwMollerADC_Channel.cc
@@ -1078,7 +1078,7 @@ VQwHardwareChannel& QwMollerADC_Channel::operator+=(const VQwHardwareChannel &so
     *this += *tmpptr;
   } else {
     TString loc="Standard exception from QwMollerADC_Channel::operator+= "
-        +source->GetElementName()+" "
+        +source.GetElementName()+" "
         +this->GetElementName()+" are not of the same type";
     throw(std::invalid_argument(loc.Data()));
   }
@@ -1092,7 +1092,7 @@ VQwHardwareChannel& QwMollerADC_Channel::operator-=(const VQwHardwareChannel &so
     *this -= *tmpptr;
   } else {
     TString loc="Standard exception from QwMollerADC_Channel::operator-= "
-        +source->GetElementName()+" "
+        +source.GetElementName()+" "
         +this->GetElementName()+" are not of the same type";
     throw(std::invalid_argument(loc.Data()));
   }
@@ -1106,7 +1106,7 @@ VQwHardwareChannel& QwMollerADC_Channel::operator*=(const VQwHardwareChannel &so
     *this *= *tmpptr;
   } else {
     TString loc="Standard exception from QwMollerADC_Channel::operator*= "
-        +source->GetElementName()+" "
+        +source.GetElementName()+" "
         +this->GetElementName()+" are not of the same type";
     throw(std::invalid_argument(loc.Data()));
   }
@@ -1120,7 +1120,7 @@ VQwHardwareChannel& QwMollerADC_Channel::operator/=(const VQwHardwareChannel &so
     *this /= *tmpptr;
   } else {
     TString loc="Standard exception from QwMollerADC_Channel::operator/= "
-        +source->GetElementName()+" "
+        +source.GetElementName()+" "
         +this->GetElementName()+" are not of the same type";
     throw(std::invalid_argument(loc.Data()));
   }

--- a/Analysis/src/QwScaler_Channel.cc
+++ b/Analysis/src/QwScaler_Channel.cc
@@ -477,13 +477,13 @@ VQwScaler_Channel& VQwScaler_Channel::operator*= (const VQwScaler_Channel &value
   return *this;
 }
 
-VQwHardwareChannel& VQwScaler_Channel::operator+=(const VQwHardwareChannel *source)
+VQwHardwareChannel& VQwScaler_Channel::operator+=(const VQwHardwareChannel &source)
 {
-  const VQwScaler_Channel* tmpptr;
-  tmpptr = dynamic_cast<const VQwScaler_Channel*>(source);
-  if (tmpptr!=NULL){
-    *this += *tmpptr;
-  } else {
+  try {
+    const VQwScaler_Channel& tmp;
+    tmp = dynamic_cast<const VQwScaler_Channel&>(source);
+    *this += tmp;
+  } catch(const std::exception& e) {
     TString loc="Standard exception from VQwScaler_Channel::operator+= "
         +source->GetElementName()+" "
         +this->GetElementName()+" are not of the same type";
@@ -491,10 +491,10 @@ VQwHardwareChannel& VQwScaler_Channel::operator+=(const VQwHardwareChannel *sour
   }
   return *this;
 }
-VQwHardwareChannel& VQwScaler_Channel::operator-=(const VQwHardwareChannel *source)
+VQwHardwareChannel& VQwScaler_Channel::operator-=(const VQwHardwareChannel &source)
 {
   const VQwScaler_Channel* tmpptr;
-  tmpptr = dynamic_cast<const VQwScaler_Channel*>(source);
+  tmpptr = dynamic_cast<const VQwScaler_Channel*>(&source);
   if (tmpptr!=NULL){
     *this -= *tmpptr;
   } else {
@@ -505,10 +505,10 @@ VQwHardwareChannel& VQwScaler_Channel::operator-=(const VQwHardwareChannel *sour
   }
   return *this;
 }
-VQwHardwareChannel& VQwScaler_Channel::operator*=(const VQwHardwareChannel *source)
+VQwHardwareChannel& VQwScaler_Channel::operator*=(const VQwHardwareChannel &source)
 {
   const VQwScaler_Channel* tmpptr;
-  tmpptr = dynamic_cast<const VQwScaler_Channel*>(source);
+  tmpptr = dynamic_cast<const VQwScaler_Channel*>(&source);
   if (tmpptr!=NULL){
     *this *= *tmpptr;
   } else {
@@ -519,10 +519,10 @@ VQwHardwareChannel& VQwScaler_Channel::operator*=(const VQwHardwareChannel *sour
   }
   return *this;
 }
-VQwHardwareChannel& VQwScaler_Channel::operator/=(const VQwHardwareChannel *source)
+VQwHardwareChannel& VQwScaler_Channel::operator/=(const VQwHardwareChannel &source)
 {
   const VQwScaler_Channel* tmpptr;
-  tmpptr = dynamic_cast<const VQwScaler_Channel*>(source);
+  tmpptr = dynamic_cast<const VQwScaler_Channel*>(&source);
   if (tmpptr!=NULL){
     *this /= *tmpptr;
   } else {

--- a/Analysis/src/QwScaler_Channel.cc
+++ b/Analysis/src/QwScaler_Channel.cc
@@ -485,7 +485,7 @@ VQwHardwareChannel& VQwScaler_Channel::operator+=(const VQwHardwareChannel &sour
     *this += tmp;
   } catch(const std::exception& e) {
     TString loc="Standard exception from VQwScaler_Channel::operator+= "
-        +source->GetElementName()+" "
+        +source.GetElementName()+" "
         +this->GetElementName()+" are not of the same type";
     throw(std::invalid_argument(loc.Data()));
   }
@@ -499,7 +499,7 @@ VQwHardwareChannel& VQwScaler_Channel::operator-=(const VQwHardwareChannel &sour
     *this -= *tmpptr;
   } else {
     TString loc="Standard exception from VQwScaler_Channel::operator-= "
-        +source->GetElementName()+" "
+        +source.GetElementName()+" "
         +this->GetElementName()+" are not of the same type";
     throw(std::invalid_argument(loc.Data()));
   }
@@ -513,7 +513,7 @@ VQwHardwareChannel& VQwScaler_Channel::operator*=(const VQwHardwareChannel &sour
     *this *= *tmpptr;
   } else {
     TString loc="Standard exception from VQwScaler_Channel::operator*= "
-        +source->GetElementName()+" "
+        +source.GetElementName()+" "
         +this->GetElementName()+" are not of the same type";
     throw(std::invalid_argument(loc.Data()));
   }
@@ -527,7 +527,7 @@ VQwHardwareChannel& VQwScaler_Channel::operator/=(const VQwHardwareChannel &sour
     *this /= *tmpptr;
   } else {
     TString loc="Standard exception from VQwScaler_Channel::operator/= "
-        +source->GetElementName()+" "
+        +source.GetElementName()+" "
         +this->GetElementName()+" are not of the same type";
     throw(std::invalid_argument(loc.Data()));
   }

--- a/Analysis/src/QwScaler_Channel.cc
+++ b/Analysis/src/QwScaler_Channel.cc
@@ -482,7 +482,7 @@ VQwHardwareChannel& VQwScaler_Channel::operator+=(const VQwHardwareChannel &sour
   try {
     const VQwScaler_Channel* tmpptr;
     tmpptr = dynamic_cast<const VQwScaler_Channel*>(&source);
-    *this += tmp;
+    *this += tmpptr;
   } catch(const std::exception& e) {
     TString loc="Standard exception from VQwScaler_Channel::operator+= "
         +source.GetElementName()+" "

--- a/Analysis/src/QwScaler_Channel.cc
+++ b/Analysis/src/QwScaler_Channel.cc
@@ -480,8 +480,8 @@ VQwScaler_Channel& VQwScaler_Channel::operator*= (const VQwScaler_Channel &value
 VQwHardwareChannel& VQwScaler_Channel::operator+=(const VQwHardwareChannel &source)
 {
   try {
-    const VQwScaler_Channel& tmp;
-    tmp = dynamic_cast<const VQwScaler_Channel&>(source);
+    const VQwScaler_Channel* tmpptr;
+    tmpptr = dynamic_cast<const VQwScaler_Channel*>(&source);
     *this += tmp;
   } catch(const std::exception& e) {
     TString loc="Standard exception from VQwScaler_Channel::operator+= "

--- a/Analysis/src/QwScaler_Channel.cc
+++ b/Analysis/src/QwScaler_Channel.cc
@@ -482,7 +482,7 @@ VQwHardwareChannel& VQwScaler_Channel::operator+=(const VQwHardwareChannel &sour
   try {
     const VQwScaler_Channel* tmpptr;
     tmpptr = dynamic_cast<const VQwScaler_Channel*>(&source);
-    *this += tmpptr;
+    *this += *tmpptr;
   } catch(const std::exception& e) {
     TString loc="Standard exception from VQwScaler_Channel::operator+= "
         +source.GetElementName()+" "

--- a/Analysis/src/QwVQWK_Channel.cc
+++ b/Analysis/src/QwVQWK_Channel.cc
@@ -1094,7 +1094,7 @@ VQwHardwareChannel& QwVQWK_Channel::operator+=(const VQwHardwareChannel &source)
     *this += *tmpptr;
   } else {
     TString loc="Standard exception from QwVQWK_Channel::operator+= "
-        +source->GetElementName()+" "
+        +source.GetElementName()+" "
         +this->GetElementName()+" are not of the same type";
     throw(std::invalid_argument(loc.Data()));
   }
@@ -1108,7 +1108,7 @@ VQwHardwareChannel& QwVQWK_Channel::operator-=(const VQwHardwareChannel &source)
     *this -= *tmpptr;
   } else {
     TString loc="Standard exception from QwVQWK_Channel::operator-= "
-        +source->GetElementName()+" "
+        +source.GetElementName()+" "
         +this->GetElementName()+" are not of the same type";
     throw(std::invalid_argument(loc.Data()));
   }
@@ -1122,7 +1122,7 @@ VQwHardwareChannel& QwVQWK_Channel::operator*=(const VQwHardwareChannel &source)
     *this *= *tmpptr;
   } else {
     TString loc="Standard exception from QwVQWK_Channel::operator*= "
-        +source->GetElementName()+" "
+        +source.GetElementName()+" "
         +this->GetElementName()+" are not of the same type";
     throw(std::invalid_argument(loc.Data()));
   }
@@ -1136,7 +1136,7 @@ VQwHardwareChannel& QwVQWK_Channel::operator/=(const VQwHardwareChannel &source)
     *this /= *tmpptr;
   } else {
     TString loc="Standard exception from QwVQWK_Channel::operator/= "
-        +source->GetElementName()+" "
+        +source.GetElementName()+" "
         +this->GetElementName()+" are not of the same type";
     throw(std::invalid_argument(loc.Data()));
   }

--- a/Analysis/src/QwVQWK_Channel.cc
+++ b/Analysis/src/QwVQWK_Channel.cc
@@ -1086,10 +1086,10 @@ QwVQWK_Channel& QwVQWK_Channel::operator*= (const QwVQWK_Channel &value)
   return *this;
 }
 
-VQwHardwareChannel& QwVQWK_Channel::operator+=(const VQwHardwareChannel *source)
+VQwHardwareChannel& QwVQWK_Channel::operator+=(const VQwHardwareChannel &source)
 {
   const QwVQWK_Channel* tmpptr;
-  tmpptr = dynamic_cast<const QwVQWK_Channel*>(source);
+  tmpptr = dynamic_cast<const QwVQWK_Channel*>(&source);
   if (tmpptr!=NULL){
     *this += *tmpptr;
   } else {
@@ -1100,10 +1100,10 @@ VQwHardwareChannel& QwVQWK_Channel::operator+=(const VQwHardwareChannel *source)
   }
   return *this;
 }
-VQwHardwareChannel& QwVQWK_Channel::operator-=(const VQwHardwareChannel *source)
+VQwHardwareChannel& QwVQWK_Channel::operator-=(const VQwHardwareChannel &source)
 {
   const QwVQWK_Channel* tmpptr;
-  tmpptr = dynamic_cast<const QwVQWK_Channel*>(source);
+  tmpptr = dynamic_cast<const QwVQWK_Channel*>(&source);
   if (tmpptr!=NULL){
     *this -= *tmpptr;
   } else {
@@ -1114,10 +1114,10 @@ VQwHardwareChannel& QwVQWK_Channel::operator-=(const VQwHardwareChannel *source)
   }
   return *this;
 }
-VQwHardwareChannel& QwVQWK_Channel::operator*=(const VQwHardwareChannel *source)
+VQwHardwareChannel& QwVQWK_Channel::operator*=(const VQwHardwareChannel &source)
 {
   const QwVQWK_Channel* tmpptr;
-  tmpptr = dynamic_cast<const QwVQWK_Channel*>(source);
+  tmpptr = dynamic_cast<const QwVQWK_Channel*>(&source);
   if (tmpptr!=NULL){
     *this *= *tmpptr;
   } else {
@@ -1128,10 +1128,10 @@ VQwHardwareChannel& QwVQWK_Channel::operator*=(const VQwHardwareChannel *source)
   }
   return *this;
 }
-VQwHardwareChannel& QwVQWK_Channel::operator/=(const VQwHardwareChannel *source)
+VQwHardwareChannel& QwVQWK_Channel::operator/=(const VQwHardwareChannel &source)
 {
   const QwVQWK_Channel* tmpptr;
-  tmpptr = dynamic_cast<const QwVQWK_Channel*>(source);
+  tmpptr = dynamic_cast<const QwVQWK_Channel*>(&source);
   if (tmpptr!=NULL){
     *this /= *tmpptr;
   } else {

--- a/Parity/src/QwBeamMod.cc
+++ b/Parity/src/QwBeamMod.cc
@@ -650,7 +650,7 @@ VQwSubsystem&  QwBeamMod::operator+=  (VQwSubsystem *value)
       QwBeamMod* input = dynamic_cast<QwBeamMod*>(value);
 
       for(size_t i=0;i<input->fModChannel.size();i++)
-	*(this->fModChannel[i]) += input->fModChannel[i];
+	*(this->fModChannel[i]) += *(input->fModChannel[i]);
 //         for(size_t i=0;i<input->fWord.size();i++)
 //    	this->fWord[i]+=input->fWord[i];
       this->fFFB_ErrorFlag |= input->fFFB_ErrorFlag;
@@ -667,7 +667,7 @@ VQwSubsystem&  QwBeamMod::operator-=  (VQwSubsystem *value){
       QwBeamMod* input = dynamic_cast<QwBeamMod*>(value);
 
       for(size_t i=0;i<input->fModChannel.size();i++)
-	*(this->fModChannel[i]) -= input->fModChannel[i];
+	*(this->fModChannel[i]) -= *(input->fModChannel[i]);
 //       for(size_t i=0;i<input->fWord.size();i++)
 //         this->fWord[i]-=input->fWord[i];
       this->fFFB_ErrorFlag |= input->fFFB_ErrorFlag;

--- a/Parity/src/QwCombinedBPM.cc
+++ b/Parity/src/QwCombinedBPM.cc
@@ -749,7 +749,7 @@ void QwCombinedBPM<T>::GetProjectedPosition(VQwBPM *device)
       else continue;
       (device->GetPosition(axis))->ClearEventData();
       (device->GetPosition(axis))->AssignScaledValue(fSlope[axis],device->GetPositionInZ());
-      (device->GetPosition(axis))->operator+=(&fIntercept[axis]);
+      (device->GetPosition(axis))->operator+=(fIntercept[axis]);
    }
    // Maybe we should apply resolution smearing to the stripline BPMs?
    // device->PrintInfo();

--- a/Parity/src/QwEnergyCalculator.cc
+++ b/Parity/src/QwEnergyCalculator.cc
@@ -157,7 +157,7 @@ void QwEnergyCalculator::GetProjectedPosition(VQwBPM *device)
       }
      tmp.Scale(fTMatrixRatio[i]);
      //  And subtract it from the device we are trying to get the position of.
-     (device->GetPosition(VQwBPM::kXAxis))->operator-=(&tmp);
+     (device->GetPosition(VQwBPM::kXAxis))->operator-=(tmp);
    }
   } // end of for(UInt_t i = 0; i<fProperty.size(); i++)
 


### PR DESCRIPTION
This PR changes the non-standard operators that take a pointer as argument to be more standard operators on const references. Standard patterns cause the compiler to recognize opportunities for optimization.