### PR TITLE
Remove dependency on boost::filesystem since C++17 has std::filesystem

### DIFF
--- a/Analysis/include/QwParameterFile.h
+++ b/Analysis/include/QwParameterFile.h
@@ -17,6 +17,8 @@
 #include <string>
 #include <map>
 #include <set>
+#include <filesystem>
+namespace fs = std::filesystem;
 
 // ROOT headers
 #include "Rtypes.h"
@@ -29,10 +31,6 @@
 
 // Boost headers
 #include "boost/lexical_cast.hpp"
-#include "boost/filesystem/directory.hpp"
-#include "boost/filesystem/operations.hpp"
-#include "boost/filesystem/path.hpp"
-namespace bfs = boost::filesystem;
 using boost::lexical_cast;
 
 // Qweak headers
@@ -262,13 +260,13 @@ class QwParameterFile {
   private:
 
     /// Find the first file in a directory that conforms to the run label
-    int FindFile(const bfs::path& dir_path,    // in this directory,
+    int FindFile(const fs::path& dir_path,    // in this directory,
                  const std::string& file_stem, // search for this stem,
                  const std::string& file_ext,  // search for this extension,
-                 bfs::path& path_found);       // placing path here if found
+                 fs::path& path_found);       // placing path here if found
 
     /// Open a file
-    bool OpenFile(const bfs::path& path_found);
+    bool OpenFile(const fs::path& path_found);
   //  TString fCurrentSecName;     // Stores the name of the current section  read
   //  TString fCurrentModuleName;  // Stores the name of the current module  read
     TString fBestParamFileName;
@@ -285,7 +283,7 @@ class QwParameterFile {
   protected:
 
     // List of search paths
-    static std::vector<bfs::path> fSearchPaths;
+    static std::vector<fs::path> fSearchPaths;
 
     // Current run number
     static UInt_t fCurrentRunNumber;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ endif(MYSQLPP_FOUND)
 #----------------------------------------------------------------------------
 # Boost
 #
-find_package(Boost COMPONENTS program_options filesystem system REQUIRED)
+find_package(Boost COMPONENTS program_options system REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ endif(MYSQLPP_FOUND)
 #----------------------------------------------------------------------------
 # Boost
 #
-find_package(Boost COMPONENTS program_options system REQUIRED)
+find_package(Boost COMPONENTS program_options REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIR})
 


### PR DESCRIPTION
This PR removes the dependency on boost::filesystem. The filesystem support from boost was included in C++17 with the syntax we were already using. This makes our code more standard which reduces maintenance burden.

gcc has `std::filesystem` support as of gcc-8, https://en.cppreference.com/w/cpp/compiler_support/17.html.