### PR TITLE
Remove support for ancient versions of boost::program_options

### DIFF
--- a/Analysis/include/QwOptions.h
+++ b/Analysis/include/QwOptions.h
@@ -47,11 +47,7 @@ inline const TString getenv_safe_TString (const char* name) {
 // Starting with boost::program_options 1.35.0 there is support for the semantic
 // implicit_value.  An explicit option value is optional, but if given, must be
 // strictly adjacent to the option.
-#if BOOST_VERSION >= 103500
 #define default_bool_value(b) default_value(b)->implicit_value(true)
-#else
-#define default_bool_value(b) default_value(b)
-#endif
 
 
 /**

--- a/Analysis/src/QwOptions.cc
+++ b/Analysis/src/QwOptions.cc
@@ -200,7 +200,6 @@ po::options_description* QwOptions::CombineOptions()
  */
 void QwOptions::ParseCommandLine()
 {
-#if BOOST_VERSION >= 103300
   //  Boost versions starting with 1.33.00 allow unrecognized options to be
   //  passed through the parser.
   try {
@@ -211,22 +210,6 @@ void QwOptions::ParseCommandLine()
     QwWarning << e.what() << " while parsing command line arguments" << QwLog::endl;
     exit(10);
   }
-#endif
-
-#if BOOST_VERSION < 103300
-  //  Boost versions before 1.33.00 do not allow unrecognized options to be
-  //  passed through the parser.
-  try {
-    //  Boost versions before 1.33.00 do not recognize "allow_unregistered".
-    po::options_description* command_line_options = CombineOptions();
-    po::store(po::command_line_parser(fArgc, fArgv).options(*command_line_options).run(), fVariablesMap);
-    delete command_line_options;
-  } catch (std::exception const& e) {
-    QwWarning << e.what() << " while parsing command line arguments" << QwLog::endl;
-    QwWarning << "All command line arguments may have been ignored!" << QwLog::endl;
-    exit(10);
-  }
-#endif
 
   // Notify of new options
   po::notify(fVariablesMap);
@@ -300,27 +283,15 @@ void QwOptions::ParseConfigFile()
     configstream << configfile.rdbuf();
 
     try {
-#if BOOST_VERSION >= 103500
       // Boost version after 1.35 have bool allow_unregistered = false in
       // their signature.  This allows for unknown options in the config file.
       po::options_description* config_file_options = CombineOptions();
       po::store(po::parse_config_file(configstream, *config_file_options, true),
 		fVariablesMap);
       delete config_file_options;
-#else
-      // Boost versions before 1.35 cannot handle files with unregistered
-      // options.
-      po::options_description* config_file_options = CombineOptions();
-      po::store(po::parse_config_file(configstream, *config_file_options),
-		fVariablesMap);
-      delete config_file_options;
-#endif
     } catch (std::exception const& e) {
       QwWarning << e.what() << " while parsing configuration file "
                 << fConfigFiles.at(i) << QwLog::endl;
-#if BOOST_VERSION < 103500
-      QwWarning << "The entire configuration file was ignored!" << QwLog::endl;
-#endif
       exit(10);
     }
     // Notify of new options

--- a/Analysis/src/QwSubsystemArray.cc
+++ b/Analysis/src/QwSubsystemArray.cc
@@ -252,21 +252,12 @@ void QwSubsystemArray::DefineOptions(QwOptions &options)
                        "map file with bad event ranges");
 
   // Versions of boost::program_options below 1.39.0 have a bug in multitoken processing
-#if BOOST_VERSION < 103900
-  options.AddOptions()("disable-by-type",
-                       po::value<std::vector <std::string> >(),
-                       "subsystem types to disable");
-  options.AddOptions()("disable-by-name",
-                       po::value<std::vector <std::string> >(),
-                       "subsystem names to disable");
-#else // BOOST_VERSION >= 103900
   options.AddOptions()("disable-by-type",
                        po::value<std::vector <std::string> >()->multitoken(),
                        "subsystem types to disable");
   options.AddOptions()("disable-by-name",
                        po::value<std::vector <std::string> >()->multitoken(),
                        "subsystem names to disable");
-#endif // BOOST_VERSION
 }
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ endif(MYSQLPP_FOUND)
 #----------------------------------------------------------------------------
 # Boost
 #
-find_package(Boost COMPONENTS program_options filesystem system REQUIRED)
+find_package(Boost 1.39 COMPONENTS program_options filesystem system REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIR})
 


### PR DESCRIPTION
This PR removes support for some ancient versions of `boost::program_options`. This reduces code complexity and maintenance burden. Corresponding version requirement in CMakeLists.txt increased.