### PR TITLE
Replace header guards with filename-agnostic #pragma once

### DIFF
--- a/Analysis/include/Coda2EventDecoder.h
+++ b/Analysis/include/Coda2EventDecoder.h
@@ -3,8 +3,7 @@
  * \brief  CODA version 2 event decoder implementation
  */
 
-#ifndef CODA2EVENTDECODER_H
-#define CODA2EVENTDECODER_H
+#pragma once
 
 #include "VEventDecoder.h"
 #include "Rtypes.h"
@@ -78,4 +77,3 @@ private:
 	UInt_t fStatSum;  
 	UInt_t fIDBankNum;
 };
-#endif

--- a/Analysis/include/Coda3EventDecoder.h
+++ b/Analysis/include/Coda3EventDecoder.h
@@ -3,8 +3,7 @@
  * \brief  CODA version 3 event decoder implementation
  */
 
-#ifndef	CODA3EVENTDECODER_H
-#define CODA3EVENTDECODER_H
+#pragma once
 
 #include "VEventDecoder.h"
 #include "Rtypes.h"
@@ -151,4 +150,3 @@ protected:
 	// Currently implemented as 0
 	uint32_t TSROCNumber;
 };
-#endif

--- a/Analysis/include/MQwCodaControlEvent.h
+++ b/Analysis/include/MQwCodaControlEvent.h
@@ -3,8 +3,7 @@
  * \brief  CODA control event data structure and management
  */
 
-#ifndef __MQWCODACONTROLEVENT__
-#define __MQWCODACONTROLEVENT__
+#pragma once
 
 #include <vector>
 #include <iostream>
@@ -93,6 +92,3 @@ class MQwCodaControlEvent
   TDatime fStartDatime;
   TDatime fEndDatime;
 };
-
-
-#endif

--- a/Analysis/include/MQwHistograms.h
+++ b/Analysis/include/MQwHistograms.h
@@ -3,8 +3,7 @@
  * \brief  Mix-in class for histogram management functionality
  */
 
-#ifndef __MQWHISTOGRAMS__
-#define __MQWHISTOGRAMS__
+#pragma once
 
 // System headers
 #include <vector>
@@ -77,4 +76,3 @@ class MQwHistograms {
 
 }; // class MQwHistograms
 
-#endif // __MQWHISTOGRAMS__

--- a/Analysis/include/MQwMockable.h
+++ b/Analysis/include/MQwMockable.h
@@ -5,8 +5,7 @@
 * Date:   Tue Mar 29 13:08:12 EDT 2011                     *
 \**********************************************************/
 
-#ifndef __MQWMOCKABLE__
-#define __MQWMOCKABLE__
+#pragma once
 
 // Boost math library for random number generation
 #include "boost/random.hpp"
@@ -123,5 +122,3 @@ public:
   std::vector<Double_t> fMockDriftPhase;     ///< Harmonic drift phase
   // @}
 };
-
-#endif

--- a/Analysis/include/MQwPublishable.h
+++ b/Analysis/include/MQwPublishable.h
@@ -1,5 +1,4 @@
-#ifndef __MQWPUBLISHABLE__
-#define __MQWPUBLISHABLE__
+#pragma once
 
 // System headers
 #include <map>
@@ -218,5 +217,3 @@ class MQwPublishable {
     std::map<TString, TString>                   fPublishedValuesDescription;
  
 };
-
-#endif

--- a/Analysis/include/QwADC18_Channel.h
+++ b/Analysis/include/QwADC18_Channel.h
@@ -4,8 +4,7 @@
 * Author: P. M. King, W. Deconinck, B. Michaels            *
 \**********************************************************/
 
-#ifndef __QwADC18_CHANNEL__
-#define __QwADC18_CHANNEL__
+#pragma once
 
 // System headers
 #include <vector>
@@ -343,5 +342,3 @@ class QwADC18_Channel: public VQwHardwareChannel, public MQwMockable {
   Bool_t bSequence_number;
 
 };
-
-#endif

--- a/Analysis/include/QwColor.h
+++ b/Analysis/include/QwColor.h
@@ -3,8 +3,7 @@
  * \brief  ANSI color codes and color management for terminal output
  */
 
-#ifndef QWCOLOR_H
-#define QWCOLOR_H
+#pragma once
 
 // System headers
 #include <map>
@@ -158,5 +157,3 @@ inline std::ostream& operator<<(std::ostream& out, const QwColor& color)
 {
   return out << color.kColorMap[color.foreground];
 }
-
-#endif // QWCOLOR_H

--- a/Analysis/include/QwDBInterface.h
+++ b/Analysis/include/QwDBInterface.h
@@ -6,8 +6,7 @@
  * \date   2010-12-14
  */
 
-#ifndef QWDBINTERFACE_H_
-#define QWDBINTERFACE_H_
+#pragma once
 
 // System headers
 #include <iostream>
@@ -246,5 +245,3 @@ inline void QwErrDBInterface::AddThisEntryToList(std::vector<T> &list)
     PrintStatus(kTRUE);
   };
 }
-
-#endif /* QWDBINTERFACE_H_ */

--- a/Analysis/include/QwDatabase.h
+++ b/Analysis/include/QwDatabase.h
@@ -6,8 +6,7 @@
  * \date   2010-01-07
  */
 
-#ifndef QWDATABASE_HH
-#define QWDATABASE_HH
+#pragma once
 
 // System headers
 #include <map>
@@ -422,5 +421,3 @@ class QwDatabase {
     Bool_t fDBInsertMissingKeys; //!< True if missing keys should be inserted into the database automatically
 
 };
-
-#endif

--- a/Analysis/include/QwEPICSEvent.h
+++ b/Analysis/include/QwEPICSEvent.h
@@ -5,8 +5,7 @@
  * Adopted from G0EPICSEvent class.
  */
 
-#ifndef __QWEPICSEVENT__
-#define __QWEPICSEVENT__
+#pragma once
 
 // System headers
 #include <map>
