### PR TITLE
Fix prompt summary handling for combined BCM/BPM

### DIFF
--- a/Analysis/include/QwPromptSummary.h
+++ b/Analysis/include/QwPromptSummary.h
@@ -140,7 +140,6 @@ class QwPromptSummary  :  public TObject
   //  friend std::ostream& operator<<(std::ostream& os, const QwF1TDC &f1tdc);
 
 
-  Int_t                    fNElements;
   std::vector<PromptSummaryElement*> fElementList; 
 
   void SetRunNumber(const Int_t in) {fRunNumber = in;};
@@ -167,9 +166,9 @@ class QwPromptSummary  :  public TObject
 
   void FillDoubleDifference(TString type, TString name1, TString name2);
 
-  Int_t  GetSize()         const {return fNElements;};
-  Int_t  Size()            const {return fNElements;};
-  Int_t  HowManyElements() const {return fNElements;};
+  Int_t  GetSize()         const {return fElementList.size();};
+  Int_t  Size()            const {return fElementList.size();};
+  Int_t  HowManyElements() const {return fElementList.size();};
 
 
   void PrintCSV(Int_t nEvents, TString start_time, TString end_time);

--- a/Analysis/include/QwPromptSummary.h
+++ b/Analysis/include/QwPromptSummary.h
@@ -140,7 +140,8 @@ class QwPromptSummary  :  public TObject
   //  friend std::ostream& operator<<(std::ostream& os, const QwF1TDC &f1tdc);
 
 
-  std::vector<PromptSummaryElement*> fElementList; 
+  std::map<TString, PromptSummaryElement*> fElementList;
+  PromptSummaryElement* fReferenceElement{nullptr};
 
   void SetRunNumber(const Int_t in) {fRunNumber = in;};
   Int_t GetRunNumber() {return fRunNumber;};

--- a/Analysis/src/QwPromptSummary.cc
+++ b/Analysis/src/QwPromptSummary.cc
@@ -113,7 +113,7 @@ if (type.Contains("asy")&& !(dd||da)){
       out = Form("%20s | Mean: %8.3f +/- %8.3f \t Width: %8.3f\n", fElementName.Data(), fAsymDiff, fAsymDiffError, fAsymDiffWidth);
 }
 if (type.Contains("double")&& (dd||da)) {
-     	out = Form ("%20s | Mean: %8.3f +/- %8.3f \t Width: %8.3f\n", fElementName.Data(), fAsymDiff, fAsymDiffError, fAsymDiffWidth);
+     	out = Form("%20s | Mean: %8.3f +/- %8.3f \t Width: %8.3f\n", fElementName.Data(), fAsymDiff, fAsymDiffError, fAsymDiffWidth);
 }     
 
 
@@ -184,9 +184,6 @@ QwPromptSummary::QwPromptSummary()
   fRunNumber    = 0;
   fRunletNumber = 0;
  
- 
-  fNElements = 0;
-
   fLocalDebug = kTRUE;
   
   this->SetupElementList();
@@ -199,9 +196,6 @@ QwPromptSummary::QwPromptSummary(Int_t run_number, Int_t runlet_number)
   fRunNumber    = run_number;
   fRunletNumber = runlet_number;
 
- 
-  fNElements = 0;
-
   fLocalDebug = kFALSE;
   
   this->SetupElementList();
