### PR TITLE
Remove SetMockDataAsDiff method from QwBPMStripline and QwCombinedBPM classes

### DIFF
--- a/Parity/include/QwBPMStripline.h
+++ b/Parity/include/QwBPMStripline.h
@@ -82,8 +82,6 @@ class QwBPMStripline : public VQwBPM {
   void    InitializeChannel(TString subsystem, TString name, TString type);
   void    ClearEventData();
 
-  void    SetMockDataAsDiff();
-
   void LoadChannelParameters(QwParameterFile &paramfile){
     for(Short_t i=0;i<4;i++){
       fWire[i].LoadChannelParameters(paramfile);

--- a/Parity/include/QwCombinedBPM.h
+++ b/Parity/include/QwCombinedBPM.h
@@ -79,8 +79,6 @@ class QwCombinedBPM : public VQwBPM {
     InitializeChannel(subsystem, name);
   }
 
-  void    SetMockDataAsDiff();
-
   void    LoadChannelParameters(QwParameterFile &paramfile){};
   void    ClearEventData();
   Int_t   ProcessEvBuffer(UInt_t* buffer,

--- a/Parity/src/QwBPMStripline.cc
+++ b/Parity/src/QwBPMStripline.cc
@@ -1169,12 +1169,6 @@ void QwBPMStripline<T>::RandomizeEventData(int helicity, double time)
 
 
 template<typename T>
-void QwBPMStripline<T>::SetMockDataAsDiff() {
-  this->SetMockDataAsDiff();
-}
-
-
-template<typename T>
 void QwBPMStripline<T>::LoadMockDataParameters(QwParameterFile &paramfile) {
 
   //Bool_t ldebug=kFALSE;

--- a/Parity/src/QwCombinedBPM.cc
+++ b/Parity/src/QwCombinedBPM.cc
@@ -1252,12 +1252,6 @@ void QwCombinedBPM<T>::RandomizeEventData(int helicity, double time)
 
 
 template<typename T>
-void QwCombinedBPM<T>::SetMockDataAsDiff() {
-  this->SetMockDataAsDiff();
-}
-
-
-template<typename T>
 void QwCombinedBPM<T>::LoadMockDataParameters(QwParameterFile &paramfile){
 /*
   Bool_t   ldebug=kFALSE;


### PR DESCRIPTION
This PR removes two unused recursive functions which are likely there for historical but now unused reasons.