### PR TITLE
Add buffer to histogram filling

### DIFF
--- a/Analysis/include/MQwHistograms.h
+++ b/Analysis/include/MQwHistograms.h
@@ -52,6 +52,7 @@ class MQwHistograms {
     /// Register a histogram
     void AddHistogram(TH1* h) {
       fHistograms.push_back(TH1_ptr(h));
+	  fHistograms.back()->SetBuffer(1000);
     }
 
   public:


### PR DESCRIPTION
This PR adds a buffer of 1k deep to the histogram filling.

We had noticed that (after the TTree writing) histogram filling is taking up resources. There are ways to improve this with buffering before filling. Based on profiling by @dimensional-difficulties this improves speedup (of histgramming only) by ~10% on a 20k event run.

Risks: memory use increase (but predictably); see #111 to provide baseline.