@@ -213,9 +207,6 @@ QwPromptSummary::QwPromptSummary(Int_t run_number, Int_t runlet_number, const st
 {
   fRunNumber    = run_number;
   fRunletNumber = runlet_number;
-
- 
-  fNElements = 0;
 
   fLocalDebug = kFALSE;
   
@@ -245,8 +236,8 @@ QwPromptSummary::SetupElementList()
   try {
     QwParameterFile paramfile(default_param_file);
     LoadElementsFromParameterFile(paramfile);
-    if (fNElements > 0) {
-      QwMessage << "QwPromptSummary: Loaded " << fNElements << " elements from " << default_param_file << QwLog::endl;
+    if (fElementList.size() > 0) {
+      QwMessage << "QwPromptSummary: Loaded " << fElementList.size() << " elements from " << default_param_file << QwLog::endl;
       return; // Successfully loaded from file
     }
   } catch (const std::exception& e) {
@@ -255,38 +246,6 @@ QwPromptSummary::SetupElementList()
                 << ", using default elements: " << e.what() << QwLog::endl;
     }
   }
-  
-  // Fall back to default hard-coded elements if parameter file not found or empty
-  QwMessage << "QwPromptSummary: Using default hard-coded element list" << QwLog::endl;
-  
-  // Add the originally commented out elements
-  this->AddElement(new PromptSummaryElement("bcm_an_us"));
-  this->AddElement(new PromptSummaryElement("bcm_an_ds"));
-  this->AddElement(new PromptSummaryElement("bcm_an_ds3"));
-  this->AddElement(new PromptSummaryElement("bcm_an_ds10"));
-  this->AddElement(new PromptSummaryElement("bcm_dg_us"));
-  this->AddElement(new PromptSummaryElement("bcm_dg_ds"));
-  
-  this->AddElement(new PromptSummaryElement("bcm_an_us-bcm_an_ds"));
-  this->AddElement(new PromptSummaryElement("bcm_an_us-bcm_an_ds3"));
-  this->AddElement(new PromptSummaryElement("bcm_an_us-bcm_an_ds10"));
-  this->AddElement(new PromptSummaryElement("bcm_an_us-bcm_dg_us"));
-  this->AddElement(new PromptSummaryElement("bcm_an_us-bcm_dg_ds"));
-  
-  this->AddElement(new PromptSummaryElement("bcm_an_ds-bcm_an_ds3"));
-  this->AddElement(new PromptSummaryElement("bcm_an_ds-bcm_an_ds10"));
-  this->AddElement(new PromptSummaryElement("bcm_an_ds-bcm_dg_us"));
-  this->AddElement(new PromptSummaryElement("bcm_an_ds-bcm_dg_ds"));
-  
-  this->AddElement(new PromptSummaryElement("bcm_an_ds3-bcm_an_ds10"));
-  this->AddElement(new PromptSummaryElement("bcm_an_ds3-bcm_dg_us"));
-  this->AddElement(new PromptSummaryElement("bcm_an_ds3-bcm_dg_ds"));
-
-  this->AddElement(new PromptSummaryElement("bcm_an_ds10-bcm_dg_us"));
-  this->AddElement(new PromptSummaryElement("bcm_an_ds10-bcm_dg_ds"));
-
-  this->AddElement(new PromptSummaryElement("bcm_dg_us-bcm_dg_ds"));
-
 };
 
 
@@ -368,22 +327,17 @@ QwPromptSummary::LoadElementsFromParameterFile(QwParameterFile& parameterfile)
     delete section;
   }
   
-  QwMessage << "QwPromptSummary: Loaded " << fNElements << " elements from parameter file" << QwLog::endl;
+  QwMessage << "QwPromptSummary: Loaded " << fElementList.size() << " elements from parameter file" << QwLog::endl;
 };
 
 
 void 
 QwPromptSummary::AddElement(PromptSummaryElement *in)
 {
-  Int_t pos = 0;
-
   fElementList.push_back(in);
   if(fLocalDebug) {
-    printf("AddElement at pos %d\n", pos);
+    printf("AddElement at pos %d\n", fElementList.size()-1);
   }
-
-  fNElements++;
-  return;
 };
 
 

--- a/Analysis/src/QwPromptSummary.cc
+++ b/Analysis/src/QwPromptSummary.cc
@@ -358,8 +358,8 @@ QwPromptSummary::GetElementByName(TString name)
     }
     return an_element;
   } else {
-      std::cout << "System " << name
-                << " QwPromptSummary::GetElementByName not found" << std::endl;
+      QwDebug << "System " << name
+              << " QwPromptSummary::GetElementByName not found" << std::endl;
   }
   return NULL;
 };

