### PR TITLE
Enable implicit multi-threading in ROOT to speed up TTree::Fill

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ link_directories(${Boost_LIBRARY_DIR})
 #----------------------------------------------------------------------------
 # ROOT
 #
-set(minimum_root_version 6.0)
+set(minimum_root_version 6.8)
 find_package(ROOT ${minimum_root_version} REQUIRED New Gui)
 config_add_dependency(ROOT ${minimum_root_version})
 

--- a/Parity/main/QwParity.cc
+++ b/Parity/main/QwParity.cc
@@ -58,6 +58,9 @@
 
 Int_t main(Int_t argc, Char_t* argv[])
 {
+  ///  Enable implicit multi-threading in e.g. TTree::Fill
+  ROOT::EnableImplicitMT();
+
   ///  Define the command line options
   DefineOptionsParity(gQwOptions);
 


### PR DESCRIPTION
ROOT has had implicit multi-threading for parallelizing operations like TTree::Fill since 6.08. This PR makes that the default (defaulting to available cores).

Note that this does not use all cores efficiently since it only uses these cores for a limited set of operations. No ideal scaling should be expected. On shared batch compute systems this should use what is available through cgroups, but I don't think it makes sense to request more cores for the marginal use of the additional cores that this provides.

Nevertheless, it makes running of mock data analysis faster by using an effective 1.4 cores (with default zlib-ng compression level 1) on my system.

The number of cores to target can be specified and we could add a command line option for this, if that's seen as useful.