@@ -201,5 +200,3 @@ class QwEPICSEvent
 
   
 }; // class QwEPICSEvent
-
-#endif // __QWEPICSEVENT__

--- a/Analysis/include/QwEventBuffer.h
+++ b/Analysis/include/QwEventBuffer.h
@@ -6,9 +6,7 @@
  * \date   2008-07-22
  */
 
-#ifndef __QWEVENTBUFFER__
-#define __QWEVENTBUFFER__
-
+#pragma once
 
 #include <string>
 #include <vector>
@@ -337,7 +335,3 @@ template < class T > Bool_t QwEventBuffer::FillObjectWithEventData(T &object){
   }
   return okay;
 }
-
-
-
-#endif

--- a/Analysis/include/QwFactory.h
+++ b/Analysis/include/QwFactory.h
@@ -3,8 +3,7 @@
  * \brief  Factory pattern implementation for creating analysis objects
  */
 
-#ifndef __QWFACTORY__
-#define __QWFACTORY__
+#pragma once
 
 // System headers
 #include <cxxabi.h>
@@ -268,6 +267,3 @@ class MQwDataElementCloneable: public MQwCloneable<VQwDataElement,dataelement_t>
 /// Macros to create and register the data element factory of type A
 /// Note: a call to this macro should be followed by a semi-colon!
 #define RegisterDataElementFactory(A) template<> const VQwDataElementFactory* MQwCloneable<VQwDataElement,A>::fFactory = new QwFactory<VQwDataElement,A>(#A)
-
-
-#endif // __QWFACTORY__

--- a/Analysis/include/QwHistogramHelper.h
+++ b/Analysis/include/QwHistogramHelper.h
@@ -7,8 +7,7 @@
 ///  describing histograms.
 ///  There will be a global copy defined within the analysis framework.
 
-#ifndef __QWHISTOGRAMHELPER__
-#define __QWHISTOGRAMHELPER__
+#pragma once
 
 #include <string>
 #include <vector>
@@ -170,7 +169,3 @@ class QwHistogramHelper{
 //  Declare a global copy of the histogram helper.
 //  It is instantiated in the source file.
 extern QwHistogramHelper gQwHists;
-
-#endif
-
-

--- a/Analysis/include/QwInterpolator.h
+++ b/Analysis/include/QwInterpolator.h
@@ -2,8 +2,7 @@
  * \brief  Multi-dimensional grid interpolation methods
  */
 
-#ifndef _QWINTERPOLATOR_H_
-#define _QWINTERPOLATOR_H_
+#pragma once
 
 // System headers
 #include <vector>
@@ -886,6 +885,3 @@ inline bool QwInterpolator<value_t,value_n>::ReadBinaryFile(const std::string& f
   file.close();
   return true;
 }
-
-
-#endif // _QWINTERPOLATOR_H_

--- a/Analysis/include/QwLog.h
+++ b/Analysis/include/QwLog.h
@@ -6,8 +6,7 @@
  * \date   2009-11-25
  */
 
-#ifndef QWLOG_HH
-#define QWLOG_HH
+#pragma once
 
 // System headers
 #include <iostream>
@@ -199,5 +198,3 @@ class QwLog : public std::ostream {
 };
 
 extern QwLog gQwLog;
-
-#endif

--- a/Analysis/include/QwMollerADC_Channel.h
+++ b/Analysis/include/QwMollerADC_Channel.h
@@ -6,8 +6,7 @@
  * \date   20021-05-25
  */
 
-#ifndef __QwMollerADC_CHANNEL__
-#define __QwMollerADC_CHANNEL__
+#pragma once
 
 // System headers
 #include <vector>
@@ -408,7 +407,3 @@ private:
 
 
 };
-
-
-
-#endif

--- a/Analysis/include/QwObjectCounter.h
+++ b/Analysis/include/QwObjectCounter.h
@@ -6,9 +6,7 @@
  *  \date   Nov 12, 2010
  */
 
-#ifndef QWOBJECTCOUNTER_H_
-#define QWOBJECTCOUNTER_H_
-
+#pragma once
 
 /**
  *  \class QwObjectCounter
@@ -67,5 +65,3 @@ size_t QwObjectCounter<T>::fObjectsCreated = 0;
 /// Initialize objects still alive counter
 template<typename T>
 size_t QwObjectCounter<T>::fObjectsAlive = 0;
-
-#endif /* QWOBJECTCOUNTER_H_ */

--- a/Analysis/include/QwOmnivore.h
+++ b/Analysis/include/QwOmnivore.h
@@ -3,8 +3,7 @@
  * \brief  An omnivorous subsystem template class
  */
 
-#ifndef QWOMNIVORE_H
-#define QWOMNIVORE_H
+#pragma once
 
 #include "VQwSubsystemParity.h"
 
@@ -127,5 +126,3 @@ class QwOmnivore: public VQwSubsystem_t {
     /// \brief Calculate the average for all good events
     void CalculateRunningAverage() override { };
 };
-
-#endif

--- a/Analysis/include/QwOptions.h
+++ b/Analysis/include/QwOptions.h
@@ -11,8 +11,7 @@
  * \brief  Command-line options processing using Boost.Program_options
  */
 
-#ifndef __QWOPTIONS__
-#define __QWOPTIONS__
+#pragma once
 
 // System headers
 #include <iostream>
@@ -322,5 +321,3 @@ class QwOptions {
 
     bool fParsed;
 };
-
-#endif // QWOPTIONS_H

--- a/Analysis/include/QwPMT_Channel.h
+++ b/Analysis/include/QwPMT_Channel.h
@@ -5,8 +5,7 @@
  * \date   2007-05-08
  */
 
-#ifndef __QwPMT_CHANNEL__
-#define __QwPMT_CHANNEL__
+#pragma once
 
 #include <vector>
 #include "TTree.h"
