### PR TITLE
Add CI workflow with callgrind run and annotation

### DIFF
--- a/.github/workflows/build-lcg-cvmfs.yml
+++ b/.github/workflows/build-lcg-cvmfs.yml
@@ -85,7 +85,7 @@ jobs:
 
             echo "::group::Compilation"
             # Build the project with ccache
-            cmake -Bbuild -S. -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_FLAGS=${{ matrix.cxxflags }}
+            cmake -Bbuild -S. -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_FLAGS="${{ matrix.cxxflags }}"
             cmake --build build -j$(nproc)
             echo "::endgroup::"
             


### PR DESCRIPTION
This PR adds steps to main build to upload the build directory as an artifact, and to perform callgrind run and annotation analysis.

Depends
- [x] #127 