### PR TITLE
Refactor class hierarchy to avoid virtual inheritance

### DIFF
--- a/Analysis/include/QwOmnivore.h
+++ b/Analysis/include/QwOmnivore.h
@@ -2,10 +2,6 @@
 #define QWOMNIVORE_H
 
 #include "VQwSubsystemParity.h"
-//#include "VQwSubsystemTracking.h"
-
-//#include "QwHitContainer.h"
-//#include "QwDetectorInfo.h"
 
 /**
  *  \class QwOmnivore
@@ -21,10 +17,12 @@ class QwOmnivore: public VQwSubsystem_t {
 
   public:
     /// Constructor with name
-    QwOmnivore(const TString& name): VQwSubsystem(name),VQwSubsystem_t(name) { };
+    QwOmnivore(const TString& name)
+    : VQwSubsystem_t(name)
+    { };
     /// Copy constructor
     QwOmnivore(const QwOmnivore& source)
-    : VQwSubsystem(source),VQwSubsystem_t(source)
+    : VQwSubsystem_t(source)
     { }
     /// Virtual destructor
     virtual ~QwOmnivore() { };

--- a/Analysis/include/VQwSubsystem.h
+++ b/Analysis/include/VQwSubsystem.h
@@ -53,7 +53,6 @@ class QwParameterFile;
  *   node [shape=box, fontname=Helvetica, fontsize=10];
  *   VQwSubsystem [ label="VQwSubsystem" URL="\ref VQwSubsystem"];
  *   VQwSubsystemParity [ label="VQwSubsystemParity" URL="\ref VQwSubsystemParity"];
- *   VQwSubsystemTracking [ label="VQwSubsystemTracking" URL="\ref VQwSubsystemTracking"];
  *   VQwSubsystem -> VQwSubsystemParity;
  *   VQwSubsystem -> VQwSubsystemTracking;
  * }
@@ -62,7 +61,7 @@ class QwParameterFile;
  * This will define the interfaces used in communicating with the
  * CODA routines.
  */
