### PR TITLE
Update CI to inlclude LCG_108 with ROOT with C++23 support

### DIFF
--- a/.github/workflows/build-lcg-cvmfs.yml
+++ b/.github/workflows/build-lcg-cvmfs.yml
@@ -36,6 +36,12 @@ jobs:
             compiler: "gcc14"
             opt: "opt"
             cxxflags: ""
+          - release: "LCG_108"
+            arch: "x86_64"
+            os: "el9"
+            compiler: "gcc15"
+            opt: "opt"
+            cxxflags: ""
     steps:
       - uses: actions/checkout@v5
       - uses: cvmfs-contrib/github-action-cvmfs@v5


### PR DESCRIPTION
This PR adds a CI target with a ROOT version that has C++23 support. This will test if this code base is C++23 capable, and provides a starting off point for sqlpp23 testing.