--- a/Parity/prminput/mock_beamline_combiner.map
+++ b/Parity/prminput/mock_beamline_combiner.map
@@ -1,0 +1,16 @@
+# Differences
+[diff:@diff_bcm1h02a_bcm1h15]
+diff:bcm1h02a, 1
+diff:bcm1h15, -1
+
+[diff:@diff_bcm_target_bcm1h15]
+diff:bcm_target, 1
+diff:bcm1h15, -1
+
+[diff:@diff_bpm1h04x_bpm1h14x]
+diff:bpm1h04x, 1
+diff:bpm1h14x, -1
+
+[diff:@diff_bpm1h04x_bpm1h14y]
+diff:bpm1h04x, 1
+diff:bpm1h14y, -1

--- a/Parity/prminput/mock_beamline_combiner.map
+++ b/Parity/prminput/mock_beamline_combiner.map
@@ -8,9 +8,9 @@ diff:bcm_target, 1
 diff:bcm1h15, -1
 
 [diff:@diff_bpm1h04x_bpm1h14x]
-diff:bpm1h04x, 1
-diff:bpm1h14x, -1
+diff:bpm1h04X, 1
+diff:bpm1h14X, -1
 
 [diff:@diff_bpm1h04x_bpm1h14y]
-diff:bpm1h04x, 1
-diff:bpm1h14y, -1
+diff:bpm1h04X, 1
+diff:bpm1h14Y, -1

--- a/Parity/prminput/mock_datahandlers.map
+++ b/Parity/prminput/mock_datahandlers.map
@@ -22,4 +22,8 @@
   alias-path = .
   disable-histos = true
   tree-name  = lrb_std
- tree-comment = Correlations
+  tree-comment = Correlations
+
+[QwCombiner]
+  name = beamline_combiner
+  map  = mock_beamline_combiner.map

--- a/Parity/prminput/prompt_summary.map
+++ b/Parity/prminput/prompt_summary.map
@@ -29,10 +29,10 @@ bpm_targetx
 bpm_targety
 bpm1h04x
 bpm1h04y
-bcm1h02a-bcm1h15
-bcm_target-bcm1h15
-bpm1h04x-bpm1h14x
-bpm1h04x-bpm1h14y
+diff_bcm1h02a_bcm1h15
+diff_bcm_target_bcm1h15
+diff_bpm1h04x_bpm1h14x
+diff_bpm1h04x_bpm1h14y
 
 ! Additional elements can be added here
 ! Examples:

--- a/Parity/prminput/prompt_summary.map
+++ b/Parity/prminput/prompt_summary.map
@@ -25,8 +25,10 @@ bcm1h12c
 bcm1h13
 bcm1h15
 bcm_target
-bpm1h04
+bpm_targetx
+bpm_targety
 bpm1h04x
+bpm1h04y
 bcm1h02a-bcm1h15
 bcm_target-bcm1h15
 bpm1h04x-bpm1h14x

