### PR TITLE
Explicitly initialize base class in copy constructors

### DIFF
--- a/Analysis/src/QwSubsystemArray.cc
+++ b/Analysis/src/QwSubsystemArray.cc
@@ -34,7 +34,8 @@ QwSubsystemArray::QwSubsystemArray(QwOptions& options, CanContainFn myCanContain
  * @param source Source subsystem array
  */
 QwSubsystemArray::QwSubsystemArray(const QwSubsystemArray& source)
-: MQwPublishable(source),
+: std::vector<std::shared_ptr<VQwSubsystem>>(),
+  MQwPublishable(source),
   fTreeArrayIndex(source.fTreeArrayIndex),
   fCodaRunNumber(source.fCodaRunNumber),
   fCodaSegmentNumber(source.fCodaSegmentNumber),

--- a/Parity/src/QwDataHandlerArray.cc
+++ b/Parity/src/QwDataHandlerArray.cc
@@ -49,7 +49,8 @@ QwDataHandlerArray::QwDataHandlerArray(QwOptions& options, QwSubsystemArrayParit
  * @param source Source handler array
  */
 QwDataHandlerArray::QwDataHandlerArray(const QwDataHandlerArray& source)
-: fHelicityPattern(source.fHelicityPattern),
+: std::vector<std::shared_ptr<VQwDataHandler>>(),
+  fHelicityPattern(source.fHelicityPattern),
   fSubsystemArray(source.fSubsystemArray),
   fDataHandlersMapFile(source.fDataHandlersMapFile),
   fDataHandlersDisabledByName(source.fDataHandlersDisabledByName),


### PR DESCRIPTION
This PR ensures that the array classes explicitly initialize the base classes in copy constructors (even if they are initialized to empty). Because of the deep copy in the copy constructor itself, this is somewhat redundant, but it avoids some compilation warnings and is better practice.