### PR TITLE
Avoid expensive options lookup in favor of locally cached options

### DIFF
--- a/Analysis/include/VQwHardwareChannel.h
+++ b/Analysis/include/VQwHardwareChannel.h
@@ -255,8 +255,6 @@ public:
     }
   };
 
-
-
 protected:
   UInt_t  fNumberOfDataWords; ///< Number of raw data words in this data element
   UInt_t  fNumberOfSubElements; ///< Number of subelements in this data element
@@ -286,9 +284,19 @@ protected:
 
   Double_t fBurpThreshold;
   Int_t fBurpCountdown;
-  Int_t fBurpHoldoff;
-
   //@}
+
+
+public:
+  /*! \name Global event cuts */
+  static void SetBurpHoldoff(Int_t holdoff) {
+    fBurpHoldoff = holdoff;
+  }
+
+protected:
+  // @{
+  static Int_t fBurpHoldoff;
+  // @}
 
 };   // class VQwHardwareChannel
 

--- a/Analysis/src/VQwHardwareChannel.cc
+++ b/Analysis/src/VQwHardwareChannel.cc
@@ -8,6 +8,8 @@
 #include "QwParameterFile.h"
 #include "QwOptions.h"
 
+Int_t VQwHardwareChannel::fBurpHoldoff = 10;
+
 VQwHardwareChannel::VQwHardwareChannel():
   fNumberOfDataWords(0),
   fNumberOfSubElements(0), fDataToSave(kRaw)
@@ -16,10 +18,7 @@ VQwHardwareChannel::VQwHardwareChannel():
   fLLimit = 1;
   fErrorFlag = 0;
   fErrorConfigFlag = 0;
-  fBurpHoldoff = 10;
   fBurpThreshold = -1.0;
-  
-  ProcessOptions();
 }
 
 VQwHardwareChannel::VQwHardwareChannel(const VQwHardwareChannel& value)
@@ -38,8 +37,7 @@ VQwHardwareChannel::VQwHardwareChannel(const VQwHardwareChannel& value)
    fLLimit(value.fLLimit),
    fStability(value.fStability),
    fBurpThreshold(value.fBurpThreshold),
-   fBurpCountdown(value.fBurpCountdown),
-   fBurpHoldoff(value.fBurpHoldoff)
+   fBurpCountdown(value.fBurpCountdown)
 {
 }
 
@@ -59,8 +57,7 @@ VQwHardwareChannel::VQwHardwareChannel(const VQwHardwareChannel& value, VQwDataE
    fLLimit(value.fLLimit),
    fStability(value.fStability),
    fBurpThreshold(value.fBurpThreshold),
-   fBurpCountdown(value.fBurpCountdown),
-   fBurpHoldoff(value.fBurpHoldoff)
+   fBurpCountdown(value.fBurpCountdown)
 {
 }
 
@@ -82,14 +79,6 @@ void VQwHardwareChannel::CopyFrom(const VQwHardwareChannel& value)
   fStability = value.fStability;
   fBurpThreshold = value.fBurpThreshold;
   fBurpCountdown = value.fBurpCountdown;
-  fBurpHoldoff = value.fBurpHoldoff;
-}
-
-
-
-void VQwHardwareChannel::ProcessOptions(){
-  if (gQwOptions.HasValue("burp.holdoff"))
-    fBurpHoldoff=gQwOptions.GetValue<int>("burp.holdoff");
 }
 
 void VQwHardwareChannel::SetSingleEventCuts(Double_t min, Double_t max)

--- a/Parity/main/QwParity.cc
+++ b/Parity/main/QwParity.cc
@@ -216,14 +216,12 @@ Int_t main(Int_t argc, Char_t* argv[])
 
     // Construct RNTuple fields if enabled
 #ifdef HAS_RNTUPLE_SUPPORT
