### PR TITLE
Change return type of CheckForMarkerWords from Int_t to std::size_t for improved type safety

### DIFF
--- a/Analysis/include/QwEventBuffer.h
+++ b/Analysis/include/QwEventBuffer.h
@@ -268,7 +268,7 @@ class QwEventBuffer {
   std::unordered_map<RocBankLabel_t, std::vector<UInt_t> > fMarkerList;
   std::unordered_map<RocBankLabel_t, std::vector<UInt_t> > fOffsetList;
 
-  Int_t CheckForMarkerWords(QwSubsystemArray &subsystems);
+  std::size_t CheckForMarkerWords(QwSubsystemArray &subsystems);
   RocBankLabel_t fThisRocBankLabel;
   UInt_t FindMarkerWord(UInt_t markerID, UInt_t* buffer, UInt_t num_words);
   UInt_t GetMarkerWord(UInt_t markerID);

--- a/Analysis/src/QwEventBuffer.cc
+++ b/Analysis/src/QwEventBuffer.cc
@@ -821,7 +821,7 @@ Bool_t QwEventBuffer::FillSubsystemData(QwSubsystemArray &subsystems)
     
     subsystems.SetCleanParameters(fCleanParameter);
 
-    Int_t nmarkers = CheckForMarkerWords(subsystems);
+    std::size_t nmarkers = CheckForMarkerWords(subsystems);
     if (nmarkers>0) {
       //  There are markerwords for this ROC/Bank
       for (size_t i=0; i<nmarkers; i++){
@@ -1224,7 +1224,7 @@ Int_t QwEventBuffer::CloseETStream()
 }
 
 //------------------------------------------------------------
-Int_t QwEventBuffer::CheckForMarkerWords(QwSubsystemArray &subsystems)
+std::size_t QwEventBuffer::CheckForMarkerWords(QwSubsystemArray &subsystems)
 {
   QwDebug << "QwEventBuffer::GetMarkerWordList:  start function" <<QwLog::endl;
   fThisRocBankLabel = decoder->GetROC();


### PR DESCRIPTION
This PR changes return type of `.size()` call to be `std::size_t` for unsigned correctness.