### PR TITLE
Enable git-lfs and pre-commit features in devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,9 @@
 
   "features": {
     "ghcr.io/devcontainers/features/git:1": {},
-    "ghcr.io/devcontainers/features/github-cli:1": {}
+    "ghcr.io/devcontainers/features/git-lfs:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/prulloac/devcontainer-features/pre-commit:1": {}
   },
 
   "runArgs": [


### PR DESCRIPTION
This ensures there are no failures due to missing git-lfs hooks and that pre-commit is enabled.