### PR TITLE
hotfix: Update CXX flags to target x86-64-v3 architecture

### DIFF
--- a/.github/workflows/build-lcg-cvmfs.yml
+++ b/.github/workflows/build-lcg-cvmfs.yml
@@ -23,28 +23,28 @@ jobs:
             os: "el9"
             compiler: "gcc13"
             opt: "opt"
-            cxxflags: "-march=x86-64-v3 -mtune=x86-64-v3 -g -pg"
+            cxxflags: "-march=x86-64-v3 -mtune=generic -g -pg"
             submodules: true
           - release: "LCG_107"
             arch: "x86_64"
             os: "el9"
             compiler: "gcc14"
             opt: "opt"
-            cxxflags: "-march=x86-64-v3 -mtune=x86-64-v3"
+            cxxflags: "-march=x86-64-v3 -mtune=generic"
             submodules: true
           - release: "LCG_108"
             arch: "x86_64"
             os: "el9"
             compiler: "clang19"
             opt: "opt"
-            cxxflags: "-march=x86-64-v3 -mtune=x86-64-v3"
+            cxxflags: "-march=x86-64-v3 -mtune=generic"
             submodules: true
           - release: "LCG_108"
             arch: "x86_64"
             os: "el9"
             compiler: "gcc15"
             opt: "opt"
-            cxxflags: "-march=x86-64-v3 -mtune=x86-64-v3"
+            cxxflags: "-march=x86-64-v3 -mtune=generic"
             submodules: true
           # Build without submodules
           - release: "LCG_108"
@@ -52,7 +52,7 @@ jobs:
             os: "el9"
             compiler: "gcc15"
             opt: "dbg"
-            cxxflags: "-march=x86-64-v3 -mtune=x86-64-v3"
+            cxxflags: "-march=x86-64-v3 -mtune=generic"
             submodules: false
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
This PR should avoid the march=native mismatch between build and run nodes in e.g. https://github.com/JeffersonLab/japan-MOLLER/actions/runs/19282384094 where the build was on icelake and the valgrind job ran on znver3.