### PR TITLE
Add calibration flag and avoid raw data handling for calibrated data in QwMollerADC_Channel

### DIFF
--- a/Analysis/include/QwMollerADC_Channel.h
+++ b/Analysis/include/QwMollerADC_Channel.h
@@ -310,17 +310,20 @@ private:
 
 
   /*! \name Event data members---Raw values */
-  // @{
-  Int_t fBlock_raw[4];      ///< Array of the sub-block data as read from the module
+  // @{ 
+  Int_t fBlock_raw[4];         ///< Array of the sub-block data as read from the module
   Int_t fHardwareBlockSum_raw; ///< Module-based sum of the four sub-blocks as read from the module
   Int_t fSoftwareBlockSum_raw; ///< Sum of the data in the four sub-blocks raw
   Long64_t fBlockSumSq_raw[5]; 
   Int_t fBlock_min[5];
   Int_t fBlock_max[5];
   Short_t fBlock_numSamples[5];
+  // @}
+
   /*! \name Event data members---Potentially calibrated values*/
   // @{
   // The following values potentially have pedestal removed  and calibration applied
+  Bool_t fCalibrated{kFALSE};  ///< Flag to indicate if the channel has been calibrated
   Double_t fBlock[4];          ///< Array of the sub-block data
   Double_t fHardwareBlockSum;  ///< Module-based sum of the four sub-blocks
   // @}

--- a/Analysis/include/QwMollerADC_Channel.h
+++ b/Analysis/include/QwMollerADC_Channel.h
@@ -323,7 +323,6 @@ private:
   /*! \name Event data members---Potentially calibrated values*/
   // @{
   // The following values potentially have pedestal removed  and calibration applied
-  Bool_t fCalibrated{kFALSE};  ///< Flag to indicate if the channel has been calibrated
   Double_t fBlock[4];          ///< Array of the sub-block data
   Double_t fHardwareBlockSum;  ///< Module-based sum of the four sub-blocks
   // @}

--- a/Analysis/include/VQwHardwareChannel.h
+++ b/Analysis/include/VQwHardwareChannel.h
@@ -180,6 +180,9 @@ public:
   void     SetCalibrationFactor(Double_t factor) { fCalibrationFactor = factor; kFoundGain = 1; };
   Double_t GetCalibrationFactor() const          { return fCalibrationFactor; };
 
+  Bool_t IsCalibrated() const {return fCalibrated;};
+  void SetCalibrated(Bool_t state=kTRUE){fCalibrated=state;};  
+
   void AddEntriesToList(std::vector<QwDBInterface> &row_list);
   virtual void AddErrEntriesToList(std::vector<QwErrDBInterface> & /*row_list*/) {};
 
@@ -269,6 +272,7 @@ protected:
 
   /*! \name Channel calibration                    */
   // @{
