### PR TITLE
Modify build-lcg-cvmfs.yml file: slim ROOT file; compare mul branch for PR requests

### DIFF
--- a/.github/workflows/build-lcg-cvmfs.yml
+++ b/.github/workflows/build-lcg-cvmfs.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
@@ -228,8 +229,74 @@ jobs:
             fi
             echo "::endgroup::"
 
+      # --- Create the slim ROOT (mul-only) and upload it ---
+
+      - name: Create ROOT macro to skim mul
+        shell: bash
+        run: |
+          cat > skim_mul.C <<'EOF'
+          #include "TFile.h"
+          #include "TTree.h"
+          #include "TKey.h"
+          #include "TDirectory.h"
+          #include "TSystem.h"
+          #include <cstdio>
+          void skim_mul(const char* inFile  = "trees/isu_sample_4.root",
+                        const char* outFile = "trees/isu_sample_4.slim.root",
+                        const char* pathToMul = "mul") {
+            TFile* fin = TFile::Open(inFile, "READ");
+            if (!fin || fin->IsZombie()) { fprintf(stderr,"Cannot open %s\n", inFile); gSystem->Exit(1); }
+            TObject* obj = fin->Get(pathToMul);
+            if (!obj)  { fprintf(stderr,"Could not find \"%s\" in %s\n", pathToMul, inFile); gSystem->Exit(2); }
+            TTree* tin = dynamic_cast<TTree*>(obj);
+            if (!tin)  { fprintf(stderr,"Object \"%s\" is not a TTree\n", pathToMul); gSystem->Exit(3); }
+            printf("Found tree \"%s\" with %lld entries\n", tin->GetName(), (long long)tin->GetEntries());
+            TFile* fout = TFile::Open(outFile, "RECREATE");
+            if (!fout || fout->IsZombie()) { fprintf(stderr,"Cannot create %s\n", outFile); gSystem->Exit(4); }
+            fout->cd();
+            TTree* tout = tin->CloneTree(-1, "fast");
+            if (!tout)  { fprintf(stderr,"CloneTree failed for \"%s\"\n", pathToMul); gSystem->Exit(5); }
+            tout->SetDirectory(fout);
+            tout->Write();
+            if (tin->GetListOfFriends() && tin->GetListOfFriends()->GetSize() > 0) {
+              printf("Note: original tree has friends; consider cloning them separately.\n");
+            }
+            fout->Write();
+            fout->Close();
+            fin->Close();
+            printf("Wrote %s containing only \"%s\".\n", outFile, pathToMul);
+          }
+          EOF
+
+      - name: Cleanup previous view_worker Docker containers
+        run: |
+          ids=$(docker ps -a --filter "name=view_worker" -q)
+          if [ -n "$ids" ]; then
+            docker rm -f $ids
+          fi
+       
+      - name: Make slim ROOT (keep only mul)
+        uses: aidasoft/run-lcg-view@v5
+        with:
+          release-platform: ${{ matrix.release }}/${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.opt }}
+          run: |
+            set -euo pipefail
+            test -f trees/isu_sample_4.root || { echo "Missing trees/isu_sample_4.root"; exit 1; }
+            root -l -b -q 'skim_mul.C("trees/isu_sample_4.root","trees/isu_sample_4.slim.root")'
+            test -f trees/isu_sample_4.slim.root
+
+        # upload the slim ROOT file
+      - name: Upload slim ROOT
+        uses: actions/upload-artifact@v5
+        with:
+          name: root-slim-${{ matrix.release }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.opt }}
+          path: trees/isu_sample_4.slim.root
+          retention-days: 7
+          if-no-files-found: error
+
       - name: Compress build directory
         run: tar -caf build.tar.zst build/
+
       - name: Upload build artifact
         uses: actions/upload-artifact@v7
         with:
@@ -304,6 +371,91 @@ jobs:
           name: regalias-${{ matrix.release }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.opt }}
           path: ./target
           if_no_artifact_found: warn
