### PR TITLE
Allocate variable length array on the heap instead of relying on vla stack allocation

### DIFF
--- a/Parity/src/QwHelicity.cc
+++ b/Parity/src/QwHelicity.cc
@@ -1171,13 +1171,14 @@ void QwHelicity::SetFirstBits(UInt_t nbits, UInt_t seed)
   if (nbits != 24)
 	throw std::invalid_argument("SetFirstBits currently only supports 24 bits.");
   // Allocate nbits+1 elements as GetRandomSeed expects Fortran indexing (1-nbits)
-  UShort_t firstbits[nbits+1];  // NB firstbits[0] is never used
+  UShort_t* firstbits = new UShort_t[nbits+1];  // NB firstbits[0] is never used
   for (unsigned int i = 0; i < nbits+1; i++) firstbits[i] = (seed >> i) & 0x1;
   // Set delayed seed
   iseed_Delayed = GetRandomSeed(firstbits);
   // Progress actual seed by the helicity delay
   iseed_Actual = iseed_Delayed;
   for (int i = 0; i < fHelicityDelay; i++) GetRandbit(iseed_Actual);
+  delete[] firstbits;
 }
 
 void QwHelicity::SetHistoTreeSave(const TString &prefix)


### PR DESCRIPTION
This PR moves some technically non-standard (but widely supported) variable length array stack extensions to the heap, in order to retain portability and avoid warnings. This is performance non-critical since only used for initialization.