-    if (gQwOptions.GetValue<bool>("enable-rntuples")) {
-      treerootfile->ConstructNTupleFields("evt", "MPS event data RNTuple", ringoutput);
-      treerootfile->ConstructNTupleFields("mul", "Helicity event data RNTuple", helicitypattern);
-      burstrootfile->ConstructNTupleFields("pr_yield", "Pair yield RNTuple", helicitypattern.GetPairYield(),"yield_");
-      burstrootfile->ConstructNTupleFields("pr_asym", "Pair asymmetry RNTuple", helicitypattern.GetPairAsymmetry(),"asym_");
-      treerootfile->ConstructNTupleFields("slow", "EPICS and slow control RNTuple", epicsevent);
-      burstrootfile->ConstructNTupleFields("burst", "Burst level data RNTuple", patternsum_per_burst, "|stat");
-    }
+    treerootfile->ConstructNTupleFields("evt", "MPS event data RNTuple", ringoutput);
+    treerootfile->ConstructNTupleFields("mul", "Helicity event data RNTuple", helicitypattern);
+    burstrootfile->ConstructNTupleFields("pr_yield", "Pair yield RNTuple", helicitypattern.GetPairYield(),"yield_");
+    burstrootfile->ConstructNTupleFields("pr_asym", "Pair asymmetry RNTuple", helicitypattern.GetPairAsymmetry(),"asym_");
+    treerootfile->ConstructNTupleFields("slow", "EPICS and slow control RNTuple", epicsevent);
+    burstrootfile->ConstructNTupleFields("burst", "Burst level data RNTuple", patternsum_per_burst, "|stat");
 #endif
 
     historootfile->ConstructHistograms("evt_histo",   datahandlerarray_evt);
@@ -236,11 +234,9 @@ Int_t main(Int_t argc, Char_t* argv[])
 
     // Construct RNTuple fields for data handlers if enabled
 #ifdef HAS_RNTUPLE_SUPPORT
-    if (gQwOptions.GetValue<bool>("enable-rntuples")) {
-      datahandlerarray_evt.ConstructNTupleFields(treerootfile, "evt_");
-      datahandlerarray_mul.ConstructNTupleFields(treerootfile);
-      datahandlerarray_burst.ConstructNTupleFields(burstrootfile, "burst_", "|stat");
-    }
+    datahandlerarray_evt.ConstructNTupleFields(treerootfile, "evt_");
+    datahandlerarray_mul.ConstructNTupleFields(treerootfile);
+    datahandlerarray_burst.ConstructNTupleFields(burstrootfile, "burst_", "|stat");
 #endif
 
     treerootfile->ConstructTreeBranches("evts", "Running sum tree", eventsum, "|stat");
@@ -249,11 +245,9 @@ Int_t main(Int_t argc, Char_t* argv[])
 
     // Construct RNTuple fields for additional data if enabled
 #ifdef HAS_RNTUPLE_SUPPORT
-    if (gQwOptions.GetValue<bool>("enable-rntuples")) {
-      treerootfile->ConstructNTupleFields("evts", "Running sum RNTuple", eventsum, "|stat");
-      treerootfile->ConstructNTupleFields("muls", "Running sum RNTuple", patternsum, "|stat");
-      burstrootfile->ConstructNTupleFields("bursts", "Burst running sum RNTuple", burstsum, "|stat");
-    }
+    treerootfile->ConstructNTupleFields("evts", "Running sum RNTuple", eventsum, "|stat");
+    treerootfile->ConstructNTupleFields("muls", "Running sum RNTuple", patternsum, "|stat");
+    burstrootfile->ConstructNTupleFields("bursts", "Burst running sum RNTuple", burstsum, "|stat");
 #endif
 
     // Summarize the ROOT file structure
@@ -325,10 +319,8 @@ Int_t main(Int_t argc, Char_t* argv[])
 	  
 	  // Fill RNTuple if enabled
 #ifdef HAS_RNTUPLE_SUPPORT
-	  if (gQwOptions.GetValue<bool>("enable-rntuples")) {
-	    treerootfile->FillNTupleFields(epicsevent);
-	    treerootfile->FillNTuple("slow");
-	  }
+	  treerootfile->FillNTupleFields(epicsevent);
+	  treerootfile->FillNTuple("slow");
 #endif
 	}
       }