@@ -108,7 +107,3 @@ class QwPMT_Channel: public VQwDataElement {
   Int_t fCrate;                      ///< ROC number
   Int_t fModule;                     ///< slot number
 };
-
-
-
-#endif

--- a/Analysis/include/QwParameterFile.h
+++ b/Analysis/include/QwParameterFile.h
@@ -5,9 +5,7 @@
  * \date   2007-05-08
  */
 
-#ifndef __QWPARAMETERFILE__
-#define __QWPARAMETERFILE__
-
+#pragma once
 
 // System headers
 #include <vector>
@@ -410,5 +408,3 @@ template <>
 inline TString QwParameterFile::ConvertValue<TString>(const std::string& value) {
   return TString(value.c_str());
 }
-
-#endif // __QWPARAMETERFILE__

--- a/Analysis/include/QwPromptSummary.h
+++ b/Analysis/include/QwPromptSummary.h
@@ -5,8 +5,7 @@
  * \date   2011-12-16
  */
 
-#ifndef __QwPromptSummary__
-#define __QwPromptSummary__
+#pragma once
 
 #include <iostream>
 #include <fstream>
@@ -195,6 +194,3 @@ private:
   ClassDefOverride(QwPromptSummary,0);
 
 };
-
-
-#endif

--- a/Analysis/include/QwRint.h
+++ b/Analysis/include/QwRint.h
@@ -3,8 +3,7 @@
  * \brief  ROOT interactive interface for Qweak analysis
  */
 
-#ifndef __QwRint_h__
-#define __QwRint_h__
+#pragma once
 
 // ROOT headers
 #include <TRint.h>
@@ -42,5 +41,3 @@ class QwRint : public TRint {
     ~QwRint() override;
 
 }; // class QwRint
-
-#endif // __QwRint_h__

--- a/Analysis/include/QwRootFile.h
+++ b/Analysis/include/QwRootFile.h
@@ -3,8 +3,7 @@
  * \brief  ROOT file and tree management wrapper classes
  */
 
-#ifndef __QWROOTFILE__
-#define __QWROOTFILE__
+#pragma once
 
 // System headers
 #include <typeindex>
@@ -1266,6 +1265,3 @@ Int_t QwRootFile::WriteParamFileList(const TString &name, T& object)
   }
   return retval;
 }
-
-
-#endif // __QWROOTFILE__

--- a/Analysis/include/QwRunCondition.h
+++ b/Analysis/include/QwRunCondition.h
@@ -5,9 +5,7 @@
  * \date   2010-09-09
  */
 
-#ifndef __QwRunCondition__
-#define __QwRunCondition__
-
+#pragma once
 
 #include <unistd.h>
 #include <iostream>
@@ -80,5 +78,3 @@ class QwRunCondition
 //         std::cout << list->At(i)->GetName() << std::endl;
 //    }
 //  }
-
-#endif

--- a/Analysis/include/QwScaler_Channel.h
+++ b/Analysis/include/QwScaler_Channel.h
@@ -6,8 +6,7 @@
  * \date   Thu Sep 16 18:08:33 CDT 2009
  */
 
-#ifndef __QWSCALER_CHANNEL__
-#define __QWSCALER_CHANNEL__
+#pragma once
 
 // System headers
 #include <vector>
@@ -301,6 +300,3 @@ typedef class QwScaler_Channel<0x00ffffff,0> QwSIS3801D24_Channel;
 typedef class QwScaler_Channel<0xffffffff,0> QwSIS3801D32_Channel;
 typedef class QwScaler_Channel<0xffffffff,0>    QwSIS3801_Channel;
 typedef class QwScaler_Channel<0xffffffff,0>    QwSTR7200_Channel;
-
-
-#endif

--- a/Analysis/include/QwSubsystemArray.h
+++ b/Analysis/include/QwSubsystemArray.h
@@ -5,8 +5,7 @@
  * \date   2008-07-22
  */
 
-#ifndef __QWSUBSYSTEMARRAY__
-#define __QWSUBSYSTEMARRAY__
+#pragma once
 
 #include <vector>
 #include <map>
@@ -318,6 +317,3 @@ protected:
   
 
 }; // class QwSubsystemArray
-
-
-#endif // __QWSUBSYSTEMARRAY__

--- a/Analysis/include/QwTypes.h
+++ b/Analysis/include/QwTypes.h
@@ -3,8 +3,7 @@
  * \brief  Basic data types and constants used throughout the Qweak analysis framework
  */
 
-#ifndef QWTYPES_H
-#define QWTYPES_H
+#pragma once
 
 // C and C++ headers
 #include <map>
@@ -323,5 +322,3 @@ typedef class QwMollerADC_Channel QwBeamCharge;
 typedef class QwMollerADC_Channel QwBeamPosition;
 typedef class QwMollerADC_Channel QwBeamAngle;
 typedef class QwMollerADC_Channel QwBeamEnergy;
-
-#endif

--- a/Analysis/include/QwUnits.h
+++ b/Analysis/include/QwUnits.h
@@ -3,8 +3,7 @@
  * \brief  Physical units and constants for Qweak analysis
  */
 
-#ifndef QWUNITS_H
-#define QWUNITS_H
+#pragma once
 
 /**
  * \ingroup QwAnalysis
@@ -143,5 +142,3 @@ namespace Qw {
   //@}
 
 } // namespace Qw
-
-#endif // QWUNITS_H

--- a/Analysis/include/QwVQWK_Channel.h
+++ b/Analysis/include/QwVQWK_Channel.h
@@ -6,8 +6,7 @@
  * \date   2007-05-08
  */
 
-#ifndef __QwVQWK_CHANNEL__
-#define __QwVQWK_CHANNEL__
+#pragma once
 
 // System headers
 #include <vector>
@@ -406,7 +405,3 @@ private:
 
 
 };
-
-
-
-#endif

--- a/Analysis/include/QwWord.h
+++ b/Analysis/include/QwWord.h
@@ -10,8 +10,7 @@
  * \brief  Word-level data manipulation and bit operations
  */
 
