### PR TITLE
Remove unreachable error logging in FillTreeVector for negative unsigned int

### DIFF
--- a/Analysis/src/QwADC18_Channel.cc
+++ b/Analysis/src/QwADC18_Channel.cc
@@ -620,9 +620,6 @@ void  QwADC18_Channel::FillTreeVector(std::vector<Double_t> &values) const
 {
   if (IsNameEmpty()) {
     //  This channel is not used, so skip setting up the tree.
-  } else if (fTreeArrayNumEntries < 0) {
-    QwError << "QwADC18_Channel::FillTreeVector:  fTreeArrayNumEntries=="
-            << fTreeArrayNumEntries << QwLog::endl;
   } else if (fTreeArrayNumEntries == 0) {
     static bool warned = false;
     if (!warned) {

--- a/Analysis/src/QwScaler_Channel.cc
+++ b/Analysis/src/QwScaler_Channel.cc
@@ -314,9 +314,6 @@ void QwScaler_Channel<data_mask,data_shift>::FillTreeVector(std::vector<Double_t
   //std::cout<<"inside QwScaler_Channel::FillTreeVector"<< std::endl;
   if (IsNameEmpty()) {
     //  This channel is not used, so skip setting up the tree.
-  } else if (fTreeArrayNumEntries < 0) {
-    QwError << "VQwScaler_Channel::FillTreeVector:  fTreeArrayNumEntries=="
-	    << fTreeArrayNumEntries << QwLog::endl;
   } else if (fTreeArrayNumEntries == 0) {
     static bool warned = false;
     if (!warned) {


### PR DESCRIPTION
This PR removes two instances of unreachable error logging for negative fTreeArrayNumEntries, which is unsigned as size_t. The condition is always false.