### PR TITLE
Use QwBCM<T>::UpdateErrorFlag in QwCombinedBCM since local implementation commented out

### DIFF
--- a/Parity/include/QwCombinedBCM.h
+++ b/Parity/include/QwCombinedBCM.h
@@ -82,7 +82,7 @@ class QwCombinedBCM : public QwBCM<T> {
 
   Bool_t ApplySingleEventCuts() override;//Check for good events by setting limits on the devices readings
 
-  using QwBCM<T>::UpdateErrorFlag; // avoid hiding UpdateErrorFlag(
+  using QwBCM<T>::UpdateErrorFlag; // avoid hiding UpdateErrorFlag(const VQwBCM*)
   //void UpdateErrorFlag(const VQwBCM *ev_error) override;
 
   UInt_t UpdateErrorFlag() override;


### PR DESCRIPTION
This PR ensures that QwBCM<T> has an UpdateErrorFlag on VQwBCM pointers which is commented out for QwCombinedBCM (but implemented for other classes derived from VQwBCM).