### PR TITLE
Adds TMapfile dependency (ROOT::libNew) if TMapfile is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,13 +267,14 @@ target_compile_options(${PROJECT_NAME}
 # TMapFile is broken with C++17 or higher and ROOT < 6.32
 if(${CMAKE_CXX_STANDARD} LESS 17 OR ${ROOT_VERSION} VERSION_GREATER_EQUAL 6.32)
   target_compile_definitions(${PROJECT_NAME} PUBLIC QW_ENABLE_MAPFILE)
+  set(LIBMAPFILE ROOT::New)
 endif()
 
 target_link_libraries(${PROJECT_NAME}
   PRIVATE
     eviowrapper
   PUBLIC
-    ROOT::Core ROOT::Tree ROOT::Hist ROOT::Rint
+    ROOT::Core ROOT::Tree ROOT::Hist ROOT::Rint ${LIBMAPFILE}
     $<TARGET_NAME_IF_EXISTS:ROOT::ROOTNTuple>
     ${Boost_LIBRARIES}
   )


### PR DESCRIPTION
### Issue 
TMapfile requires the ROOT library, `libNew`. In commit 3cfda1b5f14af9cd8b9a7a15ca17a9c180eb2d5b, we made the change 
```
CMakelists.txt
@@ -270,7 +267,8 @@ target_link_libraries(${PROJECT_NAME}
   PRIVATE
     eviowrapper
   PUBLIC
-    ROOT::Libraries
+    ROOT::Core ROOT::Tree ROOT::Hist ROOT::Rint
+    $<TARGET_NAME_IF_EXISTS:ROOT::ROOTNTuple>
     ${Boost_LIBRARIES}
   )
   ```
[ROOT::Libraries included `libNew` ](https://github.com/JeffersonLab/japan-MOLLER/commit/b7c52f6a1670b11649e2f394f15b6f96d4ab412c).

As far as I can tell, libNew deals with allocations for TMapfiles (likely overloads the new operator but I have not checked), so we do not get a linker issue, instead we get a strange segfault 
```
Error in <TMapFile::TMapFile>: no memory mapped file capability available
Use rootn.exe or link application against "-lNew"
================== RealTime Producer Memory Map File =================
Memory mapped file:   /dev/shm//QwMemMapFile.map
Title:                RealTime Producer File
Option:               file closed
======================================================================
QwRootFile::ConstructHistograms::detectors address 0x7fffffff7de0 and its name evt_histo

Program received signal SIGSEGV, Segmentation fault.
QwRootFile::ConstructHistograms<QwSubsystemArrayParity> (this=this@entry=0x55555d77ad20, name="evt_histo", object=...) at /usr/include/c++/11/bits/basic_string.h:194
194           _M_data() const
(gdb) where
#0  QwRootFile::ConstructHistograms<QwSubsystemArrayParity> (this=this@entry=0x55555d77ad20,
    name="evt_histo", object=...) at /usr/include/c++/11/bits/basic_string.h:194
#1  0x0000555555563015 in main (argc=<optimized out>, argv=<optimized out>)
    at /home/mrc/Github/japan-MOLLER/Parity/main/QwParity.cc:20
   ```
 ### Solution
 Add `ROOT::New` as a dependency. This PR sets a ${LIBMAPFILE} variable if we enable TMapfile
 
 Output with `ROOT::New` included: 
 ```
 Warning in <TMapFile::TMapFile>: map file already open in write mode, opening in read-only mode
================== RealTime Producer Memory Map File =================
Memory mapped file:   /dev/shm//QwMemMapFile.map
Title:                RealTime Producer File
Option:               READ
Mapped Memory region: 0x7fff9b31a000 - 0x7fffdb31a000 (1024.00 MB)
Current breakval:     0x7fff9b598000
======================================================================
QwRootFile::ConstructHistograms::detectors address 0x7fffffff7df0 and its name evt_histo
QwRootFile::ConstructHistograms::detectors address 0x7fffffff8740 and its name mul_histo
QwRootFile::ConstructHistograms::detectors address 0x7fffffff9a10 and its name burst_histo
```