### PR TITLE
Add regalias difference checks to  CI tests

### DIFF
--- a/.github/workflows/build-lcg-cvmfs.yml
+++ b/.github/workflows/build-lcg-cvmfs.yml
@@ -91,6 +91,15 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
+      - name: Upload regression alias definitions
+        uses: actions/upload-artifact@v4
+        with:
+          name: regalias-${{ matrix.release }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.compiler }}
+          path: |
+            *regalias*.C
+          retention-days: 7
+          if-no-files-found: error
+
   compare-artifacts:
     runs-on: ubuntu-latest
     needs: linux
@@ -98,6 +107,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        artifacts_to_check:
+        - "prompt-summary"
+        - "regalias"
         include:
           - release: "LCG_106"
             arch: "x86_64"
@@ -118,7 +130,7 @@ jobs:
       - name: Download current artifacts
         uses: actions/download-artifact@v4
         with:
-          name: prompt-summary-${{ matrix.release }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.compiler }}
+          name: ${{ matrix.artifacts_to_check }}-${{ matrix.release }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.compiler }}
           path: ./current
 
       - name: Download target branch artifacts
@@ -126,13 +138,13 @@ jobs:
         with:
           workflow: build-lcg-cvmfs.yml
           branch: ${{ github.event.pull_request.base.ref }}
-          name: prompt-summary-${{ matrix.release }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.compiler }}
+          name: ${{ matrix.artifacts_to_check }}-${{ matrix.release }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.compiler }}
           path: ./target
           if_no_artifact_found: warn
 
       - name: Compare artifacts
         run: |
-          echo "Comparing artifacts for ${{ matrix.release }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.compiler }}"
+          echo "Comparing ${{ matrix.artifacts_to_check }} artifacts for ${{ matrix.release }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.compiler }}"
 
           # Check if target artifacts exist
           if [ ! -d "./target" ] || [ -z "$(ls -A ./target)" ]; then
@@ -142,8 +154,8 @@ jobs:
           fi
 
           # Find summary files in both directories
-          current_files=$(find ./current -name "summary_*.txt" | sort)
-          target_files=$(find ./target -name "summary_*.txt" | sort)
+          current_files=$(find ./current -name "summary_*.txt" -o -name "*regalias*.txt" | sort)
+          target_files=$(find ./target -name "summary_*.txt" -o -name "*regalias*.txt" | sort)
 
           echo "Current files found:"
           echo "$current_files"
@@ -180,7 +192,7 @@ jobs:
           done
 
           if [ "$comparison_failed" = "true" ]; then
-            echo "❌ Artifact comparison failed. Changes detected in prompt summary beyond timestamps."
+            echo "❌ Artifact comparison failed. Changes detected in ${{ matrix.artifacts_to_check }} beyond timestamps."
             exit 1
           else
             echo "✅ All artifacts match expected results (ignoring timestamps)."


### PR DESCRIPTION
This PR adds the regalias macros to the files to check for differences. They are uploaded as artifacts and won't exist in the reference branch until this is merged.