-#ifndef __QWWORD__
-#define __QWWORD__
+#pragma once
 
 // ROOT headers
 #include "Rtypes.h"
@@ -67,7 +66,3 @@ class QwWord
    
 
 };
-
-
-
-#endif /* QWWORD_H_ */

--- a/Analysis/include/VEventDecoder.h
+++ b/Analysis/include/VEventDecoder.h
@@ -3,8 +3,7 @@
  * \brief  Virtual base class for event decoders to encode and decode CODA data
  */
 
-#ifndef VEVENTDECODER_H
-#define VEVENTDECODER_H
+#pragma once
 
 #include <vector>
 
@@ -171,5 +170,3 @@ protected:
 	};
 
 };
-
-#endif

--- a/Analysis/include/VQwAnalyzer.h
+++ b/Analysis/include/VQwAnalyzer.h
@@ -3,8 +3,7 @@
  * \brief  Virtual base class for analyzer implementations
  */
 
-#ifndef __VQwAnalyzer_h__
-#define __VQwAnalyzer_h__
+#pragma once
 
 #include <iostream>
 
@@ -44,5 +43,3 @@ class VQwAnalyzer : public VQwSystem {
     };
 
 };
-
-#endif // __VQwAnalyzer_h__

--- a/Analysis/include/VQwDataElement.h
+++ b/Analysis/include/VQwDataElement.h
@@ -6,8 +6,7 @@
  * \date   2007-05-08 15:40
  */
 
-#ifndef __VQWDATAELEMENT__
-#define __VQWDATAELEMENT__
+#pragma once
 
 // System headers
 #include <vector>
@@ -270,5 +269,3 @@ class VQwDataElement: public MQwHistograms {
   UInt_t fErrorConfigFlag; ///<contains the global/local/stability flags
 //@}
 }; // class VQwDataElement
-
-#endif // __VQWDATAELEMENT__

--- a/Analysis/include/VQwHardwareChannel.h
+++ b/Analysis/include/VQwHardwareChannel.h
@@ -5,8 +5,7 @@
 * Date:   Tue Mar 29 13:08:12 EDT 2011                     *
 \**********************************************************/
 
-#ifndef __VQWHARDWARECHANNEL__
-#define __VQWHARDWARECHANNEL__
+#pragma once
 
 // System headers
 #include <cmath>
@@ -360,5 +359,3 @@ protected:
   // @}
 
 };   // class VQwHardwareChannel
-
-#endif // __MQWHARDWARECHANNEL__

--- a/Analysis/include/VQwSubsystem.h
+++ b/Analysis/include/VQwSubsystem.h
@@ -6,8 +6,7 @@
  * \date   2007-05-08 15:40
  */
 
-#ifndef __VQWSUBSYSTEM__
-#define __VQWSUBSYSTEM__
+#pragma once
 
 // System headers
 #include <iostream>
@@ -514,6 +513,3 @@ class VQwSubsystem: virtual public VQwSubsystemCloneable, public MQwHistograms, 
   VQwSubsystem();
 
 }; // class VQwSubsystem
-
-
-#endif // __VQWSUBSYSTEM__

--- a/Analysis/include/VQwSystem.h
+++ b/Analysis/include/VQwSystem.h
@@ -3,8 +3,7 @@
  * \brief  Virtual base class for all Qweak system objects
  */
 
-#ifndef __VQwSystem_h__
-#define __VQwSystem_h__
+#pragma once
 
 #include "TROOT.h"
 #include "TNamed.h"
@@ -24,5 +23,3 @@ class VQwSystem : public TNamed {
     virtual ~VQwSystem() { };
 
 };
-
-#endif // __VQwSystem_h__

--- a/Parity/include/LRBCorrector.h
+++ b/Parity/include/LRBCorrector.h
@@ -5,8 +5,7 @@
  * \date   2018-08-01
  */
 
-#ifndef LRBCORRECTOR_H_
-#define LRBCORRECTOR_H_
+#pragma once
 
 // Parent Class
 #include "VQwDataHandler.h"
@@ -68,6 +67,3 @@ class LRBCorrector : public VQwDataHandler, public MQwDataHandlerCloneable<LRBCo
     std::map<Short_t,std::vector<std::vector<Double_t>>> fSensitivity;
     
 };
-
-
-#endif // LRBCORRECTOR_H_

--- a/Parity/include/LinReg_Bevington_Pebay.h
+++ b/Parity/include/LinReg_Bevington_Pebay.h
@@ -3,10 +3,16 @@
  * \brief  Linear regression utility class based on Bevington and Pebay algorithms
  * \author Jan Balewski, MIT
  * \date   2010
+ *
+ * References:
+ *  "Data reduction and error analysis for the physical sciences"
+ *   Philip R. Bevington, D. Keith Robinson. Bevington, Philip R., 1933- Boston : McGraw-Hill, c2003.
+ *
+ *  "Formulas for Robust, One-Pass Parallel Computation of Covariances and Arbitrary-Order Statistical Moments"
+ *  Philippe Pebay, SANDIA REPORT SAND2008-6212, Unlimited Release, Printed September 2008
  */
 
-#ifndef LINREGBEVPEB_h
-#define LINREGBEVPEB_h
+#pragma once
 
 // System headers
 #include <utility>
@@ -121,5 +127,3 @@ inline std::ostream& operator<< (std::ostream& stream, const LinRegBevPeb& h)
   stream << "LRB: " << h.fGoodEventNumber << " events";
   return stream;
 }
-
-#endif

--- a/Parity/include/QwAlarmHandler.h
+++ b/Parity/include/QwAlarmHandler.h
@@ -5,8 +5,7 @@
  * \date   2010-10-22
  */
 
-#ifndef QWALARMHANDLER_H_
-#define QWALARMHANDLER_H_
+#pragma once
 
 // Parent Class
 #include "VQwDataHandler.h"
