### PR TITLE
Add warnings and treat as error in CMake configuration in CI

### DIFF
--- a/.github/workflows/build-lcg-cvmfs.yml
+++ b/.github/workflows/build-lcg-cvmfs.yml
@@ -104,14 +104,18 @@ jobs:
             echo "::group::Compilation with ccache"
             cmake -Bbuild -S. \
               -Wdev -Werror=dev \
-              -DCMAKE_ERROR_ON_UNUSED_VARIABLES=ON \
               -DBUILD_MARIADB_CONNECTOR=ON \
               -DBUILD_MYSQL_CONNECTOR=ON \
               -DBUILD_POSTGRESQL_CONNECTOR=ON \
               -DBUILD_SQLITE3_CONNECTOR=ON \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache \
               -DCMAKE_INSTALL_PREFIX=install \
-              -DCMAKE_CXX_FLAGS="${{ matrix.cxxflags }}"
+              -DCMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" 2>&1 | tee cmake.txt
+            # Check the log file for unused variables
+            if grep -q "Manually-specified variables were not used" cmake.txt; then
+                echo "ERROR: Unused CMake variables detected."
+                exit 1
+            fi
             cmake --build build -j$(nproc) --target install
             echo "::endgroup::"
 


### PR DESCRIPTION
Needs:
- [x] #204 

We had silently started to fail database functionality in CI since we don't fail CI on CMake developer warnings. While #204 should fix the database issue, this PR should ensure we don't have failures going forward. Until #204, this should fail.