### PR TITLE
Make UpdateErrorFlag non-virtual to prevent hiding in derived classes

### DIFF
--- a/Analysis/include/VQwDataElement.h
+++ b/Analysis/include/VQwDataElement.h
@@ -224,7 +224,9 @@ class VQwDataElement: public MQwHistograms {
 
   //  The most basic version of UpdateErrorFlag, which should get hidden
   //  by all the derived class versions.
-  virtual void UpdateErrorFlag(const UInt_t& error){fErrorFlag |= (error);};
+  void UpdateErrorFlag(const UInt_t& error){
+    fErrorFlag |= (error);
+  };
 
  protected:
   TString fElementName; ///< Name of this data element


### PR DESCRIPTION
Change the UpdateErrorFlag method to non-virtual to ensure it is not hidden by overloads in derived classes. This removes the remaining source of these kind of warnings.