@@ -124,5 +123,3 @@ inline std::ostream& operator<< (std::ostream& stream, const QwAlarmHandler::EQw
   }
   return stream;
 }
-
-#endif // QWALARMHANDLER_H_

--- a/Parity/include/QwBCM.h
+++ b/Parity/include/QwBCM.h
@@ -3,8 +3,7 @@
  * \brief  Beam current monitor template class
  */
 
-#ifndef __QWBCM__
-#define __QWBCM__
+#pragma once
 
 // System headers
 #include <vector>
@@ -192,6 +191,3 @@ public:
  Double_t fResolution;
 
 };
-
-
-#endif // __QWBCM__

--- a/Parity/include/QwBPMCavity.h
+++ b/Parity/include/QwBPMCavity.h
@@ -3,8 +3,7 @@
  * \brief  Cavity beam position monitor implementation
  */
 
-#ifndef __QwVQWK_CAVITY__
-#define __QwVQWK_CAVITY__
+#pragma once
 
 // System headers
 #include <vector>
@@ -174,6 +173,3 @@ class QwBPMCavity : public VQwBPM {
   std::vector<QwVQWK_Channel> fBPMElementList;
 
 };
-
-
-#endif

--- a/Parity/include/QwBPMStripline.h
+++ b/Parity/include/QwBPMStripline.h
@@ -3,8 +3,7 @@
  * \brief  Stripline beam position monitor implementation
  */
 
-#ifndef __QwBPMSTRIPLINE__
-#define __QwBPMSTRIPLINE__
+#pragma once
 
 // System headers
 #include <vector>
@@ -226,6 +225,3 @@ private:
 
 
 };
-
-
-#endif

--- a/Parity/include/QwBeamDetectorID.h
+++ b/Parity/include/QwBeamDetectorID.h
@@ -3,8 +3,7 @@
  * \brief  Beam detector identification and mapping class
  */
 
-#ifndef __QWBEAMDETECTORID__
-#define __QWBEAMDETECTORID__
+#pragma once
 
 // ROOT headers
 #include "Rtypes.h"
@@ -57,5 +56,3 @@ private:
   QwBeamDetectorID();
 
 };
-
-#endif

--- a/Parity/include/QwBeamLine.h
+++ b/Parity/include/QwBeamLine.h
@@ -3,8 +3,7 @@
  * \brief  Beamline subsystem containing BPMs, BCMs, and other beam monitoring devices
  */
 
-#ifndef __QwBEAMLINE__
-#define __QwBEAMLINE__
+#pragma once
 
 // System headers
 #include <vector>
@@ -217,5 +216,3 @@ private:
   
 
 };
-
-#endif

--- a/Parity/include/QwBeamMod.h
+++ b/Parity/include/QwBeamMod.h
@@ -5,8 +5,7 @@
  * \date   2010-05-25
  */
 
-#ifndef __QwBEAMMOD__
-#define __QwBEAMMOD__
+#pragma once
 
 // System headers
 #include <vector>
@@ -230,5 +229,3 @@ class QwBeamMod: public VQwSubsystemParity, public MQwSubsystemCloneable<QwBeamM
  UInt_t fBmwObj_ErrorFlag;
 
 };
-
-#endif

--- a/Parity/include/QwBlindDetectorArray.h
+++ b/Parity/include/QwBlindDetectorArray.h
@@ -7,8 +7,7 @@
 
 /// \ingroup QwAnalysis_ADC
 
-#ifndef __QWBLINDDETECTORARRAY__
-#define __QWBLINDDETECTORARRAY__
+#pragma once
 
 // System headers
 #include <vector>
@@ -81,6 +80,3 @@ class QwBlindDetectorArray:
 #endif // HAS_RNTUPLE_SUPPORT
 
 };
-
-
-#endif

--- a/Parity/include/QwBlinder.h
+++ b/Parity/include/QwBlinder.h
@@ -11,8 +11,7 @@
  * \brief  Data blinding utilities for parity violation analysis
  */
 
-#ifndef __QWBLINDER__
-#define __QWBLINDER__
+#pragma once
 
 // System headers
 #include <vector>
@@ -317,5 +316,3 @@ class QwBlinder {
     std::vector<Int_t> fPatternCounters; ///< Counts the number of events in each failure mode
     std::vector<Int_t> fPairCounters; ///< Counts the number of helicity pairs in each failure mode
 };
-
-#endif //__QWBLINDER__

--- a/Parity/include/QwClock.h
+++ b/Parity/include/QwClock.h
@@ -6,8 +6,7 @@
  * \date   2011-06-16
  */
 
-#ifndef __QWCLOCK__
-#define __QWCLOCK__
+#pragma once
 
 // System headers
 #include <vector>
@@ -183,5 +182,3 @@ class QwClock : public VQwClock {
   Double_t fNormalizationValue;
 
 };
-
-#endif // __QWCLOCK__

--- a/Parity/include/QwCombinedBCM.h
+++ b/Parity/include/QwCombinedBCM.h
@@ -3,8 +3,7 @@
  * \brief  Combined beam current monitor using weighted average of multiple BCMs
  */
 
-#ifndef __Qw_COMBINEDBCM__
-#define __Qw_COMBINEDBCM__
+#pragma once
 
 // System headers
 #include <vector>
@@ -137,5 +136,3 @@ public:
   static void SetTripSeed(uint seedval);
   // @}
 };
-
-#endif

--- a/Parity/include/QwCombinedBPM.h
+++ b/Parity/include/QwCombinedBPM.h
@@ -4,8 +4,7 @@
  * \author B. Waidyawansa
  */
 
-#ifndef __QwCOMBINEDBPM__
-#define __QwCOMBINEDBPM__
+#pragma once
 
 // System headers
 #include <vector>
@@ -239,7 +238,3 @@ private:
   std::vector<T> fBPMComboElementList;
 
 };
-
-
-
-#endif

