### PR TITLE
Seed randomness generator per run in mock data generation

### DIFF
--- a/Parity/main/QwMockDataGenerator.cc
+++ b/Parity/main/QwMockDataGenerator.cc
@@ -167,7 +167,9 @@ if(1==2){
               run <= runnumber_max;
               run++) {
 
-     QwCombinedBCM<QwVQWK_Channel>::SetTripSeed(0x56781234 ^ (run*run));
+    // Set the random seed for this run
+    randomnessGenerator.seed(run);
+    QwCombinedBCM<QwVQWK_Channel>::SetTripSeed(0x56781234 ^ (run*run));
 
     // Open new output file
     // (giving run number as argument to OpenDataFile confuses the segment search)


### PR DESCRIPTION
Ensure the mt19937 RNG is reseeded with the current run number so random values are independent across runs.