### PR TITLE
Add safe directory configuration for git submodules in CI

### DIFF
--- a/.github/workflows/build-lcg-cvmfs.yml
+++ b/.github/workflows/build-lcg-cvmfs.yml
@@ -47,10 +47,6 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-      - name: Add submodules to git safe directories
-        run: |
-          git config --global --add safe.directory $PWD/thirdparty/\* # Literal asterisk
-          git config --global --get-all safe.directory
       - uses: cvmfs-contrib/github-action-cvmfs@v5
         with:
           cvmfs_repositories: 'sft.cern.ch,geant4.cern.ch'
@@ -77,6 +73,12 @@ jobs:
         with:
           release-platform: ${{ matrix.release }}/${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.opt }}
           run: |
+            echo "::group::Add submodules to git safe directories"
+            git config --global --add safe.directory $PWD
+            git config --global --add safe.directory $PWD/thirdparty/\* # Literal asterisk
+            git config --global --get-all safe.directory
+            echo "::endgroup"
+
             echo "::group::Dependencies"
             # Install dependencies
             PYTHONHOME="" PYTHONPATH="" dnf install -y time


### PR DESCRIPTION
This PR fixes the commit version check for sqlpp11 submodules in CI checks. It appears that the thirdparty directory is not added to safe directories and when running as a different user (`root`) in the LCG container this causes the git ancestor check to fail before even trying. Adding the safe directory outside the container doesn't work since it fails to have the right ownership on the `.gitconfig` global file.