### PR TITLE
Change fPatternSize type from Int_t to size_t, and avoid casting

### DIFF
--- a/Parity/include/QwHelicityPattern.h
+++ b/Parity/include/QwHelicityPattern.h
@@ -218,7 +218,7 @@ class QwHelicityPattern {
   std::vector<Int_t> fHelicity;// this is here up to when we code the Helicity decoding routine
   std::vector<Int_t> fEventNumber;
   Int_t fCurrentPatternNumber;
-  Int_t fPatternSize;
+  size_t fPatternSize;
   Int_t fQuartetNumber;
 
   // Blinding strategy

--- a/Parity/src/QwHelicityPattern.cc
+++ b/Parity/src/QwHelicityPattern.cc
@@ -183,7 +183,7 @@ QwHelicityPattern::QwHelicityPattern(QwSubsystemArrayParity &event, const TStrin
         {
           TString loc=
             "Standard exception from QwHelicityPattern : the pattern size has to be even;  right now pattern_size=";
-          loc+=Form("%d",fPatternSize);
+          loc+=Form("%zu",fPatternSize);
           throw std::invalid_argument(loc.Data());
         }
     }
@@ -497,9 +497,9 @@ void  QwHelicityPattern::CalculateAsymmetry()
   if (fIgnoreHelicity){
     //  Don't check to see if we have equal numbers of even and odd helicity states in this pattern.
     //  Build an asymmetry with even-parity phases as "+" and odd-parity phases as "-"
-    for (size_t i = 0; i < (size_t) fPatternSize; i++) {
+    for (size_t i = 0; i < fPatternSize; i++) {
       Int_t localhel = 1;
-      for (size_t j = 0; j < (size_t) fPatternSize/2; j++) {
+      for (size_t j = 0; j < fPatternSize/2; j++) {
 	localhel ^= ((i >> j)&0x1);
       }
       if (localhel == plushel) {
@@ -520,7 +520,7 @@ void  QwHelicityPattern::CalculateAsymmetry()
     }
   } else {
     //  
-    for (size_t i = 0; i < (size_t) fPatternSize; i++) {
+    for (size_t i = 0; i < fPatternSize; i++) {
       if (fHelicity[i] == plushel) {
 	if (localdebug) std::cout<<"QwHelicityPattern::CalculateAsymmetry:  here filling fPositiveHelicitySum \n";
 	if (firstplushel) {
@@ -549,8 +549,8 @@ void  QwHelicityPattern::CalculateAsymmetry()
 		<<" but is "<< fHelicity[i]
 		<< "; Asymmetry computation aborted!"<<QwLog::endl;
 	ClearEventData();
-	i = fPatternSize;
 	checkhel = -9999;
+  break;
 	// This is an unknown helicity event.
       }
     }
@@ -615,7 +615,7 @@ void  QwHelicityPattern::CalculateAsymmetry()
       fPositiveHelicitySum = fEvents.at(0);
       fNegativeHelicitySum = fEvents.at(fPatternSize/2);
       if (fPatternSize/2 > 1){
-	for (size_t i = 1; i < (size_t) fPatternSize/2 ; i++){
+	for (size_t i = 1; i < fPatternSize/2 ; i++){
 	  fPositiveHelicitySum += fEvents.at(i);
 	  fNegativeHelicitySum += fEvents.at(fPatternSize/2 +i);
 	}
@@ -633,7 +633,7 @@ void  QwHelicityPattern::CalculateAsymmetry()
 	fPositiveHelicitySum = fEvents.at(0);
 	fNegativeHelicitySum = fEvents.at(1);
 	if (fPatternSize/2 > 1){
-	  for (size_t i = 1; i < (size_t) fPatternSize/2 ; i++){
+	  for (size_t i = 1; i < fPatternSize/2 ; i++){
 	    fPositiveHelicitySum += fEvents.at(2*i);
 	    fNegativeHelicitySum += fEvents.at(2*i + 1);
 	  }
@@ -1015,7 +1015,7 @@ void QwHelicityPattern::WritePromptSummary(QwPromptSummary *ps)
 void QwHelicityPattern::Print() const
 {
   QwOut << "Pattern number = " << fCurrentPatternNumber << QwLog::endl;
-  for (Int_t i = 0; i < fPatternSize; i++)
+  for (size_t i = 0; i < fPatternSize; i++)
     QwOut << "Event " << fEventNumber[i] << ": "
           << fEventLoaded[i] << ", " << fHelicity[i] << QwLog::endl;
   QwOut << "Is a complete pattern? (n/y:0/1) " << IsCompletePattern() << QwLog::endl;


### PR DESCRIPTION
This PR changes fPatternSize to an unsigned int (size_t) to avoid signed-unsigned comparison warnings and avoid the C-style casts (now unnecessary).