### PR TITLE
Coda3EventDecoder: replace direct pointer access with memcpy for aligned data handling

### DIFF
--- a/Analysis/src/Coda3EventDecoder.cc
+++ b/Analysis/src/Coda3EventDecoder.cc
@@ -362,7 +362,7 @@ uint32_t Coda3EventDecoder::TBOBJ::Fill( const uint32_t* evbuffer,
 		memcpy(&evtNum, q++, sizeof(evtNum)); // uint64_t
 		if (withTimeStamp()) {
 			evTS = reinterpret_cast<const uint64_t*>(++q); // uint64_t[blkSize]
-			q += blksize-1;
+			q += 2*(blksize-1);
 		} else {
 		    evTS = nullptr;
 		}


### PR DESCRIPTION
This PR possibly(!) addresses issue #103. I don't have coda files to test this on.

I replaced the pointer arithmetic with memcpy which doesn't require aligned data. I think I got the offset right, but someone should check :)