### PR TITLE
Update Doxyfile to restrict the input directories for documentation

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -791,7 +791,12 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  =
+INPUT                  = Feedback \
+                         Analysis \
+                         Parity \
+                         cmake \
+                         evio \
+                         README.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
This PR restricts the doxygen documentation to the following:
```
Feedback \
Analysis \
Parity \
cmake \
evio \
README.md
```