-class VQwSubsystem: virtual public VQwSubsystemCloneable, public MQwHistograms, public MQwPublishable_child<QwSubsystemArray,VQwSubsystem> {
+class VQwSubsystem: public VQwSubsystemCloneable, public MQwHistograms, public MQwPublishable_child<QwSubsystemArray,VQwSubsystem> {
 
  public:
 

--- a/Parity/include/QwBeamLine.h
+++ b/Parity/include/QwBeamLine.h
@@ -44,11 +44,11 @@ class QwBeamLine : public VQwSubsystemParity, public MQwSubsystemCloneable<QwBea
  public:
   /// Constructor with name
   QwBeamLine(const TString& name)
-  : VQwSubsystem(name),VQwSubsystemParity(name)
+  : VQwSubsystemParity(name)
   { };
   /// Copy constructor
   QwBeamLine(const QwBeamLine& source)
-  : VQwSubsystem(source),VQwSubsystemParity(source),
+  : VQwSubsystemParity(source),
     fQPD(source.fQPD),
     fLinearArray(source.fLinearArray),
     fCavity(source.fCavity),

--- a/Parity/include/QwBeamMod.h
+++ b/Parity/include/QwBeamMod.h
@@ -94,7 +94,7 @@ class QwBeamMod: public VQwSubsystemParity, public MQwSubsystemCloneable<QwBeamM
  public:
   /// Constructor with name
   QwBeamMod(const TString& name)
-  : VQwSubsystem(name),VQwSubsystemParity(name)
+  : VQwSubsystemParity(name)
     {
       fFFB_holdoff_Counter=0;
       fFFB_Flag=kTRUE;
@@ -108,7 +108,7 @@ class QwBeamMod: public VQwSubsystemParity, public MQwSubsystemCloneable<QwBeamM
     };
   /// Copy constructor
   QwBeamMod(const QwBeamMod& source)
-  : VQwSubsystem(source),VQwSubsystemParity(source),
+  : VQwSubsystemParity(source),
     fWord(source.fWord)
   { 
     // std::cout<< "Here in the copy constructor" << std::endl;

--- a/Parity/include/QwBlindDetectorArray.h
+++ b/Parity/include/QwBlindDetectorArray.h
@@ -26,7 +26,6 @@ class QwBlindDetectorArrayID;
 
 class QwBlindDetectorArray: 
  public VQwDetectorArray, 
- virtual public VQwSubsystemParity,
  public MQwSubsystemCloneable<QwBlindDetectorArray>{
 
   /******************************************************************
@@ -46,12 +45,12 @@ class QwBlindDetectorArray:
   /// Constructor with name
 
   QwBlindDetectorArray(const TString& name)
-  : VQwSubsystem(name), VQwSubsystemParity(name), VQwDetectorArray(name) {};
+  : VQwDetectorArray(name) {};
 
 
   /// Copy constructor
   QwBlindDetectorArray(const QwBlindDetectorArray& source)
-  : VQwSubsystem(source),VQwSubsystemParity(source), VQwDetectorArray(source){};
+  : VQwDetectorArray(source){};
 
 
   /// Virtual destructor

--- a/Parity/include/QwCombinerSubsystem.h
+++ b/Parity/include/QwCombinerSubsystem.h
@@ -32,11 +32,11 @@ class QwCombinerSubsystem: public VQwSubsystemParity,
       // Constructors
       /// \brief Constructor with just name.
       QwCombinerSubsystem(const TString name)
-      : VQwSubsystem(name), VQwSubsystemParity(name), QwCombiner(name) { }
+      : VQwSubsystemParity(name), QwCombiner(name) { }
 
       // Copy Constructor
       QwCombinerSubsystem(const QwCombinerSubsystem &source)
-      : VQwSubsystem(source), VQwSubsystemParity(source), QwCombiner(source) { }
+      : VQwSubsystemParity(source), QwCombiner(source) { }
 	
       // Destructor 
       ~QwCombinerSubsystem();

--- a/Parity/include/QwDetectorArray.h
+++ b/Parity/include/QwDetectorArray.h
@@ -24,7 +24,6 @@ class QwDetectorArrayID;
 
 class QwDetectorArray: 
  public VQwDetectorArray, 
- virtual public VQwSubsystemParity, 
  public MQwSubsystemCloneable<QwDetectorArray> {
 
 /******************************************************************
@@ -42,15 +41,13 @@ public:
 
 /// Constructor with name
 QwDetectorArray(const TString& name) 
- :VQwSubsystem(name), VQwSubsystemParity(name), VQwDetectorArray(name){};
-
+ : VQwDetectorArray(name){};
 
 /// Copy constructor
 QwDetectorArray(const QwDetectorArray& source)
-  :VQwSubsystem(source), VQwSubsystemParity(source), VQwDetectorArray(source){};
+ : VQwDetectorArray(source){};
 
-
-/// Virtual destructor
+  /// Virtual destructor
 ~QwDetectorArray() {};
 
 };

--- a/Parity/include/QwFakeHelicity.h
+++ b/Parity/include/QwFakeHelicity.h
@@ -18,8 +18,9 @@
 
 class QwFakeHelicity: public QwHelicity {
  public:
-  QwFakeHelicity(TString region_tmp):VQwSubsystem(region_tmp),QwHelicity(region_tmp),fMinPatternPhase(1)
-
+  QwFakeHelicity(TString region_tmp)
+  : QwHelicity(region_tmp),
+    fMinPatternPhase(1)
     {
       // using the constructor of the base class
     };

--- a/Parity/include/QwIntegratedRaster.h
+++ b/Parity/include/QwIntegratedRaster.h
@@ -66,11 +66,11 @@ class QwIntegratedRaster : public VQwSubsystemParity, public MQwSubsystemCloneab
  public:
   /// Constructor with name
   QwIntegratedRaster(const TString& name)
-  : VQwSubsystem(name),VQwSubsystemParity(name)
+  : VQwSubsystemParity(name)
   { };
   /// Copy constructor
   QwIntegratedRaster(const QwIntegratedRaster& source)
-  : VQwSubsystem(source),VQwSubsystemParity(source),
+  : VQwSubsystemParity(source),
     fIntegratedRasterChannel(source.fIntegratedRasterChannel)
   { }
   /// Virtual destructor

--- a/Parity/include/QwMollerDetector.h
+++ b/Parity/include/QwMollerDetector.h
@@ -75,11 +75,11 @@ class QwMollerDetector:
 
     /// Constructor with name
     QwMollerDetector(const TString& name)
-    : VQwSubsystem(name), VQwSubsystemParity(name)
+    : VQwSubsystemParity(name)
     { };
     /// Copy constructor
     QwMollerDetector(const QwMollerDetector& source)
-    : VQwSubsystem(source),VQwSubsystemParity(source),
+    : VQwSubsystemParity(source),
       fSTR7200_Channel(source.fSTR7200_Channel)
     { }
     /// Virtual destructor

--- a/Parity/include/QwScaler.h
+++ b/Parity/include/QwScaler.h
@@ -28,7 +28,7 @@ class QwScaler: public VQwSubsystemParity, public MQwSubsystemCloneable<QwScaler
     QwScaler(const TString& name);
     /// Copy constructor
     QwScaler(const QwScaler& source)
-    : VQwSubsystem(source),VQwSubsystemParity(source)
+    : VQwSubsystemParity(source)
     {
       fScaler.resize(source.fScaler.size());
       for (size_t i = 0; i < fScaler.size(); i++) {

--- a/Parity/include/VQwDataHandler.h
+++ b/Parity/include/VQwDataHandler.h
@@ -26,7 +26,7 @@ class QwRootFile;
 class QwPromptSummary;
 class QwDataHandlerArray;
 
-class VQwDataHandler:  virtual public VQwDataHandlerCloneable, public MQwPublishable_child<QwDataHandlerArray,VQwDataHandler> {
+class VQwDataHandler:  public VQwDataHandlerCloneable, public MQwPublishable_child<QwDataHandlerArray,VQwDataHandler> {
 
   public:
   

--- a/Parity/include/VQwDetectorArray.h
+++ b/Parity/include/VQwDetectorArray.h
@@ -55,7 +55,7 @@ class QwDetectorArrayID {
 };
 
 
-class VQwDetectorArray: virtual public VQwSubsystemParity {
+class VQwDetectorArray: public VQwSubsystemParity {
 
  /******************************************************************
  *  Class: QwDetectorArray
@@ -72,7 +72,9 @@ class VQwDetectorArray: virtual public VQwSubsystemParity {
 
     /// Constructor with name
     VQwDetectorArray(const TString& name) 
-     :VQwSubsystem(name),VQwSubsystemParity(name),bNormalization(kFALSE) {
+    : VQwSubsystemParity(name),
+      bNormalization(kFALSE)
+    {
 
         fTargetCharge.InitializeChannel("q_targ","derived");
         fTargetX.InitializeChannel("x_targ","derived");
@@ -86,7 +88,7 @@ class VQwDetectorArray: virtual public VQwSubsystemParity {
     /// Copy constructor
   
     VQwDetectorArray(const VQwDetectorArray& source)
-     :VQwSubsystem(source),VQwSubsystemParity(source),
+     :VQwSubsystemParity(source),
      fIntegrationPMT(source.fIntegrationPMT),
      fCombinedPMT(source.fCombinedPMT),
      fMainDetID(source.fMainDetID){}

--- a/Parity/include/VQwSubsystemParity.h
+++ b/Parity/include/VQwSubsystemParity.h
@@ -34,7 +34,7 @@ class QwPromptSummary;
  *   with the CODA routines.
  *
  */
-class VQwSubsystemParity: virtual public VQwSubsystem {
+class VQwSubsystemParity: public VQwSubsystem {
 
   private:
     /// Private default constructor (not implemented, will throw linker error on use)

--- a/Parity/src/QwHelicity.cc
+++ b/Parity/src/QwHelicity.cc
@@ -43,8 +43,7 @@ const std::vector<UInt_t> QwHelicity::kDefaultHelicityBitPattern{0x69};
 //**************************************************//
 /// Constructor with name
 QwHelicity::QwHelicity(const TString& name)
-: VQwSubsystem(name),
-  VQwSubsystemParity(name),
+: VQwSubsystemParity(name),
   fInputReg_HelPlus(kDefaultInputReg_HelPlus),
   fInputReg_HelMinus(kDefaultInputReg_HelMinus),
   fInputReg_PatternSync(kDefaultInputReg_PatternSync),
@@ -88,8 +87,7 @@ QwHelicity::QwHelicity(const TString& name)
 // all of the copy protection built into the helicity subsystem.  I can't be
 // bothered to clean it up right now... (wdc)
 QwHelicity::QwHelicity(const QwHelicity& source)
-: VQwSubsystem(source.GetName()),
-  VQwSubsystemParity(source.GetName()),
+: VQwSubsystemParity(source.GetName()),
   fInputReg_HelPlus(source.fInputReg_HelPlus),
   fInputReg_HelMinus(source.fInputReg_HelMinus),
   fInputReg_PatternSync(source.fInputReg_PatternSync),

--- a/Parity/src/QwScaler.cc
+++ b/Parity/src/QwScaler.cc
@@ -33,7 +33,7 @@ void QwScaler::ProcessOptions(QwOptions &/*options*/)
  * Constructor
  */
 QwScaler::QwScaler(const TString& name)
-: VQwSubsystem(name),VQwSubsystemParity(name)
+: VQwSubsystemParity(name)
 {
   // Nothing, really
 }


### PR DESCRIPTION
This PR removes the virtual inheritance support which was originally introduced to support multiple subsystem types:
```mermaid
classDiagram
    class VQwSubsystem {
        <<abstract>>
        +TString fSystemName
        +ProcessEvent()
        +operator=(VQwSubsystem*)
    }
    
    class VQwSubsystemParity {
        <<abstract>>
        +operator=(VQwSubsystem*) = 0
        +operator+=(VQwSubsystem*) = 0
        +FillDB()
        +Blind()
    }

    class VQwSubsystemTracking {
        <<abstract>>
        +operator=(VQwSubsystem*) = 0
    }

    class VQwDetectorArray {
        <<abstract>>
        +vector<QwIntegrationPMT> fIntegrationPMT
        +vector<QwCombinedPMT> fCombinedPMT
        +operator=(VQwSubsystem*)
        +operator+=(VQwSubsystem*)
    }
    
    class QwDetectorArray {
        +QwDetectorArray(name)
        +using VQwDetectorArray::operator=
    }
    
    class QwBlindDetectorArray {
        +Blind(QwBlinder*)
        +using VQwDetectorArray::operator=
    }

    class QwScanner {
        +QwScanner(name)
        +operator=(VQwSubsystem*)
        +operator+=(VQwSubsystem*)
        +FillDB()
        +Blind()
    }

    %% Virtual inheritance relationships
    VQwSubsystem <|-- VQwSubsystemParity : "virtual inheritance"
    VQwSubsystem <|-- VQwSubsystemTracking : "virtual inheritance"
    VQwSubsystemParity <|-- VQwDetectorArray : "virtual inheritance"
    
    %% Regular inheritance
    VQwDetectorArray <|-- QwDetectorArray : "public inheritance"
    QwDetectorArray <|-- QwBlindDetectorArray : "public inheritance"

    %% Show the diamond pattern being avoided
    VQwSubsystemParity <|-- QwDetectorArray : "virtual public (redundant)"
    VQwSubsystemParity <|-- QwBlindDetectorArray : "virtual public (redundant)"

    %% Show the diamond pattern being avoided
    VQwSubsystemParity <|-- QwScanner : "virtual public (redundant)"
    VQwSubsystemTracking <|-- QwScanner : "virtual public (redundant)"

    note for VQwSubsystemParity "Uses virtual inheritance\nto avoid diamond problem"
    note for QwDetectorArray "Uses 'using' declarations\nto expose base operators"
    note for VQwSubsystemTracking "Already removed"
    note for QwScanner "Already removed"
```

Since we don't aim to support VQwSubsystemTracking anymore, we can get rid of the virtual inheritance entirely.