@@ -369,10 +361,8 @@ Int_t main(Int_t argc, Char_t* argv[])
 
 	  // Fill RNTuple if enabled
 #ifdef HAS_RNTUPLE_SUPPORT
-	  if (gQwOptions.GetValue<bool>("enable-rntuples")) {
-	    treerootfile->FillNTupleFields(ringoutput);
-	    treerootfile->FillNTuple("evt");
-	  }
+	  treerootfile->FillNTupleFields(ringoutput);
+	  treerootfile->FillNTuple("evt");
 #endif
 
 	  // Process data handlers
@@ -386,9 +376,7 @@ Int_t main(Int_t argc, Char_t* argv[])
 
           // Fill data handler RNTuple fields if enabled
 #ifdef HAS_RNTUPLE_SUPPORT
-          if (gQwOptions.GetValue<bool>("enable-rntuples")) {
-            datahandlerarray_evt.FillNTupleFields(treerootfile);
-          }
+          datahandlerarray_evt.FillNTupleFields(treerootfile);
 #endif
 
           // Load the event into the helicity pattern
@@ -405,12 +393,10 @@ Int_t main(Int_t argc, Char_t* argv[])
 	    
 	    // Fill pair RNTuples if enabled
 #ifdef HAS_RNTUPLE_SUPPORT
-	    if (gQwOptions.GetValue<bool>("enable-rntuples")) {
-	      burstrootfile->FillNTupleFields("pr_yield", helicitypattern.GetPairYield());
-	      burstrootfile->FillNTupleFields("pr_asym", helicitypattern.GetPairAsymmetry());
-	      burstrootfile->FillNTuple("pr_yield");
-	      burstrootfile->FillNTuple("pr_asym");
-	    }
+	    burstrootfile->FillNTupleFields("pr_yield", helicitypattern.GetPairYield());
+	    burstrootfile->FillNTupleFields("pr_asym", helicitypattern.GetPairAsymmetry());
+	    burstrootfile->FillNTuple("pr_yield");
+	    burstrootfile->FillNTuple("pr_asym");
 #endif
 	    
 	    // Clear the data
@@ -430,10 +416,8 @@ Int_t main(Int_t argc, Char_t* argv[])
 
               // Fill helicity RNTuple if enabled
 #ifdef HAS_RNTUPLE_SUPPORT
-              if (gQwOptions.GetValue<bool>("enable-rntuples")) {
-                treerootfile->FillNTupleFields(helicitypattern);
-                treerootfile->FillNTuple("mul");
-              }
+              treerootfile->FillNTupleFields(helicitypattern);
+              treerootfile->FillNTuple("mul");
 #endif
 
               // Process data handlers
@@ -448,9 +432,7 @@ Int_t main(Int_t argc, Char_t* argv[])
 
               // Fill data handler RNTuple fields if enabled
 #ifdef HAS_RNTUPLE_SUPPORT
-              if (gQwOptions.GetValue<bool>("enable-rntuples")) {
-                datahandlerarray_mul.FillNTupleFields(treerootfile);
-              }
+              datahandlerarray_mul.FillNTupleFields(treerootfile);
 #endif
 
               // Fill the pattern into the sum for this burst
@@ -483,10 +465,8 @@ Int_t main(Int_t argc, Char_t* argv[])
 
                 // Fill burst RNTuple if enabled
 #ifdef HAS_RNTUPLE_SUPPORT
-                if (gQwOptions.GetValue<bool>("enable-rntuples")) {
-                  burstrootfile->FillNTupleFields(patternsum_per_burst);
-                  burstrootfile->FillNTuple("burst");
-                }
+                burstrootfile->FillNTupleFields(patternsum_per_burst);
+                burstrootfile->FillNTuple("burst");
 #endif
 
                 // Finish data handler for burst
@@ -500,9 +480,7 @@ Int_t main(Int_t argc, Char_t* argv[])
 
                 // Fill data handler RNTuple fields if enabled
 #ifdef HAS_RNTUPLE_SUPPORT
