### PR TITLE
Inherit assignment operators on second-level derived classes

### DIFF
--- a/Parity/include/QwBlindDetectorArray.h
+++ b/Parity/include/QwBlindDetectorArray.h
@@ -52,7 +52,6 @@ class QwBlindDetectorArray:
  public:
 
   /// Constructor with name
-
   QwBlindDetectorArray(const TString& name)
   : VQwSubsystem(name), VQwSubsystemParity(name), VQwDetectorArray(name) {};
 
@@ -64,6 +63,9 @@ class QwBlindDetectorArray:
 
   /// Virtual destructor
   ~QwBlindDetectorArray() override{};
+
+  /// Inherit assignment operator on base class
+  using VQwDetectorArray::operator=;
 
   public:
 

--- a/Parity/include/QwDetectorArray.h
+++ b/Parity/include/QwDetectorArray.h
@@ -62,4 +62,8 @@ QwDetectorArray(const QwDetectorArray& source)
 /// Virtual destructor
 ~QwDetectorArray() override {};
 
+
+/// Inherit assignment operator on base class
+using VQwDetectorArray::operator=;
+
 };

--- a/Parity/include/QwFakeHelicity.h
+++ b/Parity/include/QwFakeHelicity.h
@@ -32,6 +32,9 @@ class QwFakeHelicity: public QwHelicity {
 
     ~QwFakeHelicity() override { };
 
+    /// Inherit assignment operator on base class
+    using QwHelicity::operator=;
+
     void    ClearEventData() override;
     Bool_t  IsGoodHelicity() override;
     void    ProcessEvent() override;


### PR DESCRIPTION
This PR adds `using` statements for the `operator=` on base class pointers and references. This ensures that these base-class-type assignment operators are not hidden by the default assignment operator in these derived classes (which don't have any specific data types).