### PR TITLE
Fix DockerHub login and push conditions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to DockerHub
-      if: ${{ steps.secrets.outputs.username }} && ${{ steps.secrets.outputs.token }}
+      if: ${{ steps.secrets.outputs.username == 'true' }} && ${{ steps.secrets.outputs.token == 'true' }}
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
@@ -52,7 +52,7 @@ jobs:
         context: .
         file: ./Dockerfile
         platforms: linux/amd64,linux/arm64
-        push: ${{ steps.secrets.outputs.token }}
+        push: ${{ steps.secrets.outputs.token == 'true' }}
         tags: |
           ${{ secrets.DOCKER_REPO || 'jeffersonlab' }}/japan-moller:latest
           ${{ secrets.DOCKER_REPO || 'jeffersonlab' }}/japan-moller:${{ github.ref_name }}
@@ -64,7 +64,7 @@ jobs:
         context: .
         file: ./Dockerfile
         platforms: linux/amd64,linux/arm64
-        push: ${{ steps.secrets.outputs.token }}
+        push: ${{ steps.secrets.outputs.token == 'true' }}
         tags: |
           ${{ secrets.DOCKER_REPO || 'jeffersonlab' }}/japan-moller:nightly
 
@@ -75,6 +75,6 @@ jobs:
         context: .
         file: ./Dockerfile
         platforms: linux/amd64,linux/arm64
-        push: ${{ steps.secrets.outputs.token }}
+        push: ${{ steps.secrets.outputs.token == 'true' }}
         tags: |
           ${{ secrets.DOCKER_REPO || 'jeffersonlab' }}/japan-moller:main


### PR DESCRIPTION
Well, #108 wasn't working. It had two complaints:
- `if:` clause wants conditional expressions to be outside of the handlebars,
- `push:` doesn't even support conditional expressions at all, so turned into a check on token only.

(Unfortunately, docker/login-action returns no output variable that indicates success or not.)