### PR TITLE
Add log level checks for QwDebug and QwVerbose macros

### DIFF
--- a/Analysis/include/QwLog.h
+++ b/Analysis/include/QwLog.h
@@ -52,12 +52,12 @@ class QwOptions;
 /*! \def QwVerbose
  *  \brief Predefined log drain for verbose messages
  */
-#define QwVerbose  gQwLog(QwLog::kVerbose,__PRETTY_FUNCTION__)
+#define QwVerbose  if (gQwLog.GetLogLevel() >= QwLog::kVerbose) gQwLog(QwLog::kVerbose,__PRETTY_FUNCTION__)
 
 /*! \def QwDebug
  *  \brief Predefined log drain for debugging output
  */
-#define QwDebug    gQwLog(QwLog::kDebug,__PRETTY_FUNCTION__)
+#define QwDebug    if (gQwLog.GetLogLevel() >= QwLog::kDebug) gQwLog(QwLog::kDebug,__PRETTY_FUNCTION__)
 
 
 /**
@@ -130,6 +130,12 @@ class QwLog : public std::ostream {
     /*! \brief Set the file log level
      */
     void                        SetFileThreshold(int thr);
+
+    /*! \brief Get highest log level 
+     */
+    QwLogLevel                  GetLogLevel() const {
+      return std::max(fScreenThreshold, fFileThreshold);
+    };
 
     /*! \brief Set the stream log level
      */

--- a/Analysis/src/Coda3EventDecoder.cc
+++ b/Analysis/src/Coda3EventDecoder.cc
@@ -180,7 +180,9 @@ Int_t Coda3EventDecoder::DecodeEventIDBank(UInt_t *buffer)
 
 	fFragLength = fEvtLength - fWordsSoFar;	
 	QwDebug << Form("buffer[0-1] 0x%x 0x%x ; ", buffer[0], buffer[1]);
-	PrintDecoderInfo(QwDebug);
+	if (gQwLog.GetLogLevel() >= QwLog::kDebug) {
+  	  PrintDecoderInfo(gQwLog(QwLog::kDebug,__PRETTY_FUNCTION__));
+	}
 
 	return CODA_OK;
 }


### PR DESCRIPTION
This PR adds a bypass condition to the verbose and debug log levels. Until now, the code below:
```
	out << Form("Event Number: %d; Length: %d; Tag: 0x%x; Bank data type: 0x%x ",
			fEvtNumber, fEvtLength, fEvtTag, fBankDataType)
		<< Form("Evt type: 0x%x; Evt number %d; fWordsSoFar %d",
				fEvtType, fEvtNumber, fWordsSoFar )
		<< QwLog::endl;
```
causes the `Form` functions to be evaluated before ultimately nothing happens with it.

Since we use `QwVerbose` and `QwDebug` as preprocessor macros, we can include an `if` clause to avoid evaluation entirely. Since they are used in single line clauses (except for one place which has been addressed), this is reasonably safe.

A better approach (which would require a wholesale rewrite of QwLog with something more performant like spdlog and fmt) is to move away from preprocessors entirely... But we do what we can with what we have.