--- a/Parity/src/QwBeamLine.cc
+++ b/Parity/src/QwBeamLine.cc
@@ -3186,8 +3186,9 @@ void QwBeamLine::WritePromptSummary(QwPromptSummary *ps, TString type)
     // Add combined BCMs
     for (size_t i = 0; i < fBCMCombo.size();  i++) {
       tmp_channel = GetChannel(kQwCombinedBCM, i,"");	
-      element_name        = tmp_channel->GetElementName();
-      element_value       = 0.0;
+      // Need to change this to add other BCMs in summary
+      static const TString kTargetBCMName = "bcm_target";
+      local_add_these_elements =  element_name.EqualTo(kTargetBCMName);
       element_value_err   = 0.0;
       element_value_width = 0.0;
 
@@ -3236,15 +3237,15 @@ void QwBeamLine::WritePromptSummary(QwPromptSummary *ps, TString type)
 
       
       if(local_ps_element) {
-	element_value       = tmp_channel->GetValue();
-	element_value_err   = tmp_channel->GetValueError();
-	element_value_width = tmp_channel->GetValueWidth();
+        element_value       = tmp_channel->GetValue();
+        element_value_err   = tmp_channel->GetValueError();
+        element_value_width = tmp_channel->GetValueWidth();
 	
-	local_ps_element->Set(type, element_value, element_value_err, element_value_width);
+        local_ps_element->Set(type, element_value, element_value_err, element_value_width);
       }
       
       if( local_print_flag && local_ps_element) {
-	printf("Type %12s, Element %32s, value %12.4e error %8.4e  width %12.4e\n", 
+        printf("Type %12s, Element %32s, value %12.4e error %8.4e  width %12.4e\n", 
 	       type.Data(), element_name.Data(), element_value, element_value_err, element_value_width);
       }
     }
@@ -3268,7 +3269,17 @@ void QwBeamLine::WritePromptSummary(QwPromptSummary *ps, TString type)
       element_value_err   = 0.0;
       element_value_width = 0.0;
 
-      local_add_these_elements=element_name.Contains("bpm4")||element_name.Contains("bpm18")||element_name.Contains("bpm14")||element_name.Contains("bpm12"); //Need to change this to add other stripline BPMs in summary
+      // List of BPM names to include in the summary (move to config if needed)
+      static const std::vector<TString> kSummaryBPMNames = {
+        "bpm4", "bpm18", "bpm14", "bpm12"
+      };
+      local_add_these_elements = false;
+      for (const auto& bpm_name : kSummaryBPMNames) {
+        if (element_name.Contains(bpm_name)) {
+          local_add_these_elements = true;
+          break;
+        }
+      }
 
       if( local_add_these_elements && local_add_element){
       	ps->AddElement(new PromptSummaryElement(element_name)); 

--- a/Parity/src/QwBeamLine.cc
+++ b/Parity/src/QwBeamLine.cc
@@ -3254,10 +3254,11 @@ void QwBeamLine::WritePromptSummary(QwPromptSummary *ps, TString type)
 
   
   char property[2][6]={"x","y"};
+
   local_ps_element=NULL;
   local_add_these_elements=false;
   
-  
+  // Add BPM striplines
   for(size_t i=0; i< fStripline.size(); i++) 
      {
      for (Int_t j=0;j<2;j++){
@@ -3278,21 +3279,53 @@ void QwBeamLine::WritePromptSummary(QwPromptSummary *ps, TString type)
           
      
       if(local_ps_element) {
-	element_value       = tmp_channel->GetValue();
-	element_value_err   = tmp_channel->GetValueError();
-	element_value_width = tmp_channel->GetValueWidth();
-	local_ps_element->Set(type, element_value, element_value_err, element_value_width);
+        element_value       = tmp_channel->GetValue();
+        element_value_err   = tmp_channel->GetValueError();
+        element_value_width = tmp_channel->GetValueWidth();
+        local_ps_element->Set(type, element_value, element_value_err, element_value_width);
       }
       
       if( local_print_flag && local_ps_element) {
-	printf("Type %12s, Element %32s, value %12.4e error %8.4e  width %12.4e\n", 
-	       type.Data(), element_name.Data(), element_value, element_value_err, element_value_width);
+        printf("Type %12s, Element %32s, value %12.4e error %8.4e  width %12.4e\n", 
+	      type.Data(), element_name.Data(), element_value, element_value_err, element_value_width);
       }
 
       }
     }
 
-  
-  
-    return;
+  // Add combined BPM striplines
+  for(size_t i=0; i< fBPMCombo.size(); i++) 
+     {
+     for (Int_t j=0;j<2;j++){
+      tmp_channel= GetChannel(kQwCombinedBPM, i, property[j]);   
+      element_name= tmp_channel->GetElementName();
+      element_value       = 0.0;
+      element_value_err   = 0.0;
+      element_value_width = 0.0;
+
+      local_add_these_elements=element_name.Contains("bpm4")||element_name.Contains("bpm18")||element_name.Contains("bpm14")||element_name.Contains("bpm12"); //Need to change this to add other stripline BPMs in summary
+
+      if( local_add_these_elements && local_add_element){
+      	ps->AddElement(new PromptSummaryElement(element_name)); 
+      }
+
+      local_ps_element=ps->GetElementByName(element_name);
+
+          
+     
+      if(local_ps_element) {
+        element_value       = tmp_channel->GetValue();
+        element_value_err   = tmp_channel->GetValueError();
+        element_value_width = tmp_channel->GetValueWidth();
+        local_ps_element->Set(type, element_value, element_value_err, element_value_width);
+      }
+      
+      if( local_print_flag && local_ps_element) {
+        printf("Type %12s, Element %32s, value %12.4e error %8.4e  width %12.4e\n", 
+	      type.Data(), element_name.Data(), element_value, element_value_err, element_value_width);
+      }
+
+      }
+    }
+
 };

--- a/Parity/src/QwBeamLine.cc
+++ b/Parity/src/QwBeamLine.cc
@@ -3150,6 +3150,7 @@ void QwBeamLine::WritePromptSummary(QwPromptSummary *ps, TString type)
   PromptSummaryElement *local_ps_element = NULL;
   Bool_t local_add_these_elements= false;
 
+  // Add BCMs
   for (size_t i = 0; i < fBCM.size();  i++) 
     {
       tmp_channel=GetChannel(kQwBCM, i,"");	
@@ -3169,20 +3170,53 @@ void QwBeamLine::WritePromptSummary(QwPromptSummary *ps, TString type)
 
       
       if(local_ps_element) {
-	element_value       = tmp_channel->GetValue();
-	element_value_err   = tmp_channel->GetValueError();
-	element_value_width = tmp_channel->GetValueWidth();
-	
-	local_ps_element->Set(type, element_value, element_value_err, element_value_width);
+        element_value       = tmp_channel->GetValue();
+        element_value_err   = tmp_channel->GetValueError();
+        element_value_width = tmp_channel->GetValueWidth();
+
+        local_ps_element->Set(type, element_value, element_value_err, element_value_width);
       }
       
       if( local_print_flag && local_ps_element) {
-	printf("Type %12s, Element %32s, value %12.4e error %8.4e  width %12.4e\n", 
-	       type.Data(), element_name.Data(), element_value, element_value_err, element_value_width);
+        printf("Type %12s, Element %32s, value %12.4e error %8.4e  width %12.4e\n", 
+          type.Data(), element_name.Data(), element_value, element_value_err, element_value_width);
       }
     }
 
-//Add BPM Cavity
+    // Add combined BCMs
+    for (size_t i = 0; i < fBCMCombo.size();  i++) {
+      tmp_channel = GetChannel(kQwCombinedBCM, i,"");	
+      element_name        = tmp_channel->GetElementName();
+      element_value       = 0.0;
+      element_value_err   = 0.0;
+      element_value_width = 0.0;
+
+      // Need to change this to add other BCMs in summary
+      local_add_these_elements =  element_name.EqualTo("bcm_target");
+
+      if(local_add_these_elements && local_add_element){
+      	ps->AddElement(new PromptSummaryElement(element_name)); 
+      }
+
+
+      local_ps_element=ps->GetElementByName(element_name);
+
+      
+      if(local_ps_element) {
+        element_value       = tmp_channel->GetValue();
+        element_value_err   = tmp_channel->GetValueError();
+        element_value_width = tmp_channel->GetValueWidth();
+
+        local_ps_element->Set(type, element_value, element_value_err, element_value_width);
+      }
+      
+      if( local_print_flag && local_ps_element) {
+        printf("Type %12s, Element %32s, value %12.4e error %8.4e  width %12.4e\n", 
+          type.Data(), element_name.Data(), element_value, element_value_err, element_value_width);
+      }
+    }
+
+  // Add BPM Cavity
   for (size_t i = 0; i < fCavity.size();  i++) 
     {
       tmp_channel=GetChannel(kQwBPMCavity, i,"ef");	


### PR DESCRIPTION
This PR adds combined BPM and BCM support in prompt summary (e.g. bcm_target, bpm_targetx, bpm_targety). This PR also moves fElementList to std::map for faster name-based lookups, and it makes those name-based lookups case insensitive.