### PR TITLE
Add CONFIGURE_DEPENDS to CMake file globbing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12)
 
 # Name of this project
 project(QwAnalysis VERSION 2.0.0 LANGUAGES CXX)


### PR DESCRIPTION
This minor PR makes CMake more robust against file addition in the glob expressions for sources, headers, and executables.