### PR TITLE
Fix assignment operators to call base class assignment consistently

### DIFF
--- a/Parity/src/QwBeamLine.cc
+++ b/Parity/src/QwBeamLine.cc
@@ -2130,6 +2130,7 @@ VQwSubsystem&  QwBeamLine::operator=  (VQwSubsystem *value)
   if(Compare(value))
     {
 
+      VQwSubsystem::operator=(value);
       QwBeamLine* input = dynamic_cast<QwBeamLine*>(value);
 
       for(size_t i=0;i<input->fClock.size();i++)

--- a/Parity/src/QwBeamMod.cc
+++ b/Parity/src/QwBeamMod.cc
@@ -628,6 +628,7 @@ VQwSubsystem&  QwBeamMod::operator=  (VQwSubsystem *value)
   if(Compare(value))
     {
 
+      VQwSubsystem::operator=(value);
       QwBeamMod* input = dynamic_cast<QwBeamMod*>(value);
 
       for(size_t i=0;i<input->fModChannel.size();i++){

--- a/Parity/src/QwCombinerSubsystem.cc
+++ b/Parity/src/QwCombinerSubsystem.cc
@@ -29,6 +29,7 @@ std::shared_ptr<VQwSubsystem> QwCombinerSubsystem::GetSharedPointerToStaticObjec
 
 VQwSubsystem& QwCombinerSubsystem::operator=(VQwSubsystem* value)
 {
+  VQwSubsystem::operator=(value);
   QwCombinerSubsystem* input= dynamic_cast<QwCombinerSubsystem*>(value);
   if (input!=NULL) {
     for(size_t i = 0; i < input->fDependentVar.size(); i++) {

--- a/Parity/src/QwMollerDetector.cc
+++ b/Parity/src/QwMollerDetector.cc
@@ -259,7 +259,7 @@ void QwMollerDetector::FillNTupleVector(std::vector<Double_t>& values) const
 VQwSubsystem&  QwMollerDetector::operator=(VQwSubsystem *value){
   // std::cout << "QwMollerDetector assignment (operator=)" << std::endl;
   if(this != value && Compare(value)){
-    //VQwSubsystem::operator=(value);
+    VQwSubsystem::operator=(value);
     QwMollerDetector* input = dynamic_cast<QwMollerDetector *> (value);
     for(size_t i = 0; i < input->fSTR7200_Channel.size(); i++){
       for(size_t j = 0; j < input->fSTR7200_Channel[i].size(); j++){

--- a/Parity/src/VQwDetectorArray.cc
+++ b/Parity/src/VQwDetectorArray.cc
@@ -1433,7 +1433,7 @@ VQwSubsystem&  VQwDetectorArray::operator=  (VQwSubsystem *value) {
 
     if (this != value && Compare(value)) {
 
-        //VQwSubsystem::operator=(value);
+        VQwSubsystem::operator=(value);
         VQwDetectorArray* input = dynamic_cast<VQwDetectorArray*> (value);
 
         for (size_t i=0;i<input->fIntegrationPMT.size();i++)


### PR DESCRIPTION
Ensure that the base class assignment operator is invoked in all relevant derived class assignment operators. This change improves the correctness of the assignment operations across the subsystem hierarchy.