### PR TITLE
Update cvmfs action to use version 5

### DIFF
--- a/.github/workflows/build-lcg-cvmfs.yml
+++ b/.github/workflows/build-lcg-cvmfs.yml
@@ -34,8 +34,8 @@ jobs:
             compiler: "gcc14"
             opt: "opt"
     steps:
-      - uses: actions/checkout@v3
-      - uses: cvmfs-contrib/github-action-cvmfs@v3
+      - uses: actions/checkout@v5
+      - uses: cvmfs-contrib/github-action-cvmfs@v5
         with:
           cvmfs_repositories: 'sft.cern.ch,geant4.cern.ch'
       - name: Install ccache


### PR DESCRIPTION
This PR updates the CI to use the github-actions-cvmfs@v5, which loads in about 20 seconds, instead of our current version v3 which takes 2m30s (later cold cache cost notwithstanding). Also updates checkout to v5.

@paulmking These updates can be done semi-automatically (PR creation, requires approval and merge) with dependabot. I'll add the necessary config file.