+  Bool_t fCalibrated{false}; /*!<Flag to indicate if the channel has been calibrated*/
   Double_t fPedestal; /*!< Pedestal of the hardware sum signal,
 			   we assume the pedestal level is constant over time
 			   and can be divided by four for use with each block,

--- a/Analysis/src/QwMollerADC_Channel.cc
+++ b/Analysis/src/QwMollerADC_Channel.cc
@@ -1313,7 +1313,9 @@ QwMollerADC_Channel& QwMollerADC_Channel::operator*= (const QwMollerADC_Channel 
           this->fBlockSumSq_raw[i] = value.fBlockSumSq_raw[i];
           this->fBlock_min[i] = value.fBlock_min[i];
           this->fBlock_max[i] = value.fBlock_max[i];
-        }
+          }
+        this->fHardwareBlockSum_raw *= value.fHardwareBlockSum_raw;
+        this->fSoftwareBlockSum_raw *= value.fSoftwareBlockSum_raw;
       }
     }
     // Both for calibrated and uncalibrated data

--- a/Analysis/src/QwMollerADC_Channel.cc
+++ b/Analysis/src/QwMollerADC_Channel.cc
@@ -395,15 +395,13 @@ void QwMollerADC_Channel::SetRawEventData(){
     fBlockSumSq_raw[4] += fBlockSumSq_raw[i];
     fBlock_min[4] = TMath::Min(fBlock_min[i],fBlock_min[4]);
     fBlock_max[4] = TMath::Max(fBlock_max[i],fBlock_max[4]);
-
-    fCalibrated = kFALSE;
-  }
+    }
 
 
 
   fSoftwareBlockSum_raw = fHardwareBlockSum_raw;
 
-  return;
+  fCalibrated = kFALSE;
 }
 
 void QwMollerADC_Channel::EncodeEventData(std::vector<UInt_t> &buffer)

--- a/Analysis/src/QwMollerADC_Channel.cc
+++ b/Analysis/src/QwMollerADC_Channel.cc
@@ -549,6 +549,7 @@ void QwMollerADC_Channel::PrintInfo() const
   std::cout<<"fBlocksPerEvent= "<<fBlocksPerEvent<<"\n"<<"\n";
   std::cout<<"fSequenceNumber= "<<fSequenceNumber<<"\n";
   std::cout<<"fNumberOfSamples= "<<fNumberOfSamples<<"\n";
+  std::cout<<"fCalibrated= "<<fCalibrated<<"\n";
   std::cout<<"fBlock_raw ";
 
   for (Int_t i = 0; i < fBlocksPerEvent; i++)
@@ -1222,6 +1223,13 @@ const QwMollerADC_Channel QwMollerADC_Channel::operator+ (const QwMollerADC_Chan
 QwMollerADC_Channel& QwMollerADC_Channel::operator+= (const QwMollerADC_Channel &value)
 {
   if (!IsNameEmpty()) {
+    if (fCalibrated ^ value.fCalibrated)  {
+      TString loc="Standard exception from QwMollerADC_Channel::operator+= "
+        +value.GetElementName()+" and "+this->GetElementName()
+        +" are not both calibrated or uncalibrated";
+      fCalibrated = value.fCalibrated;
+      QwWarning << loc << QwLog::endl;
+    }
     if (fCalibrated) {
       for (Int_t i = 0; i < fBlocksPerEvent; i++) {
         this->fBlock[i] += value.fBlock[i];
@@ -1258,6 +1266,13 @@ const QwMollerADC_Channel QwMollerADC_Channel::operator- (const QwMollerADC_Chan
 QwMollerADC_Channel& QwMollerADC_Channel::operator-= (const QwMollerADC_Channel &value)
 {
   if (!IsNameEmpty()){
+    if (fCalibrated ^ value.fCalibrated)  {
+      TString loc="Standard exception from QwMollerADC_Channel::operator-= "
+        +value.GetElementName()+" and "+this->GetElementName()
+        +" are not both calibrated or uncalibrated";
+      fCalibrated = value.fCalibrated;
+      QwWarning << loc << QwLog::endl;
+    }
     if (fCalibrated) {
       for (Int_t i=0; i<fBlocksPerEvent; i++){
         this->fBlock[i] -= value.fBlock[i];
@@ -1294,6 +1309,13 @@ const QwMollerADC_Channel QwMollerADC_Channel::operator* (const QwMollerADC_Chan
 QwMollerADC_Channel& QwMollerADC_Channel::operator*= (const QwMollerADC_Channel &value)
 {
   if (!IsNameEmpty()){
+    if (fCalibrated ^ value.fCalibrated)  {
+      TString loc="Standard exception from QwMollerADC_Channel::operator*= "
+        +value.GetElementName()+" and "+this->GetElementName()
+        +" are not both calibrated or uncalibrated";
+      fCalibrated = value.fCalibrated;
+      QwWarning << loc << QwLog::endl;
+    }
     if (fCalibrated) {
       for (Int_t i=0; i<fBlocksPerEvent; i++){
         this->fBlock[i] *= value.fBlock[i];

--- a/Analysis/src/QwMollerADC_Channel.cc
+++ b/Analysis/src/QwMollerADC_Channel.cc
@@ -1268,13 +1268,13 @@ QwMollerADC_Channel& QwMollerADC_Channel::operator-= (const QwMollerADC_Channel 
       this->fHardwareBlockSumM2   = 0.0;
     } else {
       for (Int_t i=0; i<fBlocksPerEvent; i++){  
-        this->fBlock_raw[i] -= value.fBlock_raw[i];
-        this->fBlockSumSq_raw[i] -= value.fBlockSumSq_raw[i];
+        this->fBlock_raw[i] = 0;
+        this->fBlockSumSq_raw[i] = value.fBlockSumSq_raw[i];
         this->fBlock_min[i] = TMath::Min(fBlock_min[i],value.fBlock_min[i]);
         this->fBlock_max[i] = TMath::Max(fBlock_max[i],value.fBlock_max[i]);    
       }
-      this->fHardwareBlockSum_raw -= value.fHardwareBlockSum_raw;
-      this->fSoftwareBlockSum_raw -= value.fSoftwareBlockSum_raw;
+      this->fHardwareBlockSum_raw = 0;
+      this->fSoftwareBlockSum_raw = 0;
     }
     // Both for calibrated and uncalibrated data
     this->fNumberOfSamples     += value.fNumberOfSamples; // Note: + since statistical power increases

--- a/Analysis/src/QwMollerADC_Channel.cc
+++ b/Analysis/src/QwMollerADC_Channel.cc
@@ -1303,15 +1303,17 @@ QwMollerADC_Channel& QwMollerADC_Channel::operator*= (const QwMollerADC_Channel 
       this->fHardwareBlockSum    *= value.fHardwareBlockSum;
       this->fHardwareBlockSumM2   = 0.0;
     } else {
-      this->fBlock_raw[i] *= value.fBlock_raw[i];
-      if(fBlockSumSq_raw[i] != 0){
-        this->fBlockSumSq_raw[i] *= value.fBlockSumSq_raw[i];
-        this->fBlock_min[i] *= value.fBlock_min[i];
-        this->fBlock_max[i] *= value.fBlock_max[i];
-      } else {
-        this->fBlockSumSq_raw[i] = value.fBlockSumSq_raw[i];
-        this->fBlock_min[i] = value.fBlock_min[i];
-        this->fBlock_max[i] = value.fBlock_max[i];
+      for (Int_t i=0; i<fBlocksPerEvent; i++){
+        this->fBlock_raw[i] *= value.fBlock_raw[i];
+        if(fBlockSumSq_raw[i] != 0){
+          this->fBlockSumSq_raw[i] *= value.fBlockSumSq_raw[i];
+          this->fBlock_min[i] *= value.fBlock_min[i];
+          this->fBlock_max[i] *= value.fBlock_max[i];
+        } else {
+          this->fBlockSumSq_raw[i] = value.fBlockSumSq_raw[i];
+          this->fBlock_min[i] = value.fBlock_min[i];
+          this->fBlock_max[i] = value.fBlock_max[i];
+        }
       }
     }
     // Both for calibrated and uncalibrated data

--- a/Analysis/src/QwMollerADC_Channel.cc
+++ b/Analysis/src/QwMollerADC_Channel.cc
@@ -1115,9 +1115,9 @@ QwMollerADC_Channel& QwMollerADC_Channel::operator= (const QwMollerADC_Channel &
     this->fHardwareBlockSumM2 = value.fHardwareBlockSumM2;
     this->fHardwareBlockSumError = value.fHardwareBlockSumError;
     this->fNumberOfSamples = value.fNumberOfSamples;
-    this->fSequenceNumber  = value.fSequenceNumber;
-   
-
+    this->fSequenceNumber = value.fSequenceNumber;
+    this->fCalibrated = value.fCalibrated;
+    // Note: fErrorFlag is not assigned
   }
   return *this;
 }
@@ -1145,6 +1145,7 @@ void QwMollerADC_Channel::AssignScaledValue(const QwMollerADC_Channel &value,
     this->fGoodEventCount  = value.fGoodEventCount;
     this->fNumberOfSamples = value.fNumberOfSamples;
     this->fSequenceNumber  = value.fSequenceNumber;
+    this->fCalibrated      = value.fCalibrated;
     this->fErrorFlag       = value.fErrorFlag;
   }
 }
@@ -1515,6 +1516,7 @@ void QwMollerADC_Channel::Product(const QwMollerADC_Channel &value1, const QwMol
     this->fHardwareBlockSum = value1.fHardwareBlockSum * value2.fHardwareBlockSum;
     this->fNumberOfSamples = value1.fNumberOfSamples;
     this->fSequenceNumber  = 0;
+    this->fCalibrated      = value1.fCalibrated;
     this->fErrorFlag       = (value1.fErrorFlag|value2.fErrorFlag);
   }
   return;

--- a/Analysis/src/VQwHardwareChannel.cc
+++ b/Analysis/src/VQwHardwareChannel.cc
@@ -10,7 +10,9 @@
 
 VQwHardwareChannel::VQwHardwareChannel():
   fNumberOfDataWords(0),
-  fNumberOfSubElements(0), fDataToSave(kRaw)
+  fNumberOfSubElements(0),
+  fDataToSave(kRaw),
+  fCalibrated(false)
 {
   fULimit = -1;
   fLLimit = 1;
@@ -29,6 +31,7 @@ VQwHardwareChannel::VQwHardwareChannel(const VQwHardwareChannel& value)
    fDataToSave(value.fDataToSave),
    fTreeArrayIndex(value.fTreeArrayIndex),
    fTreeArrayNumEntries(value.fTreeArrayNumEntries),
+   fCalibrated(value.fCalibrated),
    fPedestal(value.fPedestal),
    fCalibrationFactor(value.fCalibrationFactor),
    kFoundPedestal(value.kFoundPedestal),
@@ -50,6 +53,7 @@ VQwHardwareChannel::VQwHardwareChannel(const VQwHardwareChannel& value, VQwDataE
    fDataToSave(datatosave),
    fTreeArrayIndex(value.fTreeArrayIndex),
    fTreeArrayNumEntries(value.fTreeArrayNumEntries),
+   fCalibrated(value.fCalibrated),
    fPedestal(value.fPedestal),
    fCalibrationFactor(value.fCalibrationFactor),
    kFoundPedestal(value.kFoundPedestal),
@@ -72,6 +76,7 @@ void VQwHardwareChannel::CopyFrom(const VQwHardwareChannel& value)
   fDataToSave = value.fDataToSave;
   fTreeArrayIndex = value.fTreeArrayIndex;
   fTreeArrayNumEntries = value.fTreeArrayNumEntries;
+  fCalibrated = value.fCalibrated;
   fPedestal = value.fPedestal;
   fCalibrationFactor = value.fCalibrationFactor;
   kFoundPedestal = value.kFoundPedestal;


### PR DESCRIPTION
This PR addresses #106 by avoiding operator+= etc on raw when the calibration has already been applied. This will avoid int overflows in aggregated quantities.