+
+      - name: Download target branch artifacts (root-slim)
+        if: github.event_name == 'pull_request'
+        uses: dawidd6/action-download-artifact@v11
+        with:
+          workflow: build-lcg-cvmfs.yml
+          branch: ${{ github.event.pull_request.base.ref }}
+          workflow_conclusion: completed
+          name: root-slim-${{ matrix.release }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.opt }}
+          path: ./target
+          if_no_artifact_found: warn
+
+      - name: Normalize baseline slim path
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          mkdir -p ./target
+          slim="$(find ./target -type f -name 'isu_sample_4.slim.root' | head -n1 || true)"
+          if [ -n "${slim:-}" ]; then
+            if [ "$slim" != "./target/isu_sample_4.slim.root" ]; then
+              cp "$slim" ./target/isu_sample_4.slim.root
+            else
+              echo "Baseline slim already at ./target/isu_sample_4.slim.root"
+            fi
+            echo "Baseline slim ready at ./target/isu_sample_4.slim.root"
+          else
+            echo "No baseline slim ROOT found under ./target"
+          fi
+          ls -R ./target || true
+
+ 
+      - name: Cleanup previous view_worker Docker containers
+        run: |
+          ids=$(docker ps -a --filter "name=view_worker" -q)
+          if [ -n "$ids" ]; then
+            docker rm -f $ids
+          fi
+       
+      - name: ROOT comparison (mul/diff_* in isu_sample_4.slim.root)
+        if: github.event_name == 'pull_request'
+        uses: aidasoft/run-lcg-view@v5
+        with:
+          release-platform: ${{ matrix.release }}/${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.opt }}
+          run: |
+            set -euo pipefail
+
+            # Filenames unique per matrix entry (for logs only)
+            COMP_TXT="compare-trees-${{ matrix.release }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.opt }}.txt"
+            : > "$COMP_TXT"  # create/empty the file up front so it always exists
+
+            # Stable paths: keep standard filenames
+            PR_ROOT_SLIM="trees/isu_sample_4.slim.root"
+            BASE_ROOT="./target/isu_sample_4.slim.root"
+
+            echo "::group::Verify PR slim"
+            test -f "trees/isu_sample_4.root" || { echo "Missing trees/isu_sample_4.root" | tee -a "$COMP_TXT"; exit 1; }
+            test -f "$PR_ROOT_SLIM" || root -l -b -q 'skim_mul.C("trees/isu_sample_4.root","trees/isu_sample_4.slim.root")'
+            test -f "$PR_ROOT_SLIM" || { echo "Failed to produce slim ROOT" | tee -a "$COMP_TXT"; exit 1; }
+            echo "Found PR slim ROOT: $PR_ROOT_SLIM" >> "$COMP_TXT"
+            echo "::endgroup::"
+
+            if [ ! -f "$BASE_ROOT" ]; then
+              {
+                echo "No baseline slim ROOT found at $BASE_ROOT"
+                echo "(Likely first run or base branch not built recently.)"
+              } >> "$COMP_TXT"
+              exit 0
+            fi
+
+            echo "::group::Run CompareTrees"
+            echo "BASE: $BASE_ROOT" >> "$COMP_TXT"
+            echo "PR  : $PR_ROOT_SLIM" >> "$COMP_TXT"
+            root -l -b -q "rootScripts/ci/CompareTrees.C(\"$BASE_ROOT\",\"$PR_ROOT_SLIM\",\"mul\",\"diff_\")" \
+              | tee -a "$COMP_TXT"
+            echo "::endgroup::"
+
+      - name: Upload compare-trees output
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v5
+        with:
+          name: compare-trees-${{ matrix.release }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.opt }}
+          path: compare-trees-${{ matrix.release }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.opt }}.txt
+          retention-days: 7
+          if-no-files-found: error
+
 
       - name: Compare artifacts
         if: github.event_name == 'pull_request'

--- a/.github/workflows/build-lcg-cvmfs.yml
+++ b/.github/workflows/build-lcg-cvmfs.yml
@@ -228,25 +228,16 @@ jobs:
             fi
             echo "::endgroup::"
 
-      # --- Create the slim ROOT (mul-only) and upload it ---
-      - name: Make slim ROOT (keep only mul)
-        uses: aidasoft/run-lcg-view@v5
-        with:
-          release-platform: ${{ matrix.release }}/${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.opt }}
-          run: |
-            set -euo pipefail
-
-            # Cleanup previous view_worker Docker containers
-            ids=$(docker ps -a --filter "name=view_worker" -q || true)
-            if [ -n "${ids:-}" ]; then
-              docker rm -f $ids || true
+            echo "::group::Make slim ROOT (keep only mul)"
+            if [ -f trees/isu_sample_4.root ]; then
+              root -l -b -q 'rootScripts/ci/skim_mul.C("trees/isu_sample_4.root","trees/isu_sample_4.slim.root")'
+              test -f trees/isu_sample_4.slim.root
+            else
+              echo "Missing trees/isu_sample_4.root"
+              exit 1
             fi
+            echo "::endgroup::"
 
-            test -f trees/isu_sample_4.root || { echo "Missing trees/isu_sample_4.root"; exit 1; }
-
-            # Use the skim_mul macro from the repository
-            root -l -b -q 'rootScripts/ci/skim_mul.C("trees/isu_sample_4.root","trees/isu_sample_4.slim.root")'
-            test -f trees/isu_sample_4.slim.root
 
         # upload the slim ROOT file
       - name: Upload slim ROOT
@@ -364,6 +355,17 @@ jobs:
           fi
           ls -R ./target || true
 
