### PR TITLE
QwRunCondition: check getlogin_r return and fallback to "unknown" username on failure

### DIFF
--- a/Analysis/src/QwRunCondition.cc
+++ b/Analysis/src/QwRunCondition.cc
@@ -58,7 +58,9 @@ QwRunCondition::SetArgs(Int_t argc, Char_t* argv[])
   char user_string[fCharLength];
 
   gethostname(host_string, fCharLength);
-  getlogin_r (user_string, fCharLength);
+  if (getlogin_r(user_string, fCharLength) != 0) {
+    snprintf(user_string, fCharLength, "unknown");
+  }
 
   TString host_name = host_string;
   TString user_name = user_string;


### PR DESCRIPTION
Using `getlogin_r` is apparently not a foolproof way of getting the username. For now, just store `unknown` when unable to determine username.