### PR TITLE
Ensure proper handling of dependent and independent variables in channel mapping

### DIFF
--- a/Parity/src/QwCombiner.cc
+++ b/Parity/src/QwCombiner.cc
@@ -186,9 +186,40 @@ Int_t QwCombiner::ConnectChannels(
   // Return if correction is not enabled
 
   /// Fill vector of pointers to the relevant data elements
+  fIndependentVar.resize(fDependentName.size());
+  fDependentVar.resize(fDependentName.size());
+  fOutputVar.resize(fDependentName.size());
+  
   for (size_t dv = 0; dv < fDependentName.size(); dv++) {
-    // Get the dependent variables
+    // Add independent variables
+    for (size_t iv = 0; iv < fIndependentName.at(dv).size(); iv++) {
+      // Get the independent variables
+      const VQwHardwareChannel* iv_ptr = 0;
+      iv_ptr = RequestExternalPointer(fIndependentName.at(dv).at(iv));
+      if (iv_ptr == NULL){
+        switch (fIndependentType.at(dv).at(iv)) {
+        case kHandleTypeAsym:
+          iv_ptr = asym.RequestExternalPointer(fIndependentName.at(dv).at(iv));
+          break;
+        case kHandleTypeDiff:
+          iv_ptr = diff.RequestExternalPointer(fIndependentName.at(dv).at(iv));
+          break;
+        default:
+          QwWarning << "Independent variable for combiner has unknown type."
+                    << QwLog::endl;
+          break;
+        }
+      }
+      if (iv_ptr) {
+        fIndependentVar[dv].push_back(iv_ptr);
+      } else {
+        QwWarning << "Independent variable " << fIndependentName.at(dv).at(iv) << " for combiner of "
+                  << "dependent variable " << fDependentName.at(dv) << " could not be found."
+                  << QwLog::endl;
+      }
+    }
 
+    // Get the dependent variables
     const VQwHardwareChannel* dv_ptr = 0;
     VQwHardwareChannel* new_chan = NULL;
     const VQwHardwareChannel* chan = NULL;
@@ -203,7 +234,7 @@ Int_t QwCombiner::ConnectChannels(
     }else{
       dv_ptr = this->RequestExternalPointer(fDependentFull.at(dv));
       if (dv_ptr==NULL){
-	switch (fDependentType.at(dv)) {
+        switch (fDependentType.at(dv)) {
         case kHandleTypeAsym:
           dv_ptr = asym.RequestExternalPointer(fDependentName.at(dv));
           break;
@@ -216,79 +247,45 @@ Int_t QwCombiner::ConnectChannels(
 		                << ", for asym/diff combiner does not have proper type, type=="
 		                << fDependentType.at(dv) << "."<< QwLog::endl;
           break;
-	}
+        }
       }
 
       name = dv_ptr->GetElementName().Data();
       name.insert(0, calc);
 
-      const QwVQWK_Channel* vqwk = dynamic_cast<const QwVQWK_Channel*>(dv_ptr);
-      const QwMollerADC_Channel* moll = dynamic_cast<const QwMollerADC_Channel*>(dv_ptr);
-      if (moll != nullptr) {
-        new_chan = new QwMollerADC_Channel(*moll, VQwDataElement::kDerived);
-        new_chan->SetElementName(name);
-        new_chan->SetSubsystemName(fName);
-      } else if (vqwk != nullptr) {
-        new_chan = new QwVQWK_Channel(*vqwk, VQwDataElement::kDerived);
-        new_chan->SetElementName(name);
-        new_chan->SetSubsystemName(fName);
-      } else {
-        QwWarning << "Dependent variable, " << fDependentName.at(dv) << ", for combiner is not a VQWK or Moller ADC channel." << QwLog::endl;
-        continue;
-      }
+      new_chan = dv_ptr->Clone(VQwDataElement::kDerived);
+      new_chan->SetElementName(name);
+      new_chan->SetSubsystemName(fName);
     }
 
     // alias
     if(fDependentName.at(dv).at(0) == '@'){
       //QwMessage << "dv: " << name << QwLog::endl;
-      new_chan = new QwMollerADC_Channel(name, VQwDataElement::kDerived);
-      new_chan  ->SetSubsystemName(fName);
+      if (fIndependentVar.at(dv).empty()) {
+        // Throw exception: alias cannot be created without independent variables
+        throw std::runtime_error("Cannot create alias '" + name + 
+              "' for dependent variable '" + fDependentName.at(dv) + 
+              "': no independent variables found to determine channel type");
+      } else {
+        // Preferred: use Clone() from first independent variable to preserve channel type
+        new_chan = fIndependentVar.at(dv).front()->Clone(VQwDataElement::kDerived);
+      }
+      new_chan->SetElementName(name);
+      new_chan->SetSubsystemName(fName);
     }
     // defined type
     else if(dv_ptr!=NULL){
       //QwMessage << "dv: " << fDependentName.at(dv) << QwLog::endl;
-    }else {
+    } else {
       QwWarning << "Dependent variable " << fDependentName.at(dv) << " could not be found, "
-                << "or is not a VQWK channel." << QwLog::endl;
+                << "or is not a known channel type." << QwLog::endl;
       continue; 
     }
 
     // pair creation
     if(new_chan != NULL){
-      fDependentType.push_back(fDependentType.at(dv));
-      fDependentVar.push_back(chan);
-      fOutputVar.push_back(new_chan);
-      //fDependentVar.push_back(std::make_pair(chan, new_chan));
-    }
-
-    // Add independent variables
-    fIndependentVar.resize(fDependentVar.size());
-    for (size_t iv = 0; iv < fIndependentName.at(dv).size(); iv++) {
-      // Get the independent variables
-      const VQwHardwareChannel* iv_ptr = 0;
-      iv_ptr = RequestExternalPointer(fIndependentName.at(dv).at(iv));
-      if (iv_ptr == NULL){
-	switch (fIndependentType.at(dv).at(iv)) {
-        case kHandleTypeAsym:
-          iv_ptr = asym.RequestExternalPointer(fIndependentName.at(dv).at(iv));
-          break;
-        case kHandleTypeDiff:
-          iv_ptr = diff.RequestExternalPointer(fIndependentName.at(dv).at(iv));
-          break;
-        default:
-          QwWarning << "Independent variable for combiner has unknown type."
-                    << QwLog::endl;
-          break;
-	}
-      }
-      if (iv_ptr) {
-        //QwMessage << " iv: " << fIndependentName.at(dv).at(iv) << " (sens = " << fSensitivity.at(dv).at(iv) << ")" << QwLog::endl;
-        fIndependentVar.back().push_back(iv_ptr);
-      } else {
-        QwWarning << "Independent variable " << fIndependentName.at(dv).at(iv) << " for combiner of "
-                  << "dependent variable " << fDependentName.at(dv) << " could not be found."
-                  << QwLog::endl;
-      }
+      fDependentVar[dv] = chan;
+      fOutputVar[dv] = new_chan;
     }
   }
   
@@ -309,9 +306,32 @@ Int_t QwCombiner::ConnectChannels(QwSubsystemArrayParity& event)
   // Return if correction is not enabled
 
   /// Fill vector of pointers to the relevant data elements
+  fIndependentVar.resize(fDependentName.size());
+  fDependentVar.resize(fDependentName.size());
+  fOutputVar.resize(fDependentName.size());
+  
   for (size_t dv = 0; dv < fDependentName.size(); dv++) {
-    // Get the dependent variables
 
+    // Add independent variables
+    for (size_t iv = 0; iv < fIndependentName.at(dv).size(); iv++) {
+      // Get the independent variables
+      const VQwHardwareChannel* iv_ptr = 0;
+      if(fIndependentType.at(dv).at(iv) == kHandleTypeMps){
+        iv_ptr = event.RequestExternalPointer(fIndependentName.at(dv).at(iv));
+    	} else {
+        QwWarning << "Independent variable for MPS combiner has unknown type."
+                  << QwLog::endl;
+      }
+      if (iv_ptr) {
+        fIndependentVar[dv].push_back(iv_ptr);
+      } else {
+        QwWarning << "Independent variable " << fIndependentName.at(dv).at(iv) << " for combiner of "
+                  << "dependent variable " << fDependentName.at(dv) << " could not be found."
+                  << QwLog::endl;
+      }
+    }
+
+    // Get the dependent variables
     const VQwHardwareChannel* dv_ptr = 0;
     VQwHardwareChannel* new_chan = NULL;
     const VQwHardwareChannel* chan = NULL;
@@ -330,63 +350,30 @@ Int_t QwCombiner::ConnectChannels(QwSubsystemArrayParity& event)
     } else {
       if(fDependentName.at(dv).at(0) == '@' ){
         name = fDependentName.at(dv).substr(1,fDependentName.at(dv).length());
-        new_chan = new QwVQWK_Channel(name, VQwDataElement::kDerived);
+        new_chan = fIndependentVar.at(dv).front()->Clone(VQwDataElement::kDerived);
+        new_chan->SetElementName(name);
+        new_chan->SetSubsystemName(fName);
       } else {
         dv_ptr = event.RequestExternalPointer(fDependentName.at(dv));
 
         name = dv_ptr->GetElementName().Data();
         name.insert(0,calc);
 
-        const QwMollerADC_Channel* moll = dynamic_cast<const QwMollerADC_Channel*>(dv_ptr);
-        const QwVQWK_Channel* vqwk = dynamic_cast<const QwVQWK_Channel*>(dv_ptr);
-        if (moll != nullptr) {
-          new_chan = new QwMollerADC_Channel(*moll, VQwDataElement::kDerived);
-          new_chan->SetElementName(name);
-        } else if (vqwk != nullptr) {
-          new_chan = new QwVQWK_Channel(*vqwk, VQwDataElement::kDerived);
-          new_chan->SetElementName(name);
-        } else {
-          QwWarning << "Dependent variable " << fDependentName.at(dv) << " could not be found, "
-                    << "or is not a VQWK or MollerADC channel." << QwLog::endl;
-          continue; 
-        }
+        new_chan = dv_ptr->Clone(VQwDataElement::kDerived);
+        new_chan->SetElementName(name);
+        new_chan->SetSubsystemName(fName);
       }
-      new_chan->SetSubsystemName(fName);
     }
 
     // alias
     if(new_chan==NULL){
       QwWarning << "Dependent variable " << fDependentName.at(dv) << " could not be found, "
-                << "or is not a VQWK channel." << QwLog::endl;
+                << "or is not a known channel type." << QwLog::endl;
       continue; 
     } else {
-      //QwMessage << "dv: " << new_vqwk->GetElementName() << QwLog::endl;
       // pair creation
-      fDependentType.push_back(fDependentType.at(dv));
-      fDependentVar.push_back(chan);
-      fOutputVar.push_back(new_chan);
-      //fDependentVar.push_back(std::make_pair(chan, new_chan));
-    }
-
-    // Add independent variables
-    fIndependentVar.resize(fDependentVar.size());
-    for (size_t iv = 0; iv < fIndependentName.at(dv).size(); iv++) {
-      // Get the independent variables
-      const VQwHardwareChannel* iv_ptr = 0;
-      if(fIndependentType.at(dv).at(iv) == kHandleTypeMps){
-        iv_ptr = event.RequestExternalPointer(fIndependentName.at(dv).at(iv));
-    	} else {
-        QwWarning << "Independent variable for MPS combiner has unknown type."
-                  << QwLog::endl;
-      }
-      if (iv_ptr) {
-        //QwMessage << " iv: " << fIndependentName.at(dv).at(iv) << " (sens = " << fSensitivity.at(dv).at(iv) << ")" << QwLog::endl;
-        fIndependentVar.back().push_back(iv_ptr);
-      } else {
-        QwWarning << "Independent variable " << fIndependentName.at(dv).at(iv) << " for combiner of "
-                  << "dependent variable " << fDependentName.at(dv) << " could not be found."
-                  << QwLog::endl;
-      }
+      fDependentVar[dv] = chan;
+      fOutputVar[dv] = new_chan;
     }
   }
   


### PR DESCRIPTION
Fill in the `fDependentFull` vector during channel map loading and enhance the `ConnectChannels` function to manage independent variables before dependent ones, improving flexibility for channel type handling.