+      - name: Cleanup previous view_worker Docker containers
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          ids=$(docker ps -a --filter "name=view_worker" -q || true)
+          if [ -n "${ids:-}" ]; then
+            echo "Removing previous view_worker container(s): $ids"
+            docker rm -f $ids || true
+          else
+            echo "No previous view_worker containers found"
+          fi
        
       - name: ROOT comparison (mul/diff_* in isu_sample_4.slim.root)
         if: github.event_name == 'pull_request'
@@ -372,12 +374,6 @@ jobs:
           release-platform: ${{ matrix.release }}/${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.opt }}
           run: |
             set -euo pipefail
-
-            # Cleanup previous view_worker Docker containers
-            ids=$(docker ps -a --filter "name=view_worker" -q || true)
-            if [ -n "${ids:-}" ]; then
-              docker rm -f $ids || true
-            fi
             
             # Filenames unique per matrix entry (for logs only)
             COMP_TXT="compare-trees-${{ matrix.release }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.opt }}.txt"

--- a/.github/workflows/build-lcg-cvmfs.yml
+++ b/.github/workflows/build-lcg-cvmfs.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
@@ -230,59 +229,23 @@ jobs:
             echo "::endgroup::"
 
       # --- Create the slim ROOT (mul-only) and upload it ---
-
-      - name: Create ROOT macro to skim mul
-        shell: bash
-        run: |
-          cat > skim_mul.C <<'EOF'
-          #include "TFile.h"
-          #include "TTree.h"
-          #include "TKey.h"
-          #include "TDirectory.h"
-          #include "TSystem.h"
-          #include <cstdio>
-          void skim_mul(const char* inFile  = "trees/isu_sample_4.root",
-                        const char* outFile = "trees/isu_sample_4.slim.root",
-                        const char* pathToMul = "mul") {
-            TFile* fin = TFile::Open(inFile, "READ");
-            if (!fin || fin->IsZombie()) { fprintf(stderr,"Cannot open %s\n", inFile); gSystem->Exit(1); }
-            TObject* obj = fin->Get(pathToMul);
-            if (!obj)  { fprintf(stderr,"Could not find \"%s\" in %s\n", pathToMul, inFile); gSystem->Exit(2); }
-            TTree* tin = dynamic_cast<TTree*>(obj);
-            if (!tin)  { fprintf(stderr,"Object \"%s\" is not a TTree\n", pathToMul); gSystem->Exit(3); }
-            printf("Found tree \"%s\" with %lld entries\n", tin->GetName(), (long long)tin->GetEntries());
-            TFile* fout = TFile::Open(outFile, "RECREATE");
-            if (!fout || fout->IsZombie()) { fprintf(stderr,"Cannot create %s\n", outFile); gSystem->Exit(4); }
-            fout->cd();
-            TTree* tout = tin->CloneTree(-1, "fast");
-            if (!tout)  { fprintf(stderr,"CloneTree failed for \"%s\"\n", pathToMul); gSystem->Exit(5); }
-            tout->SetDirectory(fout);
-            tout->Write();
-            if (tin->GetListOfFriends() && tin->GetListOfFriends()->GetSize() > 0) {
-              printf("Note: original tree has friends; consider cloning them separately.\n");
-            }
-            fout->Write();
-            fout->Close();
-            fin->Close();
-            printf("Wrote %s containing only \"%s\".\n", outFile, pathToMul);
-          }
-          EOF
-
-      - name: Cleanup previous view_worker Docker containers
-        run: |
-          ids=$(docker ps -a --filter "name=view_worker" -q)
-          if [ -n "$ids" ]; then
-            docker rm -f $ids
-          fi
-       
       - name: Make slim ROOT (keep only mul)
         uses: aidasoft/run-lcg-view@v5
         with:
           release-platform: ${{ matrix.release }}/${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.opt }}
           run: |
             set -euo pipefail
+
+            # Cleanup previous view_worker Docker containers
+            ids=$(docker ps -a --filter "name=view_worker" -q || true)
+            if [ -n "${ids:-}" ]; then
+              docker rm -f $ids || true
+            fi
+
             test -f trees/isu_sample_4.root || { echo "Missing trees/isu_sample_4.root"; exit 1; }
-            root -l -b -q 'skim_mul.C("trees/isu_sample_4.root","trees/isu_sample_4.slim.root")'
+
+            # Use the skim_mul macro from the repository
+            root -l -b -q 'rootScripts/ci/skim_mul.C("trees/isu_sample_4.root","trees/isu_sample_4.slim.root")'
             test -f trees/isu_sample_4.slim.root
 
         # upload the slim ROOT file
@@ -401,13 +364,6 @@ jobs:
           fi
           ls -R ./target || true
 