--- a/Parity/include/QwCombinedPMT.h
+++ b/Parity/include/QwCombinedPMT.h
@@ -1,11 +1,9 @@
-
 /*!
  * \file   QwCombinedPMT.h
  * \brief  Combined PMT detector using Moller ADC channels
  */
 
-#ifndef __QwMollerADC_COMBINEDPMT__
-#define __QwMollerADC_COMBINEDPMT__
+#pragma once
 
 // System headers
 #include <vector>
@@ -179,5 +177,3 @@ class QwCombinedPMT : public VQwDataElement {
   const static  Bool_t bDEBUG=kFALSE; /// debugging display purposes
 
 };
-
-#endif

--- a/Parity/include/QwCombiner.h
+++ b/Parity/include/QwCombiner.h
@@ -5,8 +5,7 @@
  * \date   2010-10-22
  */
 
-#ifndef QWCOMBINER_H_
-#define QWCOMBINER_H_
+#pragma once
 
 // Parent Class
 #include "VQwDataHandler.h"
@@ -79,6 +78,3 @@ inline std::ostream& operator<< (std::ostream& stream, const QwCombiner::EQwHand
   }
   return stream;
 }
-
-
-#endif // QWCOMBINER_H_

--- a/Parity/include/QwCombinerSubsystem.h
+++ b/Parity/include/QwCombinerSubsystem.h
@@ -5,9 +5,7 @@
  * \date   2011-08-11
  */
 
-
-#ifndef __QWCOMBINERSUBSYSTEM__
-#define __QWCOMBINERSUBSYSTEM__
+#pragma once
 
 // headers
 #include "VQwSubsystemParity.h"
@@ -140,7 +138,3 @@ class QwCombinerSubsystem: public VQwSubsystemParity,
 
       
 }; // class QwCombinerSubsystem
-
-
-#endif // __QWCOMBINERSUBSYSTEM__
-

--- a/Parity/include/QwCorrelator.h
+++ b/Parity/include/QwCorrelator.h
@@ -5,8 +5,7 @@
  * \date   2018-08-01
  */
 
-#ifndef QWCORRELATOR_H_
-#define QWCORRELATOR_H_
+#pragma once
 
 // Parent Class
 #include "VQwDataHandler.h"
@@ -139,6 +138,3 @@ class QwCorrelator : public VQwDataHandler, public MQwDataHandlerCloneable<QwCor
   QwCorrelator();
 
 };
-
-
-#endif //QWCORRELATOR_H_

--- a/Parity/include/QwDataHandlerArray.h
+++ b/Parity/include/QwDataHandlerArray.h
@@ -5,8 +5,7 @@
  * \date   2009-02-04
  */
 
-#ifndef __QWDATAHANDLERARRAY__
-#define __QWDATAHANDLERARRAY__
+#pragma once
 
 #include <vector>
 #include <map>
@@ -226,5 +225,3 @@ class QwDataHandlerArray:
     };
 
 }; // class QwDataHandlerArray
-
-#endif // __QWDATAHANDLERARRAY__

--- a/Parity/include/QwDetectorArray.h
+++ b/Parity/include/QwDetectorArray.h
@@ -7,8 +7,7 @@
 
 /// \ingroup QwAnalysis_ADC
 
-#ifndef __QWDETECTORARRAY__
-#define __QWDETECTORARRAY__
+#pragma once
 
 // System headers
 #include <vector>
@@ -64,5 +63,3 @@ QwDetectorArray(const QwDetectorArray& source)
 ~QwDetectorArray() override {};
 
 };
-
-#endif

--- a/Parity/include/QwEnergyCalculator.h
+++ b/Parity/include/QwEnergyCalculator.h
@@ -6,8 +6,7 @@
  * \date   05-24-2010
  */
 
-#ifndef __QwVQWK_ENERGYCALCULATOR__
-#define __QwVQWK_ENERGYCALCULATOR__
+#pragma once
 
 // System headers
 #include <vector>
@@ -165,5 +164,3 @@ class QwEnergyCalculator : public VQwDataElement{
 
 
 };
-
-#endif

--- a/Parity/include/QwEventRing.h
+++ b/Parity/include/QwEventRing.h
@@ -10,8 +10,7 @@
  * \brief  Event ring buffer for burp detection and stability monitoring
  */
 
-#ifndef __QwEventRing__
-#define __QwEventRing__
+#pragma once
 
 #include <vector>
 
@@ -110,8 +109,3 @@ class QwEventRing {
   Int_t fBurpPrecut;
   QwSubsystemArrayParity fBurpAvg;
 };
-
-
-
-
-#endif

--- a/Parity/include/QwExtractor.h
+++ b/Parity/include/QwExtractor.h
@@ -5,8 +5,7 @@
  * \date   2019-11-22
  */
 
-#ifndef QWEXTRACTOR_H_
-#define QWEXTRACTOR_H_
+#pragma once
 
 // Parent Class
 #include "VQwDataHandler.h"
@@ -62,6 +61,3 @@ class QwExtractor:public VQwDataHandler, public MQwDataHandlerCloneable<QwExtrac
     QwExtractor();
 
 }; // class QwExtractor
-
-#endif // QWEXTRACTOR_H_
-

--- a/Parity/include/QwFakeHelicity.h
+++ b/Parity/include/QwFakeHelicity.h
@@ -10,9 +10,7 @@
   related calculations.
 */
 
-
-#ifndef __QwFAKEHELICITY__
-#define __QwFAKEHELICITY__
+#pragma once
 
 #include "QwHelicity.h"
 
@@ -49,5 +47,3 @@ class QwFakeHelicity: public QwHelicity {
     UInt_t GetRandbit(UInt_t& ranseed) override;
 
 };
-
-#endif

--- a/Parity/include/QwHaloMonitor.h
+++ b/Parity/include/QwHaloMonitor.h
@@ -5,8 +5,7 @@
  * \date   2010-06-24
  */
 
