### PR TITLE
Fixup gitignore to avoid matching all of Analysis/include and Parity/include

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,10 +38,10 @@ qwparity_simple
 qwroot
 
 # Directories
-bin
-lib
+/bin
+/lib
 *build*
-include
+/include
 *test*
 output
 Doxygen/html


### PR DESCRIPTION
This fixes up an incorrect commit in #186. That PR added `include` to the `.gitignore`, but without a leading slash this matches all files in Analysis/include and Parity/include. This PR fixes that error.