### PR TITLE
Avoid comparison of unsigned int with -1

### DIFF
--- a/Analysis/src/QwEventBuffer.cc
+++ b/Analysis/src/QwEventBuffer.cc
@@ -825,15 +825,13 @@ Bool_t QwEventBuffer::FillSubsystemData(QwSubsystemArray &subsystems)
     if (nmarkers>0) {
       //  There are markerwords for this ROC/Bank
       for (size_t i=0; i<nmarkers; i++){
-	offset = FindMarkerWord(i,&localbuff[decoder->GetWordsSoFar()],decoder->GetFragLength());
-	BankID_t tmpbank = GetMarkerWord(i);
-	tmpbank = ((tmpbank)<<32) + decoder->GetSubbankTag();
-	if (offset != -1){
-	  offset++; //  Skip the marker word
-	  subsystems.ProcessEvBuffer(decoder->GetEvtType(), decoder->GetROC(), tmpbank,
+        offset = FindMarkerWord(i,&localbuff[decoder->GetWordsSoFar()],decoder->GetFragLength());
+	      BankID_t tmpbank = GetMarkerWord(i);
+        tmpbank = ((tmpbank)<<32) + decoder->GetSubbankTag();
+        offset++; //  Skip the marker word
+        subsystems.ProcessEvBuffer(decoder->GetEvtType(), decoder->GetROC(), tmpbank,
 				     &localbuff[decoder->GetWordsSoFar()+offset],
 				     decoder->GetFragLength()-offset);
-	}
       }
     } else {
       QwDebug << "QwEventBuffer::FillSubsystemData:  "


### PR DESCRIPTION
This PR avoids `if (offset != -1)` for unsigned int `offset`. There does not seem to be any way to get a -1 into offset.