-#ifndef __QwHALO_MONITOR__
-#define __QwHALO_MONITOR__
+#pragma once
 
 // System headers
 #include <vector>
@@ -158,6 +157,3 @@ class  QwHaloMonitor : public VQwDataElement{
   Bool_t bEVENTCUTMODE;//If this set to kFALSE then Event cuts do not depend on HW ckecks. This is set externally through the qweak_beamline_eventcuts.map
 
 };
-
-
-#endif

--- a/Parity/include/QwHelicity.h
+++ b/Parity/include/QwHelicity.h
@@ -10,8 +10,7 @@
  * \brief  Helicity state management and pattern recognition
  */
 
-#ifndef __QWHELICITY__
-#define __QWHELICITY__
+#pragma once
 
 // System headers
 #include <vector>
@@ -334,8 +333,3 @@ class QwHelicity: public VQwSubsystemParity, public MQwSubsystemCloneable<QwHeli
   }
 
 };
-
-
-#endif
-
-

--- a/Parity/include/QwHelicityPattern.h
+++ b/Parity/include/QwHelicityPattern.h
@@ -4,8 +4,8 @@
  * \author P. M. King
  * \date   2007-05-08
  */
-#ifndef __QwHelicityPattern__
-#define __QwHelicityPattern__
+
+#pragma once
 
 // System headers
 #include <vector>
@@ -290,6 +290,3 @@ class QwHelicityPattern {
 
   friend class QwDataHandlerArray;
 };
-
-
-#endif

--- a/Parity/include/QwIntegratedRaster.h
+++ b/Parity/include/QwIntegratedRaster.h
@@ -3,8 +3,7 @@
  * \brief  Integrated raster subsystem for beam position tracking
  */
 
-#ifndef __QwIntegratedRaster__
-#define __QwIntegratedRaster__
+#pragma once
 
 // System headers
 #include <vector>
@@ -184,8 +183,3 @@ private:
   static const Bool_t bDEBUG=kFALSE;
 
 };
-
-
-
-
-#endif

--- a/Parity/include/QwIntegratedRasterChannel.h
+++ b/Parity/include/QwIntegratedRasterChannel.h
@@ -3,8 +3,7 @@
  * \brief  Integrated raster channel template class for position data
  */
 
-#ifndef __QwIntegratedRasterChannel__
-#define __QwIntegratedRasterChannel__
+#pragma once
 
 // System headers
 #include <vector>
@@ -143,5 +142,3 @@ class QwIntegratedRasterChannel : public VQwDataElement{
 
 
 };
-
-#endif

--- a/Parity/include/QwIntegrationPMT.h
+++ b/Parity/include/QwIntegrationPMT.h
@@ -3,8 +3,7 @@
  * \brief  Integration PMT detector for charge and asymmetry measurements
  */
 
-#ifndef __QwMollerADC_IntegrationPMT__
-#define __QwMollerADC_IntegrationPMT__
+#pragma once
 
 // System headers
 #include <vector>
@@ -216,7 +215,3 @@ void RandomizeMollerEvent(int helicity, const QwBeamCharge& charge, const QwBeam
   const static  Bool_t bDEBUG=kFALSE;//debugging display purposes
   Bool_t bEVENTCUTMODE; //global switch to turn event cuts ON/OFF
 };
-
-
-
-#endif

--- a/Parity/include/QwLinearDiodeArray.h
+++ b/Parity/include/QwLinearDiodeArray.h
@@ -5,8 +5,7 @@
  * \date   2010-09-14
  */
 
-#ifndef __QwLinearDiodeArray__
-#define __QwLinearDiodeArray__
+#pragma once
 
 // System headers
 #include <vector>
@@ -175,6 +174,3 @@ class QwLinearDiodeArray : public VQwBPM {
   std::vector<QwVQWK_Channel> fLinearArrayElementList;
 
 };
-
-
-#endif

--- a/Parity/include/QwMollerDetector.h
+++ b/Parity/include/QwMollerDetector.h
@@ -6,9 +6,7 @@
  * \ingroup QwMoller
  */
 
-
-#ifndef __QwMollerDetector__
-#define __QwMollerDetector__
+#pragma once
 
 // System headers
 #include <vector>
@@ -173,5 +171,3 @@ class QwMollerDetector:
     UInt_t fNumberOfEvents; //! Number of triggered events
 
 };
-
-#endif // __QwMollerDetector__

--- a/Parity/include/QwOptionsParity.h
+++ b/Parity/include/QwOptionsParity.h
@@ -11,8 +11,7 @@
  * \date   2009-12-10
  */
 
-#ifndef QWOPTIONSPARITY_H
-#define QWOPTIONSPARITY_H
+#pragma once
 
 // Qweak options header (should be first)
 #include "QwOptions.h"
@@ -46,5 +45,3 @@ void DefineOptionsParity(QwOptions& options)
   QwParityDB::DefineAdditionalOptions(options);
   #endif //__USE_DATABASE__
 }
-
-#endif // QWOPTIONSPARITY_H

--- a/Parity/include/QwParityDB.h
+++ b/Parity/include/QwParityDB.h
@@ -6,9 +6,9 @@
  * \date   2010-01-07
  */
 
+#pragma once
+
 #ifdef __USE_DATABASE__
-#ifndef QWPARITYDB_HH
-#define QWPARITYDB_HH
 
 // System headers
 #include <map>
@@ -117,8 +117,5 @@ class QwParityDB: public QwDatabase {
     friend class StoreSlowControlDetectorID;
     friend class StoreErrorCodeID;
 };
-
-
-#endif
 
 #endif // #ifdef __USE_DATABASE__                                                                                                         

--- a/Parity/include/QwQPD.h
+++ b/Parity/include/QwQPD.h
@@ -6,8 +6,7 @@
  * \date   09-14-2010
  */
 
-#ifndef __QwQPD__
-#define __QwQPD__
+#pragma once
 
 // System headers
 #include <vector>