- 
-      - name: Cleanup previous view_worker Docker containers
-        run: |
-          ids=$(docker ps -a --filter "name=view_worker" -q)
-          if [ -n "$ids" ]; then
-            docker rm -f $ids
-          fi
        
       - name: ROOT comparison (mul/diff_* in isu_sample_4.slim.root)
         if: github.event_name == 'pull_request'
@@ -417,6 +373,12 @@ jobs:
           run: |
             set -euo pipefail
 
+            # Cleanup previous view_worker Docker containers
+            ids=$(docker ps -a --filter "name=view_worker" -q || true)
+            if [ -n "${ids:-}" ]; then
+              docker rm -f $ids || true
+            fi
+            
             # Filenames unique per matrix entry (for logs only)
             COMP_TXT="compare-trees-${{ matrix.release }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.opt }}.txt"
             : > "$COMP_TXT"  # create/empty the file up front so it always exists
@@ -427,7 +389,7 @@ jobs:
 
             echo "::group::Verify PR slim"
             test -f "trees/isu_sample_4.root" || { echo "Missing trees/isu_sample_4.root" | tee -a "$COMP_TXT"; exit 1; }
-            test -f "$PR_ROOT_SLIM" || root -l -b -q 'skim_mul.C("trees/isu_sample_4.root","trees/isu_sample_4.slim.root")'
+            test -f "$PR_ROOT_SLIM" || root -l -b -q 'rootScripts/ci/skim_mul.C("trees/isu_sample_4.root","trees/isu_sample_4.slim.root")'
             test -f "$PR_ROOT_SLIM" || { echo "Failed to produce slim ROOT" | tee -a "$COMP_TXT"; exit 1; }
             echo "Found PR slim ROOT: $PR_ROOT_SLIM" >> "$COMP_TXT"
             echo "::endgroup::"

--- a/rootScripts/ci/skim_mul.C
+++ b/rootScripts/ci/skim_mul.C
@@ -1,0 +1,40 @@
+// rootScripts/ci/skim_mul.C
+#include "TFile.h"
+#include "TTree.h"
+#include "TKey.h"
+#include "TDirectory.h"
+#include "TSystem.h"
+#include <cstdio>
+
+void skim_mul(const char* inFile  = "trees/isu_sample_4.root",
+              const char* outFile = "trees/isu_sample_4.slim.root",
+              const char* pathToMul = "mul") {
+  TFile* fin = TFile::Open(inFile, "READ");
+  if (!fin || fin->IsZombie()) { fprintf(stderr,"Cannot open %s\n", inFile); gSystem->Exit(1); }
+
+  TObject* obj = fin->Get(pathToMul);
+  if (!obj)  { fprintf(stderr,"Could not find \"%s\" in %s\n", pathToMul, inFile); gSystem->Exit(2); }
+
+  TTree* tin = dynamic_cast<TTree*>(obj);
+  if (!tin)  { fprintf(stderr,"Object \"%s\" is not a TTree\n", pathToMul); gSystem->Exit(3); }
+
+  printf("Found tree \"%s\" with %lld entries\n", tin->GetName(), (long long)tin->GetEntries());
+
+  TFile* fout = TFile::Open(outFile, "RECREATE");
+  if (!fout || fout->IsZombie()) { fprintf(stderr,"Cannot create %s\n", outFile); gSystem->Exit(4); }
+
+  fout->cd();
+  TTree* tout = tin->CloneTree(-1, "fast");
+  if (!tout)  { fprintf(stderr,"CloneTree failed for \"%s\"\n", pathToMul); gSystem->Exit(5); }
+  tout->SetDirectory(fout);
+  tout->Write();
+
+  if (tin->GetListOfFriends() && tin->GetListOfFriends()->GetSize() > 0) {
+    printf("Note: original tree has friends; consider cloning them separately.\n");
+  }
+
+  fout->Write();
+  fout->Close();
+  fin->Close();
+  printf("Wrote %s containing only \"%s\".\n", outFile, pathToMul);
+}


### PR DESCRIPTION
Updated build-lcg-cvmfs.yml file to streamline ROOT comparison part.
- create a slim ROOT file that contains only "mul" tree.
- On pull requests, the workflow downloads the baseline slim ROOT file and runs a CompareTrees.C macro to check if there are any differences in the mul branches between PR and the main branch.
- The result is saved as a text artifact (compare-trees-*.txt).
- Had to add docker cleanup step because I was getting `"docker: Error response from daemon: Conflict. The container name "/view_worker" is already in use by container "9bbbd3035baa0bdf8083189942de00b8dbf7bea3e88784441477892605d9a3a9". You have to remove (or rename) that container to be able to reuse that name."`

errors when I was testing the workflow in my forked area.  @wdconinc: could you please review the changes?