-                if (gQwOptions.GetValue<bool>("enable-rntuples")) {
-                  datahandlerarray_burst.FillNTupleFields(burstrootfile);
-                }
+                datahandlerarray_burst.FillNTupleFields(burstrootfile);
 #endif
 
 		helicitypattern.IncrementBurstCounter();
@@ -553,10 +531,8 @@ Int_t main(Int_t argc, Char_t* argv[])
     
       // Fill burst RNTuple if enabled
 #ifdef HAS_RNTUPLE_SUPPORT
-      if (gQwOptions.GetValue<bool>("enable-rntuples")) {
-        burstrootfile->FillNTupleFields(patternsum_per_burst);
-        burstrootfile->FillNTuple("burst");
-      }
+      burstrootfile->FillNTupleFields(patternsum_per_burst);
+      burstrootfile->FillNTuple("burst");
 #endif
     
       // Finish data handler for burst
@@ -570,9 +546,7 @@ Int_t main(Int_t argc, Char_t* argv[])
 
       // Fill data handler RNTuple fields if enabled
 #ifdef HAS_RNTUPLE_SUPPORT
-      if (gQwOptions.GetValue<bool>("enable-rntuples")) {
-        datahandlerarray_burst.FillNTupleFields(burstrootfile);
-      }
+      datahandlerarray_burst.FillNTupleFields(burstrootfile);
 #endif
       patternsum_per_burst.PrintIndexMapFile(run_number);
     }
@@ -605,10 +579,8 @@ Int_t main(Int_t argc, Char_t* argv[])
 
     // Fill running sum RNTuple if enabled
 #ifdef HAS_RNTUPLE_SUPPORT
-    if (gQwOptions.GetValue<bool>("enable-rntuples")) {
-      treerootfile->FillNTupleFields(eventsum);
-      treerootfile->FillNTuple("evts");
-    }
+    treerootfile->FillNTupleFields(eventsum);
+    treerootfile->FillNTuple("evts");
 #endif
 
     if (gQwOptions.GetValue<bool>("print-patternsum")) {
@@ -621,10 +593,8 @@ Int_t main(Int_t argc, Char_t* argv[])
 
     // Fill pattern sum RNTuple if enabled
 #ifdef HAS_RNTUPLE_SUPPORT
-    if (gQwOptions.GetValue<bool>("enable-rntuples")) {
-      treerootfile->FillNTupleFields(patternsum);
-      treerootfile->FillNTuple("muls");
-    }
+    treerootfile->FillNTupleFields(patternsum);
+    treerootfile->FillNTuple("muls");
 #endif
 
     if (gQwOptions.GetValue<bool>("print-burstsum")) {
@@ -637,10 +607,8 @@ Int_t main(Int_t argc, Char_t* argv[])
 
     // Fill burst sum RNTuple if enabled
 #ifdef HAS_RNTUPLE_SUPPORT
-    if (gQwOptions.GetValue<bool>("enable-rntuples")) {
-      burstrootfile->FillNTupleFields(burstsum);
-      burstrootfile->FillNTuple("bursts");
-    }
+    burstrootfile->FillNTupleFields(burstsum);
+    burstrootfile->FillNTuple("bursts");
 #endif
 
     //  Construct objects

--- a/Parity/src/QwEventRing.cc
+++ b/Parity/src/QwEventRing.cc
@@ -83,6 +83,9 @@ void QwEventRing::ProcessOptions(QwOptions &options)
     fRING_SIZE = tmpval;
   }
 
+  if (gQwOptions.HasValue("burp.holdoff"))
+    VQwHardwareChannel::SetBurpHoldoff(gQwOptions.GetValue<int>("burp.holdoff"));
+
   if (gQwOptions.HasValue("ring.stability_cut"))
     stability=gQwOptions.GetValue<double>("ring.stability_cut");
 


### PR DESCRIPTION
This PR avoids some expensive options retrievals that trigger string-based map lookup and boost::any casts multiple times per event (50k calls for 20k events mock data). This shows up as the most expensive code in gprof profiling (when turning off trees and histograms).

Another approach here would be to implement some caching in the QwOptions class, but that was not immediately easy due to the structure of `po::variables_map`.