### PR TITLE
Avoid signed/unsigned integer comparison warning

### DIFF
--- a/Analysis/src/QwADC18_Channel.cc
+++ b/Analysis/src/QwADC18_Channel.cc
@@ -383,7 +383,7 @@ Int_t QwADC18_Channel::ProcessEvBuffer(UInt_t* buffer, UInt_t num_words_left, UI
   // Print buffer
   if (debug) {
     QwOut << GetElementName() << " : " << QwLog::endl << std::hex;
-    Int_t n = 25;
+    UInt_t n = 25;
     for (size_t i = 0; i < num_words_left; i++) {
       QwOut << "0x" << std::setfill('0') << std::setw(8) << buffer[i] << " ";
       if (i % n == n - 1) QwOut << QwLog::endl;


### PR DESCRIPTION
This PR fixes one signed/unsigned integer comparison warning by ensuring that `n` is UInt_t. It's the number of debug columns.