### PR TITLE
Add system architecture logging to build workflow

### DIFF
--- a/.github/workflows/build-lcg-cvmfs.yml
+++ b/.github/workflows/build-lcg-cvmfs.yml
@@ -113,6 +113,10 @@ jobs:
             SetupFiles/make_SET_ME_UP
             echo "::endgroup::"
 
+            echo "::group::System architecture"
+            gcc -march=native -Q --help=target | grep -m1 -- '-march='
+            echo "::endgroup::"
+
             echo "::group::Compilation with ccache"
             if [[ "${{ matrix.submodules }}" == "true" ]] ; then
               SQLPP_OPTIONS="\
@@ -374,6 +378,10 @@ jobs:
         with:
           release-platform: ${{ matrix.release }}/${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.opt }}
           run: |
+            echo "::group::System architecture"
+            gcc -march=native -Q --help=target | grep -m1 -- '-march='
+            echo "::endgroup::"
+
             echo "::group::Mock data generation"
             build/qwmockdatagenerator -r 4 -e 1:20000 --config qwparity_simple.conf --detectors mock_newdets.map --data .
             echo "::endgroup::"


### PR DESCRIPTION
It is technically possible that the build happens on a different architecture than the valgrind run. This may be the cause behind failures like https://github.com/JeffersonLab/japan-MOLLER/actions/runs/19040739228/job/54378828855.

This PR adds logging of architecture. This PR may also add setting the architecture from native to a specific target in the CI builds.