### PR TITLE
Allow choosing different ROOT TFile compression algorithms: does it help?

### DIFF
--- a/Analysis/include/QwRootFile.h
+++ b/Analysis/include/QwRootFile.h
@@ -828,6 +828,7 @@ class QwRootFile {
     TMapFile* fMapFile;
     Bool_t fEnableMapFile;
     Int_t fUpdateInterval;
+    Int_t fCompressionAlgorithm;
     Int_t fCompressionLevel;
     Int_t fBasketSize;
     Int_t fAutoFlush;

--- a/Analysis/src/QwRootFile.cc
+++ b/Analysis/src/QwRootFile.cc
@@ -91,6 +91,7 @@ QwRootFile::QwRootFile(const TString& run_label)
       );
     }
 
+    fRootFile->SetCompressionAlgorithm(fCompressionAlgorithm);
     fRootFile->SetCompressionLevel(fCompressionLevel);
   }
 }
@@ -242,8 +243,11 @@ void QwRootFile::DefineOptions(QwOptions &options)
     ("circular-buffer", po::value<int>()->default_value(0),
      "TTree circular buffer");
   options.AddOptions("ROOT performance options")
+    ("compression-algorithm", po::value<int>()->default_value(1),
+     "TFile compression algorithm (default = 1 ZLIB)");
+  options.AddOptions("ROOT performance options")
     ("compression-level", po::value<int>()->default_value(1),
-     "TFile compression level");
+     "TFile compression level (default = 1, no compression = 0)");
 }
 
 
@@ -303,6 +307,7 @@ void QwRootFile::ProcessOptions(QwOptions &options)
   // Update interval for the map file
   fCircularBufferSize = options.GetValue<int>("circular-buffer");
   fUpdateInterval = options.GetValue<int>("mapfile-update-interval");
+  fCompressionAlgorithm = options.GetValue<int>("compression-algorithm");
   fCompressionLevel = options.GetValue<int>("compression-level");
   fBasketSize = options.GetValue<int>("basket-size");
 


### PR DESCRIPTION
No. It doesn't help. But this PR at least provides an option to explore this again after further development.

The simple zlib deflate algorithm is a single-threaded dinosaur and doesn't aim to use modern CPU vector registers (sse, avx) very well. Other options are often more performant.

Benchmark command:
```
valgrind --tool=callgrind build/qwparity -r 4 -e :5000 --config qwparity_simple.conf --detectors mock_newdets.map --datahandlers mock_datahandlers.map --data . --rootfiles . --compression-algorithm=4
```

Zlib(-ng): 39.3% in TBranch::FillImpl
<img width="944" height="361" alt="image" src="https://github.com/user-attachments/assets/16726dc8-6c15-4936-90c3-236c8279419a" />

Zstd: 39.8% in TBranch::FillImpl
<img width="1189" height="313" alt="image" src="https://github.com/user-attachments/assets/06110783-9bf2-4e9d-b12b-35ce6c688cc0" />

I think there are still opportunities to improve this. Zstd has multithreaded capabilities, which are not exploited here. They may be used in #125, but I can't verify in the ROOT source code that this is explicitly enabled.