### PR TITLE
Initialize temporary variables to prevent undefined behavior in QwBlinder and VQwDetectorArray

### DIFF
--- a/Parity/src/QwBlinder.cc
+++ b/Parity/src/QwBlinder.cc
@@ -796,7 +796,7 @@ void QwBlinder::InitTestValues(const int n)
 Int_t QwBlinder::UseStringManip(const TString& barestring)
 {
   std::vector<UInt_t> choppedwords;
-  UInt_t tmpword;
+  UInt_t tmpword = 0;
   Int_t finalseed = 0;
 
   for (Int_t i = 0; i < barestring.Length(); i++)

--- a/Parity/src/VQwDetectorArray.cc
+++ b/Parity/src/VQwDetectorArray.cc
@@ -134,7 +134,7 @@ Bool_t VQwDetectorArray::PublishInternalValues() const {
         device_type.ToLower();
         device_prop.ToLower();
 
-        const VQwHardwareChannel* tmp_channel;
+        const VQwHardwareChannel* tmp_channel = NULL;
 
         if (device_type == "integrationpmt") {
 


### PR DESCRIPTION
Set temporary variables to defined values to avoid potential undefined behavior in the QwBlinder and VQwDetectorArray classes. This avoids `-Wmaybe-uninitialized` warnings.