@@ -176,6 +175,3 @@ class QwQPD : public VQwBPM {
   std::vector<QwVQWK_Channel> fQPDElementList;
 
 };
-
-
-#endif

--- a/Parity/include/QwScaler.h
+++ b/Parity/include/QwScaler.h
@@ -1,12 +1,9 @@
-
-
 /*!
  * \file   QwScaler.h
  * \brief  Scaler subsystem for counting and rate measurements
  */
 
-#ifndef __QWSCALER__
-#define __QWSCALER__
+#pragma once
 
 // System headers
 #include <vector>
@@ -152,5 +149,3 @@ class QwScaler: public VQwSubsystemParity, public MQwSubsystemCloneable<QwScaler
     std::vector< UInt_t > fBufferOffset; // Offset in scaler buffer
     std::vector< std::pair< VQwScaler_Channel*, double > > fNorm;
 };
-
-#endif

--- a/Parity/include/QwSubsystemArrayParity.h
+++ b/Parity/include/QwSubsystemArrayParity.h
@@ -10,8 +10,7 @@
  * \brief  Subsystem array container for parity analysis with asymmetry calculations
  */
 
-#ifndef __QWSUBSYSTEMARRAYPARITY__
-#define __QWSUBSYSTEMARRAYPARITY__
+#pragma once
 
 #include <vector>
 #include <TTree.h>
@@ -157,5 +156,3 @@ class QwSubsystemArrayParity: public QwSubsystemArray {
     Int_t  fErrorFlagTreeIndex;
 
 }; // class QwSubsystemArrayParity
-
-#endif // __QWSUBSYSTEMARRAYPARITY__

--- a/Parity/include/QwUtil.h
+++ b/Parity/include/QwUtil.h
@@ -5,8 +5,7 @@
  * \date   2023-08-16
  */
 
-#ifndef QWANALYSIS_QWUTIL_H
-#define QWANALYSIS_QWUTIL_H
+#pragma once
 
 #include <algorithm>
 #include <iterator>
@@ -18,5 +17,3 @@ void QwCopyArray( const T& a, T& b ) {
     b.at(i).CopyFrom(a.at(i));
   }
 }
-
-#endif //QWANALYSIS_QWUTIL_H

--- a/Parity/include/VQwBCM.h
+++ b/Parity/include/VQwBCM.h
@@ -10,8 +10,7 @@
  * \brief  Virtual base class for beam current monitors
  */
 
-#ifndef __VQWBCM__
-#define __VQWBCM__
+#pragma once
 
 // System headers
 #include <vector>
@@ -183,5 +182,3 @@ protected:
 };
 
 typedef std::shared_ptr<VQwBCM> VQwBCM_ptr;
-
-#endif // __VQWBCM__

--- a/Parity/include/VQwBPM.h
+++ b/Parity/include/VQwBPM.h
@@ -5,14 +5,12 @@
 * Time-stamp: <2010-05-24>                                 *
 \**********************************************************/
 
-
 /*!
  * \file   VQwBPM.h
  * \brief  Virtual base class for beam position monitors
  */
 
-#ifndef __VQWBPM__
-#define __VQWBPM__
+#pragma once
 
 // ROOT headers
 #include <TTree.h>
@@ -354,7 +352,3 @@ public:
 };
 
 typedef std::shared_ptr<VQwBPM> VQwBPM_ptr;
-
-#endif
-
-

--- a/Parity/include/VQwClock.h
+++ b/Parity/include/VQwClock.h
@@ -5,8 +5,7 @@
 * Time-stamp: <2011-06-16>                               *
 \********************************************************/
 
-#ifndef __VQWCLOCK__
-#define __VQWCLOCK__
+#pragma once
 
 // System headers
 #include <vector>
@@ -120,5 +119,3 @@ public:
 };
 
 typedef std::shared_ptr<VQwClock> VQwClock_ptr;
-
-#endif // __VQWCLOCK__

--- a/Parity/include/VQwDataHandler.h
+++ b/Parity/include/VQwDataHandler.h
@@ -5,8 +5,7 @@
  * \date   2018-08-01
  */
 
-#ifndef VQWDATAHANDLER_H_
-#define VQWDATAHANDLER_H_
+#pragma once
 
 // Qweak headers
 #include "QwHelicityPattern.h"
@@ -210,5 +209,3 @@ class VQwDataHandler:  virtual public VQwDataHandlerCloneable, public MQwPublish
    Bool_t fRunningsumFillsTree;
    VQwDataHandler *fRunningsum;
 };
-
-#endif // VQWDATAHANDLER_H_

--- a/Parity/include/VQwDetectorArray.h
+++ b/Parity/include/VQwDetectorArray.h
@@ -13,8 +13,7 @@
  * \brief  Virtual base class for detector arrays (PMTs, etc.)
  */
 
-#ifndef __VQWDETECTORARRAY__
-#define __VQWDETECTORARRAY__
+#pragma once
 
 // System headers
 #include <vector>
@@ -281,6 +280,3 @@ class VQwDetectorArray: virtual public VQwSubsystemParity {
   Int_t fMainDetErrorCount;
 
 };
-
-
-#endif

--- a/Parity/include/VQwSubsystemParity.h
+++ b/Parity/include/VQwSubsystemParity.h
@@ -5,9 +5,7 @@
  * \date   2007-05-08
  */
 
-
-#ifndef __VQWSUBSYSTEMPARITY__
-#define __VQWSUBSYSTEMPARITY__
+#pragma once
 
 // ROOT headers
 #include <TTree.h>
@@ -154,5 +152,3 @@ class VQwSubsystemParity: virtual public VQwSubsystem {
     virtual void LoadMockDataParameters(TString /*mapfile*/) {};
 	
 }; // class VQwSubsystemParity
-
-#endif // __VQWSUBSYSTEMPARITY__


### PR DESCRIPTION
This PR replaces all header guards with `#pragma once`, which is better maintainable when class source is copied.