### PR TITLE
Make CopyFrom non-virtual in VQwDataElement and VQwHardwareChannel

### DIFF
--- a/Analysis/include/VQwDataElement.h
+++ b/Analysis/include/VQwDataElement.h
@@ -84,7 +84,7 @@ class VQwDataElement: public MQwHistograms {
   /// Virtual destructor
   ~VQwDataElement() override { };
 
-  virtual void CopyFrom(const VQwDataElement& value){
+  void CopyFrom(const VQwDataElement& value){
     fElementName       = value.fElementName;
     //    fNumberOfDataWords = value.fNumberOfDataWords;
     fGoodEventCount    = value.fGoodEventCount;

--- a/Analysis/include/VQwHardwareChannel.h
+++ b/Analysis/include/VQwHardwareChannel.h
@@ -44,7 +44,7 @@ public:
   VQwHardwareChannel(const VQwHardwareChannel& value, VQwDataElement::EDataToSave datatosave);
   ~VQwHardwareChannel() override { };
 
-  virtual void CopyFrom(const VQwHardwareChannel& value);
+  void CopyFrom(const VQwHardwareChannel& value);
 
   void ProcessOptions();
 


### PR DESCRIPTION
Remove the virtual specifier from the CopyFrom declarations so these are
regular member functions rather than virtual methods. This clarifies intent
and avoids unintended virtual dispatch for the CopyFrom implementations. It also removes recurring warnings about the hiding of virtuals by overloading them.