### PR TITLE
Implement QwEventRing with move semantics and swap operations for efficient event handling

### DIFF
--- a/Parity/include/QwEventRing.h
+++ b/Parity/include/QwEventRing.h
@@ -12,9 +12,12 @@
 
 #pragma once
 
+// System headers
+#include <fstream>
+#include <optional>
 #include <vector>
 
-#include <fstream>
+// Qweak headers
 #include "QwSubsystemArrayParity.h"
 
 /**
@@ -47,8 +50,16 @@ class QwEventRing {
 
   /// \brief Add the subsystem to the ring
   void push(QwSubsystemArrayParity &event);
+  /// \brief Add the subsystem to the ring (move semantics)
+  void push(QwSubsystemArrayParity &&event);
+  /// \brief Add the subsystem to the ring using swap when ring is full, preserving configuration
+  void push_swap(QwSubsystemArrayParity &event);
   /// \brief Return the last subsystem in the ring
   QwSubsystemArrayParity& pop();
+  /// \brief Return the last subsystem in the ring (move semantics)
+  QwSubsystemArrayParity pop_move();
+  /// \brief Return the last subsystem in the ring using swap, preserving configuration
+  void pop_swap(QwSubsystemArrayParity &outgoing_event);
 
   /// \brief Print value of rolling average
   void PrintRollingAverage() {
@@ -64,9 +75,9 @@ class QwEventRing {
   /// \brief Return the number of events in the ring
   Int_t GetNumberOfEvents() const { return fNumberOfEvents; }
 
-  /// \brief Unwind the ring until empty
+  /// \brief Unwind the ring until empty (two-phased approach)
   void Unwind() {
-    while (GetNumberOfEvents() > 0) pop();
+    while (GetNumberOfEvents() > 0) pop_move();
     if (fPrintAfterUnwind) {
       QwMessage << "Residual rolling average (should be zero)" << QwLog::endl;
       PrintRollingAverage();
@@ -108,4 +119,7 @@ class QwEventRing {
   Int_t fBurpExtent;
   Int_t fBurpPrecut;
   QwSubsystemArrayParity fBurpAvg;
+
+  // Helicity preservation for swap operations
+  std::optional<size_t> fHelicityIndex;  // Index of helicity subsystem for efficient access
 };


### PR DESCRIPTION
This PR adds move semantics and swap operations to the QwEventRing. This avoids cascading assignment operators down the subsystems and into the data elements. Instead, this just takes the whole shebang and stuffs it in the event ring.

## Move semantics
Ordinarily, we would approach an event ring by moving an object into it (not actually copying), and then moving the object out of it when needed. We can do this with std::move, but it has a side effect: when moving an object into the event ring, it invalidates that object. And we still need it to be valid because that is the configured subsystem array that contains the information needed to decode the event buffer.

## Swap operations
We can approach this slightly different but similar in spirit by using swap operations. Now we don't simply std::move a new object into the event ring (when the ring is filled up), but we simultaneously move the replaced entry out and return that to the caller. That means that we return the channel configuration.

### Ok, but what about helicity?
There is one more issue: the QwHelicity subsystem has state that is checked for inter-event consistency. If we swap an old event ring entry with the new entry that we are adding, then we run into trouble with the helicity checking. So, we figure out what the helicity subsystem is, and after the swap we do a single(!) assignment for only that (small) subsystem.