### PR TITLE
Remove unused Sum and Difference methods from multiple channel classes

### DIFF
--- a/Analysis/include/QwADC18_Channel.h
+++ b/Analysis/include/QwADC18_Channel.h
@@ -145,8 +145,6 @@ class QwADC18_Channel: public VQwHardwareChannel, public MQwMockable {
   const QwADC18_Channel operator+ (const QwADC18_Channel &value) const;
   const QwADC18_Channel operator- (const QwADC18_Channel &value) const;
   const QwADC18_Channel operator* (const QwADC18_Channel &value) const;
-  void Sum(const QwADC18_Channel &value1, const QwADC18_Channel &value2);
-  void Difference(const QwADC18_Channel &value1, const QwADC18_Channel &value2);
   void Ratio(const QwADC18_Channel &numer, const QwADC18_Channel &denom);
   void Product(const QwADC18_Channel &value1, const QwADC18_Channel &value2);
   void DivideBy(const QwADC18_Channel& denom);

--- a/Analysis/include/QwMollerADC_Channel.h
+++ b/Analysis/include/QwMollerADC_Channel.h
@@ -140,7 +140,6 @@ class QwMollerADC_Channel: public VQwHardwareChannel, public MQwMockable {
 
 
   QwMollerADC_Channel& operator=  (const QwMollerADC_Channel &value);
-  //  VQwHardwareChannel& operator=  (const VQwHardwareChannel &value);
   void AssignScaledValue(const QwMollerADC_Channel &value, Double_t scale);
   void AssignValueFrom(const VQwDataElement* valueptr);
   void AddValueFrom(const VQwHardwareChannel* valueptr);
@@ -161,8 +160,6 @@ class QwMollerADC_Channel: public VQwHardwareChannel, public MQwMockable {
   const QwMollerADC_Channel operator+ (const QwMollerADC_Channel &value) const;
   const QwMollerADC_Channel operator- (const QwMollerADC_Channel &value) const;
   const QwMollerADC_Channel operator* (const QwMollerADC_Channel &value) const;
-  void Sum(const QwMollerADC_Channel &value1, const QwMollerADC_Channel &value2);
-  void Difference(const QwMollerADC_Channel &value1, const QwMollerADC_Channel &value2);
   void Ratio(const QwMollerADC_Channel &numer, const QwMollerADC_Channel &denom);
   void Product(const QwMollerADC_Channel &value1, const QwMollerADC_Channel &value2);
   void DivideBy(const QwMollerADC_Channel& denom);

--- a/Analysis/include/QwPromptSummary.h
+++ b/Analysis/include/QwPromptSummary.h
@@ -140,7 +140,6 @@ class QwPromptSummary  :  public TObject
   //  friend std::ostream& operator<<(std::ostream& os, const QwF1TDC &f1tdc);
 
 
-  Int_t                    fNElements;
   std::vector<PromptSummaryElement*> fElementList; 
 
   void SetRunNumber(const Int_t in) {fRunNumber = in;};
@@ -167,9 +166,9 @@ class QwPromptSummary  :  public TObject
 
   void FillDoubleDifference(TString type, TString name1, TString name2);
 
-  Int_t  GetSize()         const {return fNElements;};
-  Int_t  Size()            const {return fNElements;};
-  Int_t  HowManyElements() const {return fNElements;};
+  Int_t  GetSize()         const {return fElementList.size();};
+  Int_t  Size()            const {return fElementList.size();};
+  Int_t  HowManyElements() const {return fElementList.size();};
 
 
   void PrintCSV(Int_t nEvents, TString start_time, TString end_time);

--- a/Analysis/include/QwPromptSummary.h
+++ b/Analysis/include/QwPromptSummary.h
@@ -140,7 +140,8 @@ class QwPromptSummary  :  public TObject
   //  friend std::ostream& operator<<(std::ostream& os, const QwF1TDC &f1tdc);
 
 
-  std::vector<PromptSummaryElement*> fElementList; 
+  std::map<TString, PromptSummaryElement*> fElementList;
+  PromptSummaryElement* fReferenceElement{nullptr};
 
   void SetRunNumber(const Int_t in) {fRunNumber = in;};
   const Int_t GetRunNumber() {return fRunNumber;};

--- a/Analysis/include/QwScaler_Channel.h
+++ b/Analysis/include/QwScaler_Channel.h
@@ -146,7 +146,6 @@ public:
   void MultiplyBy(const VQwHardwareChannel* valueptr);
   void DivideBy(const VQwHardwareChannel* valueptr);
 
-  //  VQwHardwareChannel& operator=  (const VQwHardwareChannel &data_value);
   VQwScaler_Channel& operator+= (const VQwScaler_Channel &value);
   VQwScaler_Channel& operator-= (const VQwScaler_Channel &value);
   VQwScaler_Channel& operator*= (const VQwScaler_Channel &value);
@@ -156,8 +155,6 @@ public:
   VQwHardwareChannel& operator*=(const VQwHardwareChannel* input);
   VQwHardwareChannel& operator/=(const VQwHardwareChannel* input);
 
-  void Sum(VQwScaler_Channel &value1, VQwScaler_Channel &value2);
-  void Difference(VQwScaler_Channel &value1, VQwScaler_Channel &value2);
   void Ratio(const VQwScaler_Channel &numer, const VQwScaler_Channel &denom);
   void Product(VQwScaler_Channel &numer, VQwScaler_Channel &denom);
   void AddChannelOffset(Double_t Offset);

--- a/Analysis/include/QwVQWK_Channel.h
+++ b/Analysis/include/QwVQWK_Channel.h
@@ -143,8 +143,7 @@ class QwVQWK_Channel: public VQwHardwareChannel, public MQwMockable {
   void  ProcessEvent();
 
 
-  QwVQWK_Channel& operator=  (const QwVQWK_Channel &value);
-  //  VQwHardwareChannel& operator=  (const VQwHardwareChannel &value);
+  QwVQWK_Channel& operator=(const QwVQWK_Channel &value);
   void AssignScaledValue(const QwVQWK_Channel &value, Double_t scale);
   void AssignValueFrom(const VQwDataElement* valueptr);
   void AddValueFrom(const VQwHardwareChannel* valueptr);
@@ -165,8 +164,6 @@ class QwVQWK_Channel: public VQwHardwareChannel, public MQwMockable {
   const QwVQWK_Channel operator+ (const QwVQWK_Channel &value) const;
   const QwVQWK_Channel operator- (const QwVQWK_Channel &value) const;
   const QwVQWK_Channel operator* (const QwVQWK_Channel &value) const;
-  void Sum(const QwVQWK_Channel &value1, const QwVQWK_Channel &value2);
-  void Difference(const QwVQWK_Channel &value1, const QwVQWK_Channel &value2);
   void Ratio(const QwVQWK_Channel &numer, const QwVQWK_Channel &denom);
   void Product(const QwVQWK_Channel &value1, const QwVQWK_Channel &value2);
   void DivideBy(const QwVQWK_Channel& denom);

--- a/Analysis/include/VQwDataElement.h
+++ b/Analysis/include/VQwDataElement.h
@@ -130,13 +130,15 @@ class VQwDataElement: public MQwHistograms {
     { std::cerr << "Operation -= not defined!" << std::endl; return *this; }
 
   /*! \brief Sum operator */
-  virtual void Sum(const VQwDataElement &value1, const VQwDataElement &value2)
+  template <typename T>
+  void Sum(const T &value1, const T &value2)
     { 
       *this =  value1;
       *this += value2;
     }
   /*! \brief Difference operator */
-  virtual void Difference(const VQwDataElement &value1, const VQwDataElement &value2)
+  template <typename T>
+  void Difference(const T &value1, const T &value2)
     { 
       *this =  value1;
       *this -= value2;

--- a/Analysis/include/VQwDataElement.h
+++ b/Analysis/include/VQwDataElement.h
@@ -102,7 +102,7 @@ class VQwDataElement: public MQwHistograms {
   virtual void LoadChannelParameters(QwParameterFile &paramfile){};
 
   virtual void LoadMockDataParameters(QwParameterFile &paramfile) {
-  std::cerr << "LoadMockDataParameters is not defined!" << std::endl;
+    std::cerr << "LoadMockDataParameters is not defined!" << std::endl;
   };
 
   /*! \brief Clear the event data in this element */
@@ -132,14 +132,12 @@ class VQwDataElement: public MQwHistograms {
   /*! \brief Sum operator */
   virtual void Sum(const VQwDataElement &value1, const VQwDataElement &value2)
     { 
-      //std::cerr << "Sum not defined!" << std::endl; 
       *this =  value1;
       *this += value2;
     }
   /*! \brief Difference operator */
   virtual void Difference(const VQwDataElement &value1, const VQwDataElement &value2)
     { 
-      //std::cerr << "Difference not defined!" << std::endl; 
       *this =  value1;
       *this -= value2;
     }

--- a/Analysis/include/VQwHardwareChannel.h
+++ b/Analysis/include/VQwHardwareChannel.h
@@ -170,6 +170,18 @@ public:
   virtual VQwHardwareChannel& operator*=(const VQwHardwareChannel* input) = 0;
   virtual VQwHardwareChannel& operator/=(const VQwHardwareChannel* input) = 0;
 
+  /*! \brief Sum operator */
+  void Sum(const VQwHardwareChannel &value1, const VQwHardwareChannel &value2)
+  { 
+    *this =   value1;
+    *this += &value2;
+  }
+  /*! \brief Difference operator */
+  void Difference(const VQwHardwareChannel &value1, const VQwHardwareChannel &value2)
+  { 
+    *this =   value1;
+    *this -= &value2;
+  }
 
   virtual void ScaledAdd(Double_t scale, const VQwHardwareChannel *value) = 0;
 

--- a/Analysis/src/QwADC18_Channel.cc
+++ b/Analysis/src/QwADC18_Channel.cc
@@ -947,20 +947,6 @@ VQwHardwareChannel& QwADC18_Channel::operator/=(const VQwHardwareChannel *source
   }
   return *this;
 }
-
-
-void QwADC18_Channel::Sum(const QwADC18_Channel &value1, const QwADC18_Channel &value2)
-{
-  *this  = value1;
-  *this += value2;
-}
-
-void QwADC18_Channel::Difference(const QwADC18_Channel &value1, const QwADC18_Channel &value2)
-{
-  *this  = value1;
-  *this -= value2;
-}
-
 void QwADC18_Channel::Ratio(const QwADC18_Channel &numer, const QwADC18_Channel &denom)
 {
   if (!IsNameEmpty()) {

--- a/Analysis/src/QwMollerADC_Channel.cc
+++ b/Analysis/src/QwMollerADC_Channel.cc
@@ -1365,20 +1365,6 @@ VQwHardwareChannel& QwMollerADC_Channel::operator/=(const VQwHardwareChannel *so
   }
   return *this;
 }
-
-
-void QwMollerADC_Channel::Sum(const QwMollerADC_Channel &value1, const QwMollerADC_Channel &value2)
-{
-  *this  = value1;
-  *this += value2;
-}
-
-void QwMollerADC_Channel::Difference(const QwMollerADC_Channel &value1, const QwMollerADC_Channel &value2)
-{
-  *this  = value1;
-  *this -= value2;
-}
-
 void QwMollerADC_Channel::Ratio(const QwMollerADC_Channel &numer, const QwMollerADC_Channel &denom)
 {
   if (!IsNameEmpty()) {

--- a/Analysis/src/QwPMT_Channel.cc
+++ b/Analysis/src/QwPMT_Channel.cc
@@ -135,6 +135,7 @@ void  QwPMT_Channel::FillTreeVector(std::vector<Double_t> &values) const
 QwPMT_Channel& QwPMT_Channel::operator= (const QwPMT_Channel &value){
   if (this != &value) {
     if (GetElementName()!=""){
+      VQwDataElement::operator=(value);
       this->fValue  = value.fValue;
     }
   }

--- a/Analysis/src/QwPromptSummary.cc
+++ b/Analysis/src/QwPromptSummary.cc
@@ -113,7 +113,7 @@ if (type.Contains("asy")&& !(dd||da)){
       out = Form("%20s | Mean: %8.3f +/- %8.3f \t Width: %8.3f\n", fElementName.Data(), fAsymDiff, fAsymDiffError, fAsymDiffWidth);
 }
 if (type.Contains("double")&& (dd||da)) {
-     	out = Form ("%20s | Mean: %8.3f +/- %8.3f \t Width: %8.3f\n", fElementName.Data(), fAsymDiff, fAsymDiffError, fAsymDiffWidth);
+     	out = Form("%20s | Mean: %8.3f +/- %8.3f \t Width: %8.3f\n", fElementName.Data(), fAsymDiff, fAsymDiffError, fAsymDiffWidth);
 }     
 
 
@@ -184,9 +184,6 @@ QwPromptSummary::QwPromptSummary()
   fRunNumber    = 0;
   fRunletNumber = 0;
  
- 
-  fNElements = 0;
-
   fLocalDebug = kTRUE;
   
   this->SetupElementList();
@@ -199,9 +196,6 @@ QwPromptSummary::QwPromptSummary(Int_t run_number, Int_t runlet_number)
   fRunNumber    = run_number;
   fRunletNumber = runlet_number;
 
- 
-  fNElements = 0;
-
   fLocalDebug = kFALSE;
   
   this->SetupElementList();
@@ -213,9 +207,6 @@ QwPromptSummary::QwPromptSummary(Int_t run_number, Int_t runlet_number, const st
 {
   fRunNumber    = run_number;
   fRunletNumber = runlet_number;
-
- 
-  fNElements = 0;
 
   fLocalDebug = kFALSE;
   
@@ -245,8 +236,8 @@ QwPromptSummary::SetupElementList()
   try {
     QwParameterFile paramfile(default_param_file);
     LoadElementsFromParameterFile(paramfile);
-    if (fNElements > 0) {
-      QwMessage << "QwPromptSummary: Loaded " << fNElements << " elements from " << default_param_file << QwLog::endl;
+    if (fElementList.size() > 0) {
+      QwMessage << "QwPromptSummary: Loaded " << fElementList.size() << " elements from " << default_param_file << QwLog::endl;
       return; // Successfully loaded from file
     }
   } catch (const std::exception& e) {
@@ -255,38 +246,6 @@ QwPromptSummary::SetupElementList()
                 << ", using default elements: " << e.what() << QwLog::endl;
     }
   }
-  
-  // Fall back to default hard-coded elements if parameter file not found or empty
-  QwMessage << "QwPromptSummary: Using default hard-coded element list" << QwLog::endl;
-  
-  // Add the originally commented out elements
-  this->AddElement(new PromptSummaryElement("bcm_an_us"));
-  this->AddElement(new PromptSummaryElement("bcm_an_ds"));
-  this->AddElement(new PromptSummaryElement("bcm_an_ds3"));
-  this->AddElement(new PromptSummaryElement("bcm_an_ds10"));
-  this->AddElement(new PromptSummaryElement("bcm_dg_us"));
-  this->AddElement(new PromptSummaryElement("bcm_dg_ds"));
-  
-  this->AddElement(new PromptSummaryElement("bcm_an_us-bcm_an_ds"));
-  this->AddElement(new PromptSummaryElement("bcm_an_us-bcm_an_ds3"));
-  this->AddElement(new PromptSummaryElement("bcm_an_us-bcm_an_ds10"));
-  this->AddElement(new PromptSummaryElement("bcm_an_us-bcm_dg_us"));
-  this->AddElement(new PromptSummaryElement("bcm_an_us-bcm_dg_ds"));
-  
-  this->AddElement(new PromptSummaryElement("bcm_an_ds-bcm_an_ds3"));
-  this->AddElement(new PromptSummaryElement("bcm_an_ds-bcm_an_ds10"));
-  this->AddElement(new PromptSummaryElement("bcm_an_ds-bcm_dg_us"));
-  this->AddElement(new PromptSummaryElement("bcm_an_ds-bcm_dg_ds"));
-  
-  this->AddElement(new PromptSummaryElement("bcm_an_ds3-bcm_an_ds10"));
-  this->AddElement(new PromptSummaryElement("bcm_an_ds3-bcm_dg_us"));
-  this->AddElement(new PromptSummaryElement("bcm_an_ds3-bcm_dg_ds"));
-
-  this->AddElement(new PromptSummaryElement("bcm_an_ds10-bcm_dg_us"));
-  this->AddElement(new PromptSummaryElement("bcm_an_ds10-bcm_dg_ds"));
-
-  this->AddElement(new PromptSummaryElement("bcm_dg_us-bcm_dg_ds"));
-
 };
 
 
@@ -368,22 +327,17 @@ QwPromptSummary::LoadElementsFromParameterFile(QwParameterFile& parameterfile)
     delete section;
   }
   
-  QwMessage << "QwPromptSummary: Loaded " << fNElements << " elements from parameter file" << QwLog::endl;
+  QwMessage << "QwPromptSummary: Loaded " << fElementList.size() << " elements from parameter file" << QwLog::endl;
 };
 
 
 void 
 QwPromptSummary::AddElement(PromptSummaryElement *in)
 {
-  Int_t pos = 0;
-
   fElementList.push_back(in);
   if(fLocalDebug) {
-    printf("AddElement at pos %d\n", pos);
+    printf("AddElement at pos %d\n", fElementList.size()-1);
   }
-
-  fNElements++;
-  return;
 };
 
 

--- a/Analysis/src/QwSIS3320_Accumulator.cc
+++ b/Analysis/src/QwSIS3320_Accumulator.cc
@@ -182,9 +182,12 @@ const QwSIS3320_Accumulator QwSIS3320_Accumulator::operator- (const QwSIS3320_Ac
  */
 QwSIS3320_Accumulator& QwSIS3320_Accumulator::operator= (const QwSIS3320_Accumulator &value)
 {
-  if (!IsNameEmpty()) {
-    this->fAccumulatorSum = value.fAccumulatorSum;
-    this->fNumberOfSamples = value.fNumberOfSamples;
+  if (this != &value) {
+    if (!IsNameEmpty()) {
+      VQwDataElement::operator=(value);
+      this->fAccumulatorSum = value.fAccumulatorSum;
+      this->fNumberOfSamples = value.fNumberOfSamples;
+    }
   }
   return *this;
 }

--- a/Analysis/src/QwScaler_Channel.cc
+++ b/Analysis/src/QwScaler_Channel.cc
@@ -626,17 +626,6 @@ VQwHardwareChannel& VQwScaler_Channel::operator/=(const VQwHardwareChannel *sour
   return *this;
 }
 
-void VQwScaler_Channel::Sum(VQwScaler_Channel &value1, VQwScaler_Channel &value2)
-{
-  *this =  value1;
-  *this += value2;
-}
-
-void VQwScaler_Channel::Difference(VQwScaler_Channel &value1, VQwScaler_Channel &value2){
-  *this =  value1;
-  *this -= value2;
-}
-
 void VQwScaler_Channel::Ratio(const VQwScaler_Channel &numer, const VQwScaler_Channel &denom)
 {
   if (!IsNameEmpty()){

--- a/Analysis/src/QwVQWK_Channel.cc
+++ b/Analysis/src/QwVQWK_Channel.cc
@@ -1301,19 +1301,6 @@ VQwHardwareChannel& QwVQWK_Channel::operator/=(const VQwHardwareChannel *source)
   return *this;
 }
 
-
-void QwVQWK_Channel::Sum(const QwVQWK_Channel &value1, const QwVQWK_Channel &value2)
-{
-  *this  = value1;
-  *this += value2;
-}
-
-void QwVQWK_Channel::Difference(const QwVQWK_Channel &value1, const QwVQWK_Channel &value2)
-{
-  *this  = value1;
-  *this -= value2;
-}
-
 void QwVQWK_Channel::Ratio(const QwVQWK_Channel &numer, const QwVQWK_Channel &denom)
 {
   if (!IsNameEmpty()) {


### PR DESCRIPTION
This PR removes the unused Sum and Difference functions in all classes derived from VQwHardwareChannel, and relies on virtual dispatch to pick the correct operator. 