### PR TITLE
Implement assignment operator and destructor for VQwDataHandler and QwScaler_Channel classes

### DIFF
--- a/Analysis/include/QwScaler_Channel.h
+++ b/Analysis/include/QwScaler_Channel.h
@@ -257,6 +257,15 @@ class QwScaler_Channel: public VQwScaler_Channel
     : VQwScaler_Channel(name,datatosave) { };
   QwScaler_Channel(const QwScaler_Channel& source, VQwDataElement::EDataToSave datatosave)
     : VQwScaler_Channel(source,datatosave) { };
+  virtual ~QwScaler_Channel() { };
+
+  QwScaler_Channel& operator=  (const QwScaler_Channel &value)
+  {
+    if (this != &value) {
+      VQwScaler_Channel::operator=(value);
+    }
+    return *this;
+  };
 
   using VQwScaler_Channel::CopyFrom;
   using VQwHardwareChannel::Clone;

--- a/Parity/include/VQwBCM.h
+++ b/Parity/include/VQwBCM.h
@@ -50,6 +50,8 @@ protected:
   VQwBCM(VQwDataElement& beamcurrent): fBeamCurrent_ref(beamcurrent) { };
   VQwBCM(VQwDataElement& beamcurrent, TString /*name*/): fBeamCurrent_ref(beamcurrent) { };
 
+  VQwBCM(const VQwBCM& source): VQwDataElement(source), fBeamCurrent_ref(source.fBeamCurrent_ref) { };
+
 public:
   virtual ~VQwBCM() { };
 

--- a/Parity/include/VQwDataHandler.h
+++ b/Parity/include/VQwDataHandler.h
@@ -39,7 +39,10 @@ class VQwDataHandler:  virtual public VQwDataHandlerCloneable, public MQwPublish
 
     VQwDataHandler(const TString& name);
     VQwDataHandler(const VQwDataHandler &source);
+    virtual ~VQwDataHandler();
 
+    VQwDataHandler& operator= (const VQwDataHandler &value);
+  
     virtual void ParseConfigFile(QwParameterFile& file);
 
     void SetPointer(QwHelicityPattern *ptr){
@@ -72,8 +75,6 @@ class VQwDataHandler:  virtual public VQwDataHandlerCloneable, public MQwPublish
     virtual void FinishDataHandler(){
       CalculateRunningAverage();
     };
-
-    virtual ~VQwDataHandler();
 
     TString GetName(){return fName;}
 

--- a/Parity/src/VQwDataHandler.cc
+++ b/Parity/src/VQwDataHandler.cc
@@ -69,7 +69,7 @@ VQwDataHandler::VQwDataHandler(const VQwDataHandler &source)
   fDependentVar  = source.fDependentVar;
   fDependentType = source.fDependentType;
   fDependentName = source.fDependentName;
-  //  Create new objects for the the outputs.
+  //  Create new objects for the outputs.
   fOutputVar.resize(source.fOutputVar.size());
   for (size_t i = 0; i < this->fDependentVar.size(); i++) {
     //const QwVQWK_Channel* vqwk = dynamic_cast<const QwVQWK_Channel*>(source.fOutputVar[i]);
@@ -93,6 +93,45 @@ VQwDataHandler::~VQwDataHandler() {
   }
   fOutputVar.clear();
 
+}
+
+VQwDataHandler& VQwDataHandler::operator=(const VQwDataHandler& value)
+{
+  if (this != &value) {
+    //  Copy the base class parts
+    fPriority = value.fPriority;
+    fBurstCounter = value.fBurstCounter;
+    fName = value.fName;
+    fMapFile = value.fMapFile;
+    fTreeName = value.fTreeName;
+    fTreeComment = value.fTreeComment;
+    fPrefix = value.fPrefix;
+    fErrorFlagPtr = value.fErrorFlagPtr;
+    fSubsystemArray = value.fSubsystemArray;
+    fHelicityPattern = value.fHelicityPattern;
+    ParseSeparator = value.ParseSeparator;
+    fKeepRunningSum = value.fKeepRunningSum;
+
+    fDependentVar = value.fDependentVar;
+    fDependentType = value.fDependentType;
+    fDependentName = value.fDependentName;
+    fDependentFull = value.fDependentFull;
+    fDependentValues = value.fDependentValues;
+
+    //  Create new objects for the outputs.
+    fOutputVar.resize(value.fOutputVar.size());
+    for (size_t i = 0; i < value.fOutputVar.size(); i++) {
+      fOutputVar[i] = value.fOutputVar[i]->Clone(VQwDataElement::kDerived);
+    }
+    fOutputValues = value.fOutputValues;
+
+    if (value.fRunningsum!=NULL){
+      fRunningsum = value.fRunningsum->Clone();
+    } else {
+      fRunningsum = NULL;
+    }
+  }
+  return *this;
 }
 
 void VQwDataHandler::ParseConfigFile(QwParameterFile& file){


### PR DESCRIPTION
This PR ensures that the classes where a custom copy constructor or custom assignment operator is implemented, they are also implementing the other one. 

The rule of three also refers to the destructor, which is not missing anywhere. Generally, when one of these implemented it means there is non-trivial treatment of objects or cloning of objects by pointers. The default implicit shallow copy or shallow assignment are bypassing that and unlikely sufficient.

This PR does introduce different behavior, for example by making the assignment create a clone of the running sum instead of copying the pointer and reusing the original running sum.