### PR TITLE
Avoid type-punning pointers with memcpy or bit_cast (C++20)

### DIFF
--- a/Parity/src/QwBlinder.cc
+++ b/Parity/src/QwBlinder.cc
@@ -722,8 +722,16 @@ void QwBlinder::InitBlinders(const UInt_t seed_id)
   }
 
   // Generate checksum
+#if __cplusplus < 202002L
+  ULong64_t factor_bits, offset_bits;
+  memcpy(&factor_bits, &fBlindingFactor, sizeof(ULong64_t));
+  memcpy(&offset_bits, &fBlindingOffset, sizeof(ULong64_t));
+#else
+  auto factor_bits = std::bit_cast<ULong64_t>(fBlindingFactor);
+  auto offset_bits = std::bit_cast<ULong64_t>(fBlindingOffset);
+#endif
   TString hex_string;
-  hex_string.Form("%.16llx%.16llx", *(ULong64_t*)(&fBlindingFactor), *(ULong64_t*)(&fBlindingOffset));
+  hex_string.Form("%.16llx%.16llx", factor_bits, offset_bits);
   fDigest = GenerateDigest(hex_string);
   fChecksum = "";
   for (size_t i = 0; i < fDigest.size(); i++)


### PR DESCRIPTION
This PR changes a bit of traditional pointer type punning with the modern way of doing things in C++20, where we bit_cast (keep same bits, interpret as new type). For pre-C++20, we use `memcpy` for this, which most compilers implement as a single operation similar to before, but without pointer magic.