### PR TITLE
Fix regalias file extension from .txt to .C in comparison

### DIFF
--- a/.github/workflows/build-lcg-cvmfs.yml
+++ b/.github/workflows/build-lcg-cvmfs.yml
@@ -169,8 +169,8 @@ jobs:
           fi
 
           # Find summary files in both directories
-          current_files=$(find ./ -maxdepth 1 -name "summary_*.txt" -o -name "*regalias*.txt" | sort)
-          target_files=$(find ./target -name "summary_*.txt" -o -name "*regalias*.txt" | sort)
+          current_files=$(find ./ -maxdepth 1 -name "summary_*.txt" -o -name "*regalias*.C" | sort)
+          target_files=$(find ./target -name "summary_*.txt" -o -name "*regalias*.C" | sort)
 
           echo "Current files found:"
           echo "$current_files"


### PR DESCRIPTION
In #102 the regalias comparison didn't run (nor in any other PR since #113) due to an incorrect extension. This PR should fix that.