### PR TITLE
Clarify ROOT::RNTupleModel Ownership

### DIFF
--- a/Analysis/include/QwADC18_Channel.h
+++ b/Analysis/include/QwADC18_Channel.h
@@ -232,7 +232,7 @@ class QwADC18_Channel: public VQwHardwareChannel, public MQwMockable {
   void  ConstructBranch(TTree *tree, TString &prefix) override;
   void  FillTreeVector(QwRootTreeBranchVector &values) const override;
 #ifdef HAS_RNTUPLE_SUPPORT
-  void  ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
+  void  ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
   void  FillNTupleVector(std::vector<Double_t>& values) const override;
 #endif // HAS_RNTUPLE_SUPPORT
 

--- a/Analysis/include/QwEPICSEvent.h
+++ b/Analysis/include/QwEPICSEvent.h
@@ -119,7 +119,7 @@ class QwEPICSEvent
 
 #ifdef HAS_RNTUPLE_SUPPORT
   /// \brief Construct the RNTuple fields and vector
-  void ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs);
+  void ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs);
   /// \brief Fill the RNTuple vector
   void FillNTupleVector(std::vector<Double_t>& values) const;
 #endif // HAS_RNTUPLE_SUPPORT

--- a/Analysis/include/QwMollerADC_Channel.h
+++ b/Analysis/include/QwMollerADC_Channel.h
@@ -243,7 +243,7 @@ class QwMollerADC_Channel: public VQwHardwareChannel, public MQwMockable {
   void  ConstructBranch(TTree *tree, TString &prefix) override;
   void  FillTreeVector(QwRootTreeBranchVector &values) const override;
 #ifdef HAS_RNTUPLE_SUPPORT
-  void  ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
+  void  ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
   void  FillNTupleVector(std::vector<Double_t>& values) const override;
 #endif // HAS_RNTUPLE_SUPPORT
 

--- a/Analysis/include/QwOmnivore.h
+++ b/Analysis/include/QwOmnivore.h
@@ -111,7 +111,7 @@ class QwOmnivore: public VQwSubsystem_t {
     void FillTreeVector(QwRootTreeBranchVector &values) const override { };
 #ifdef HAS_RNTUPLE_SUPPORT
     /// Construct the RNTuple fields and vector
-    void ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override { };
+    void ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override { };
     /// Fill the RNTuple vector
     void FillNTupleVector(std::vector<Double_t>& values) const override { };
 #endif // HAS_RNTUPLE_SUPPORT

--- a/Analysis/include/QwRootFile.h
+++ b/Analysis/include/QwRootFile.h
@@ -660,7 +660,7 @@ class QwRootNTuple {
 
       // Associate fields with vector - now using shared field pointers
       TString prefix = Form("%s", fPrefix.c_str());
-      object.ConstructNTupleAndVector(fModel, prefix, fVector, fFieldPtrs);
+      object.ConstructNTupleAndVector(fModel.get(), prefix, fVector, fFieldPtrs);
 
       // Store the type of object
       fType = typeid(object).name();

--- a/Analysis/include/QwScaler_Channel.h
+++ b/Analysis/include/QwScaler_Channel.h
@@ -192,7 +192,7 @@ public:
   void  FillTreeVector(QwRootTreeBranchVector &values) const override = 0;
   void  ConstructBranch(TTree *tree, TString &prefix) override;
 #ifdef HAS_RNTUPLE_SUPPORT
-  void  ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override = 0;
+  void  ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override = 0;
   void  FillNTupleVector(std::vector<Double_t>& values) const override = 0;
 #endif // HAS_RNTUPLE_SUPPORT
 
@@ -290,7 +290,7 @@ class QwScaler_Channel: public VQwScaler_Channel
   void  ConstructBranchAndVector(TTree *tree, TString &prefix, QwRootTreeBranchVector &values) override;
   void  FillTreeVector(QwRootTreeBranchVector &values) const override;
 #ifdef HAS_RNTUPLE_SUPPORT
-  void  ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
+  void  ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
   void  FillNTupleVector(std::vector<Double_t>& values) const override;
 #endif // HAS_RNTUPLE_SUPPORT
 

--- a/Analysis/include/QwSubsystemArray.h
+++ b/Analysis/include/QwSubsystemArray.h
@@ -222,12 +222,12 @@ class QwSubsystemArray:
 
 #ifdef HAS_RNTUPLE_SUPPORT
   /// \brief Construct RNTuple fields and vector for this subsystem
-  void ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) {
+  void ConstructNTupleAndVector(ROOT::RNTupleModel *model, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) {
     TString tmpstr("");
     ConstructNTupleAndVector(model, tmpstr, values, fieldPtrs);
   };
   /// \brief Construct RNTuple fields and vector for this subsystem with a prefix
-  void ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs);
+  void ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs);
   /// \brief Fill the RNTuple vector for this subsystem
   void FillNTupleVector(std::vector<Double_t>& values) const;
 #endif // HAS_RNTUPLE_SUPPORT

--- a/Analysis/include/QwVQWK_Channel.h
+++ b/Analysis/include/QwVQWK_Channel.h
@@ -244,7 +244,7 @@ class QwVQWK_Channel: public VQwHardwareChannel, public MQwMockable {
 
 #ifdef HAS_RNTUPLE_SUPPORT
   // RNTuple support methods
-  void  ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString &prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>> &fieldPtrs) override;
+  void  ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString &prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>> &fieldPtrs) override;
   void  FillNTupleVector(std::vector<Double_t>& values) const override;
 #endif // HAS_RNTUPLE_SUPPORT
 

--- a/Analysis/include/VQwHardwareChannel.h
+++ b/Analysis/include/VQwHardwareChannel.h
@@ -259,7 +259,7 @@ public:
   void ConstructBranch(TTree *tree, TString &prefix, QwParameterFile& modulelist);
   virtual void FillTreeVector(QwRootTreeBranchVector& values) const = 0;
 #ifdef HAS_RNTUPLE_SUPPORT
-  virtual void ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) = 0;
+  virtual void ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) = 0;
   virtual void FillNTupleVector(std::vector<Double_t>& values) const = 0;
 #endif // HAS_RNTUPLE_SUPPORT
 

--- a/Analysis/include/VQwSubsystem.h
+++ b/Analysis/include/VQwSubsystem.h
@@ -335,9 +335,9 @@ class VQwSubsystem: virtual public VQwSubsystemCloneable, public MQwHistograms, 
    * @param values    Export values vector.
    * @param fieldPtrs Shared pointers to field backing storage.
    */
-  virtual void ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) = 0;
+  virtual void ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) = 0;
   /// \brief Construct the RNTuple fields and vector
-  virtual void ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) {
+  virtual void ConstructNTupleAndVector(ROOT::RNTupleModel *model, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) {
     TString tmpstr("");
     ConstructNTupleAndVector(model, tmpstr, values, fieldPtrs);
   };

--- a/Analysis/src/QwADC18_Channel.cc
+++ b/Analysis/src/QwADC18_Channel.cc
@@ -647,7 +647,7 @@ void  QwADC18_Channel::FillTreeVector(QwRootTreeBranchVector &values) const
 }
 
 #ifdef HAS_RNTUPLE_SUPPORT
-void  QwADC18_Channel::ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
+void  QwADC18_Channel::ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
 {
   if (IsNameEmpty()){
     //  This channel is not used, so skip setting up the RNTuple.

--- a/Analysis/src/QwEPICSEvent.cc
+++ b/Analysis/src/QwEPICSEvent.cc
@@ -232,7 +232,7 @@ void QwEPICSEvent::FillTreeVector(QwRootTreeBranchVector &values) const
 }
 
 #ifdef HAS_RNTUPLE_SUPPORT
-void QwEPICSEvent::ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
+void QwEPICSEvent::ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
 {
   fTreeArrayIndex = values.size();
   for (size_t tagindex = 0; tagindex < fEPICSVariableType.size(); tagindex++) {

--- a/Analysis/src/QwMollerADC_Channel.cc
+++ b/Analysis/src/QwMollerADC_Channel.cc
@@ -856,7 +856,7 @@ void  QwMollerADC_Channel::FillTreeVector(QwRootTreeBranchVector& values) const
 }
 
 #ifdef HAS_RNTUPLE_SUPPORT
-void  QwMollerADC_Channel::ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
+void  QwMollerADC_Channel::ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
 {
   //For rntuple
   if (IsNameEmpty()) {

--- a/Analysis/src/QwScaler_Channel.cc
+++ b/Analysis/src/QwScaler_Channel.cc
@@ -342,7 +342,7 @@ void QwScaler_Channel<data_mask,data_shift>::FillTreeVector(QwRootTreeBranchVect
 
 #ifdef HAS_RNTUPLE_SUPPORT
 template<unsigned int data_mask, unsigned int data_shift>
-void QwScaler_Channel<data_mask,data_shift>::ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
+void QwScaler_Channel<data_mask,data_shift>::ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
 {
   if (IsNameEmpty()){
     //  This channel is not used, so skip setting up the RNTuple.

--- a/Analysis/src/QwSubsystemArray.cc
+++ b/Analysis/src/QwSubsystemArray.cc
@@ -672,7 +672,7 @@ void QwSubsystemArray::FillTreeVector(QwRootTreeBranchVector &values) const
  * @param fieldPtrs Vector of shared field pointers
  */
 void QwSubsystemArray::ConstructNTupleAndVector(
-    std::unique_ptr<ROOT::RNTupleModel>& model,
+    ROOT::RNTupleModel *model,
     TString& prefix,
     std::vector<Double_t>& values,
     std::vector<std::shared_ptr<Double_t>>& fieldPtrs)

--- a/Analysis/src/QwVQWK_Channel.cc
+++ b/Analysis/src/QwVQWK_Channel.cc
@@ -901,7 +901,7 @@ void  QwVQWK_Channel::FillTreeVector(QwRootTreeBranchVector &values) const
 }
 
 #ifdef HAS_RNTUPLE_SUPPORT
-void  QwVQWK_Channel::ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString &prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>> &fieldPtrs)
+void  QwVQWK_Channel::ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString &prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>> &fieldPtrs)
 {
   //  This channel is not used, so skip setting up the RNTuple.
   if (IsNameEmpty()) return;

--- a/Parity/include/QwBCM.h
+++ b/Parity/include/QwBCM.h
@@ -170,7 +170,7 @@ public:
   void  ConstructBranch(TTree *tree, TString &prefix, QwParameterFile& modulelist) override;
   void  FillTreeVector(QwRootTreeBranchVector &values) const override;
 #ifdef HAS_RNTUPLE_SUPPORT
-  void  ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
+  void  ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
   void  FillNTupleVector(std::vector<Double_t>& values) const override;
 #endif
 

--- a/Parity/include/QwBPMCavity.h
+++ b/Parity/include/QwBPMCavity.h
@@ -140,7 +140,7 @@ class QwBPMCavity : public VQwBPM {
   void    ConstructBranch(TTree *tree, TString &prefix) override;
   void    ConstructBranch(TTree *tree, TString &prefix, QwParameterFile& modulelist) override;
 #ifdef HAS_RNTUPLE_SUPPORT
-  void    ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
+  void    ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
   void    FillNTupleVector(std::vector<Double_t>& values) const override;
 #endif
 

--- a/Parity/include/QwBPMStripline.h
+++ b/Parity/include/QwBPMStripline.h
@@ -169,7 +169,7 @@ class QwBPMStripline : public VQwBPM {
 
 #ifdef HAS_RNTUPLE_SUPPORT
   // RNTuple methods
-  void    ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
+  void    ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
   void    FillNTupleVector(std::vector<Double_t>& values) const override;
 #endif
 

--- a/Parity/include/QwBeamLine.h
+++ b/Parity/include/QwBeamLine.h
@@ -134,7 +134,7 @@ class QwBeamLine : public VQwSubsystemParity, public MQwSubsystemCloneable<QwBea
 
 #ifdef HAS_RNTUPLE_SUPPORT
   using  VQwSubsystem::ConstructNTupleAndVector;
-  void   ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
+  void   ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
   void   FillNTupleVector(std::vector<Double_t>& values) const override;
 #endif
 

--- a/Parity/include/QwBeamMod.h
+++ b/Parity/include/QwBeamMod.h
@@ -186,7 +186,7 @@ class QwBeamMod: public VQwSubsystemParity, public MQwSubsystemCloneable<QwBeamM
   void ConstructBranch(TTree *tree, TString& prefix, QwParameterFile& trim_file) override { };
   void FillTreeVector(QwRootTreeBranchVector &values) const override;
 #ifdef HAS_RNTUPLE_SUPPORT
-  void ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
+  void ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
   void FillNTupleVector(std::vector<Double_t>& values) const override;
 #endif // HAS_RNTUPLE_SUPPORT
 

--- a/Parity/include/QwClock.h
+++ b/Parity/include/QwClock.h
@@ -145,7 +145,7 @@ class QwClock : public VQwClock {
   void  ConstructBranch(TTree *tree, TString &prefix, QwParameterFile& modulelist) override;
   void  FillTreeVector(QwRootTreeBranchVector &values) const override;
 #ifdef HAS_RNTUPLE_SUPPORT
-  void  ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
+  void  ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
   void  FillNTupleVector(std::vector<Double_t>& values) const override;
 #endif // HAS_RNTUPLE_SUPPORT
 

--- a/Parity/include/QwCombinedBPM.h
+++ b/Parity/include/QwCombinedBPM.h
@@ -157,7 +157,7 @@ class QwCombinedBPM : public VQwBPM {
 
 #ifdef HAS_RNTUPLE_SUPPORT
   // RNTuple methods
-  void    ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
+  void    ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
   void    FillNTupleVector(std::vector<Double_t>& values) const override;
 #endif // HAS_RNTUPLE_SUPPORT
 

--- a/Parity/include/QwCombinedPMT.h
+++ b/Parity/include/QwCombinedPMT.h
@@ -139,7 +139,7 @@ class QwCombinedPMT : public VQwDataElement {
 
 #ifdef HAS_RNTUPLE_SUPPORT
   // RNTuple methods
-  void  ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs);
+  void  ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs);
   void  FillNTupleVector(std::vector<Double_t>& values) const;
 #endif // HAS_RNTUPLE_SUPPORT
 

--- a/Parity/include/QwCombinerSubsystem.h
+++ b/Parity/include/QwCombinerSubsystem.h
@@ -69,7 +69,7 @@ class QwCombinerSubsystem: public VQwSubsystemParity,
         QwCombiner::FillTreeVector(values);
       }
 #ifdef HAS_RNTUPLE_SUPPORT
-      void ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override{
+      void ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override{
         QwCombiner::ConstructNTupleAndVector(model, prefix, values, fieldPtrs);
       }
       void FillNTupleVector(std::vector<Double_t>& values) const override{

--- a/Parity/include/QwEnergyCalculator.h
+++ b/Parity/include/QwEnergyCalculator.h
@@ -131,7 +131,7 @@ class QwEnergyCalculator : public VQwDataElement{
     void    FillTreeVector(QwRootTreeBranchVector &values) const;
 
 #ifdef HAS_RNTUPLE_SUPPORT
-    void    ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs);
+    void    ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs);
     void    FillNTupleVector(std::vector<Double_t>& values) const;
 #endif // HAS_RNTUPLE_SUPPORT
 

--- a/Parity/include/QwHaloMonitor.h
+++ b/Parity/include/QwHaloMonitor.h
@@ -122,7 +122,7 @@ class  QwHaloMonitor : public VQwDataElement{
   void  FillTreeVector(QwRootTreeBranchVector &values) const;
 
 #ifdef HAS_RNTUPLE_SUPPORT
-  void  ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs);
+  void  ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs);
   void  FillNTupleVector(std::vector<Double_t>& values) const;
 #endif // HAS_RNTUPLE_SUPPORT
 

--- a/Parity/include/QwHelicity.h
+++ b/Parity/include/QwHelicity.h
@@ -152,7 +152,7 @@ class QwHelicity: public VQwSubsystemParity, public MQwSubsystemCloneable<QwHeli
 
 #ifdef HAS_RNTUPLE_SUPPORT
   using VQwSubsystem::ConstructNTupleAndVector;
-  void  ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString &prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
+  void  ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString &prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
   void  FillNTupleVector(std::vector<Double_t>& values) const override;
 #endif // HAS_RNTUPLE_SUPPORT
 

--- a/Parity/include/QwHelicityPattern.h
+++ b/Parity/include/QwHelicityPattern.h
@@ -188,7 +188,7 @@ class QwHelicityPattern {
 
 #ifdef HAS_RNTUPLE_SUPPORT
   // RNTuple methods
-  void  ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs);
+  void  ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs);
   void  FillNTupleVector(std::vector<Double_t>& values) const;
 #endif // HAS_RNTUPLE_SUPPORT
 

--- a/Parity/include/QwIntegrationPMT.h
+++ b/Parity/include/QwIntegrationPMT.h
@@ -180,7 +180,7 @@ void RandomizeMollerEvent(int helicity, const QwBeamCharge& charge, const QwBeam
 
 #ifdef HAS_RNTUPLE_SUPPORT
   // RNTuple methods
-  void  ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs);
+  void  ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs);
   void  FillNTupleVector(std::vector<Double_t>& values) const;
 #endif // HAS_RNTUPLE_SUPPORT
 

--- a/Parity/include/QwLinearDiodeArray.h
+++ b/Parity/include/QwLinearDiodeArray.h
@@ -138,7 +138,7 @@ class QwLinearDiodeArray : public VQwBPM {
   void    ConstructBranch(TTree *tree, TString &prefix, QwParameterFile& modulelist) override;
   void    FillTreeVector(QwRootTreeBranchVector &values) const override;
 #ifdef HAS_RNTUPLE_SUPPORT
-  void    ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
+  void    ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
   void    FillNTupleVector(std::vector<Double_t>& values) const override;
 #endif
 

--- a/Parity/include/QwMollerDetector.h
+++ b/Parity/include/QwMollerDetector.h
@@ -139,7 +139,7 @@ class QwMollerDetector:
 
     // RNTuple methods
 #ifdef HAS_RNTUPLE_SUPPORT
-    void ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
+    void ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
     void FillNTupleVector(std::vector<Double_t>& values) const override;
 #endif // HAS_RNTUPLE_SUPPORT
 

--- a/Parity/include/QwQPD.h
+++ b/Parity/include/QwQPD.h
@@ -138,7 +138,7 @@ class QwQPD : public VQwBPM {
   void    ConstructBranch(TTree *tree, TString &prefix, QwParameterFile& modulelist) override;
   void    FillTreeVector(QwRootTreeBranchVector &values) const override;
 #ifdef HAS_RNTUPLE_SUPPORT
-  void    ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
+  void    ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
   void    FillNTupleVector(std::vector<Double_t>& values) const override;
 #endif
 

--- a/Parity/include/QwScaler.h
+++ b/Parity/include/QwScaler.h
@@ -81,7 +81,7 @@ class QwScaler: public VQwSubsystemParity, public MQwSubsystemCloneable<QwScaler
 
     // RNTuple methods
 #ifdef HAS_RNTUPLE_SUPPORT
-    void ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
+    void ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
     void FillNTupleVector(std::vector<Double_t>& values) const override;
 #endif // HAS_RNTUPLE_SUPPORT
 

--- a/Parity/include/VQwBCM.h
+++ b/Parity/include/VQwBCM.h
@@ -109,7 +109,7 @@ public:
   virtual void FillTreeVector(QwRootTreeBranchVector &values) const = 0;
 
 #ifdef HAS_RNTUPLE_SUPPORT
-  virtual void ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) = 0;
+  virtual void ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) = 0;
   virtual void FillNTupleVector(std::vector<Double_t>& values) const = 0;
 #endif // HAS_RNTUPLE_SUPPORT
 

--- a/Parity/include/VQwBPM.h
+++ b/Parity/include/VQwBPM.h
@@ -192,7 +192,7 @@ public:
   virtual void FillTreeVector(QwRootTreeBranchVector &values) const = 0;
 
 #ifdef HAS_RNTUPLE_SUPPORT
-  virtual void ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) = 0;
+  virtual void ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) = 0;
   virtual void FillNTupleVector(std::vector<Double_t>& values) const = 0;
 #endif // HAS_RNTUPLE_SUPPORT
 

--- a/Parity/include/VQwClock.h
+++ b/Parity/include/VQwClock.h
@@ -89,7 +89,7 @@ public:
   virtual void ConstructBranch(TTree *tree, TString &prefix, QwParameterFile& modulelist) = 0;
   virtual void FillTreeVector(QwRootTreeBranchVector &values) const = 0;
 #ifdef HAS_RNTUPLE_SUPPORT
-  virtual void ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) = 0;
+  virtual void ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) = 0;
   virtual void FillNTupleVector(std::vector<Double_t>& values) const = 0;
 #endif // HAS_RNTUPLE_SUPPORT
 

--- a/Parity/include/VQwDataHandler.h
+++ b/Parity/include/VQwDataHandler.h
@@ -128,7 +128,7 @@ class VQwDataHandler:  virtual public VQwDataHandlerCloneable, public MQwPublish
 
     void ConstructBranchAndVector(TTree *tree, TString& prefix, QwRootTreeBranchVector &values);
 #ifdef HAS_RNTUPLE_SUPPORT
-    void ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs);
+    void ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs);
     void FillNTupleVector(std::vector<Double_t>& values) const;
 #endif // HAS_RNTUPLE_SUPPORT
 

--- a/Parity/include/VQwDetectorArray.h
+++ b/Parity/include/VQwDetectorArray.h
@@ -177,7 +177,7 @@ class VQwDetectorArray: virtual public VQwSubsystemParity {
 
     void  FillTreeVector(QwRootTreeBranchVector &values) const override;
 #ifdef HAS_RNTUPLE_SUPPORT
-    void  ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
+    void  ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
     void  FillNTupleVector(std::vector<Double_t>& values) const override;
 #endif // HAS_RNTUPLE_SUPPORT
 

--- a/Parity/src/QwBCM.cc
+++ b/Parity/src/QwBCM.cc
@@ -650,7 +650,7 @@ void QwBCM<T>::FillTreeVector(QwRootTreeBranchVector &values) const
 #ifdef HAS_RNTUPLE_SUPPORT
 /** \brief Construct RNTuple fields and append values vector entries. */
 template<typename T>
-void QwBCM<T>::ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
+void QwBCM<T>::ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
 {
   if (this->GetElementName()==""){
     //  This channel is not used, so skip

--- a/Parity/src/QwBPMCavity.cc
+++ b/Parity/src/QwBPMCavity.cc
@@ -925,7 +925,7 @@ void  QwBPMCavity::FillTreeVector(QwRootTreeBranchVector &values) const
  * Define RNTuple fields and attach backing vectors for output variables.
  * The prefix "asym_" is converted to "diff_" for positions.
  */
-void  QwBPMCavity::ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
+void  QwBPMCavity::ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
 {
   if (GetElementName()==""){
     //  This channel is not used, so skip constructing.

--- a/Parity/src/QwBPMStripline.cc
+++ b/Parity/src/QwBPMStripline.cc
@@ -1003,7 +1003,7 @@ void  QwBPMStripline<T>::FillTreeVector(QwRootTreeBranchVector &values) const
 
 #ifdef HAS_RNTUPLE_SUPPORT
 template<typename T>
-void QwBPMStripline<T>::ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
+void QwBPMStripline<T>::ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
 {
   if (GetElementName()==""){
     //  This channel is not used, so skip constructing RNTuple.

--- a/Parity/src/QwBeamLine.cc
+++ b/Parity/src/QwBeamLine.cc
@@ -2707,7 +2707,7 @@ void QwBeamLine::FillTreeVector(QwRootTreeBranchVector &values) const
 
 #ifdef HAS_RNTUPLE_SUPPORT
 //*****************************************************************//
-void QwBeamLine::ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
+void QwBeamLine::ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
 {
   for(size_t i = 0; i < fClock.size(); i++)
     fClock[i].get()->ConstructNTupleAndVector(model, prefix, values, fieldPtrs);

--- a/Parity/src/QwBeamMod.cc
+++ b/Parity/src/QwBeamMod.cc
@@ -832,7 +832,7 @@ void QwBeamMod::FillTreeVector(QwRootTreeBranchVector &values) const
 }
 
 #ifdef HAS_RNTUPLE_SUPPORT
-void QwBeamMod::ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
+void QwBeamMod::ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
 {
   TString basename;
 

--- a/Parity/src/QwClock.cc
+++ b/Parity/src/QwClock.cc
@@ -423,7 +423,7 @@ void QwClock<T>::FillTreeVector(QwRootTreeBranchVector &values) const
 
 #ifdef HAS_RNTUPLE_SUPPORT
 template<typename T>
-void QwClock<T>::ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
+void QwClock<T>::ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
 {
   if (this->GetElementName()==""){
     //  This channel is not used, so skip RNTuple construction

--- a/Parity/src/QwCombinedBPM.cc
+++ b/Parity/src/QwCombinedBPM.cc
@@ -1199,7 +1199,7 @@ void  QwCombinedBPM<T>::FillTreeVector(QwRootTreeBranchVector &values) const
 
 #ifdef HAS_RNTUPLE_SUPPORT
 template<typename T>
-void QwCombinedBPM<T>::ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
+void QwCombinedBPM<T>::ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
 {
   if (this->GetElementName()==""){
     //  This channel is not used, so skip constructing RNTuple.

--- a/Parity/src/QwCombinedPMT.cc
+++ b/Parity/src/QwCombinedPMT.cc
@@ -504,7 +504,7 @@ void  QwCombinedPMT::FillTreeVector(QwRootTreeBranchVector &values) const
 }
 
 #ifdef HAS_RNTUPLE_SUPPORT
-void QwCombinedPMT::ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
+void QwCombinedPMT::ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
 {
   if (GetElementName()=="")
     {

--- a/Parity/src/QwEnergyCalculator.cc
+++ b/Parity/src/QwEnergyCalculator.cc
@@ -626,7 +626,7 @@ void  QwEnergyCalculator::FillTreeVector(QwRootTreeBranchVector &values) const
 }
 
 #ifdef HAS_RNTUPLE_SUPPORT
-void  QwEnergyCalculator::ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
+void  QwEnergyCalculator::ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
 {
   if (GetElementName()==""){
     //  This channel is not used, so skip construction.

--- a/Parity/src/QwHaloMonitor.cc
+++ b/Parity/src/QwHaloMonitor.cc
@@ -286,7 +286,7 @@ void  QwHaloMonitor::FillTreeVector(QwRootTreeBranchVector &values) const
 }
 
 #ifdef HAS_RNTUPLE_SUPPORT
-void  QwHaloMonitor::ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
+void  QwHaloMonitor::ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
 {
   if (GetElementName()==""){
     //  This channel is not used, so skip construction.

--- a/Parity/src/QwHelicity.cc
+++ b/Parity/src/QwHelicity.cc
@@ -1535,7 +1535,7 @@ void  QwHelicity::FillTreeVector(QwRootTreeBranchVector &values) const
 }
 
 #ifdef HAS_RNTUPLE_SUPPORT
-void QwHelicity::ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString &prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
+void QwHelicity::ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString &prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
 {
   SetHistoTreeSave(prefix);
 

--- a/Parity/src/QwHelicityPattern.cc
+++ b/Parity/src/QwHelicityPattern.cc
@@ -937,7 +937,7 @@ void QwHelicityPattern::FillTreeVector(QwRootTreeBranchVector &values) const
 }
 
 #ifdef HAS_RNTUPLE_SUPPORT
-void QwHelicityPattern::ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
+void QwHelicityPattern::ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
 {
   TString basename = prefix(0, (prefix.First("|") >= 0)? prefix.First("|"): prefix.Length())+"BurstCounter";
   // Note: fBurstCounter is a Short_t, but we're only creating Double_t fields for now

--- a/Parity/src/QwIntegrationPMT.cc
+++ b/Parity/src/QwIntegrationPMT.cc
@@ -616,7 +616,7 @@ void  QwIntegrationPMT::FillTreeVector(QwRootTreeBranchVector &values) const
 }
 
 #ifdef HAS_RNTUPLE_SUPPORT
-void QwIntegrationPMT::ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
+void QwIntegrationPMT::ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
 {
   if (GetElementName()==""){
     //  This channel is not used, so skip RNTuple construction.

--- a/Parity/src/QwLinearDiodeArray.cc
+++ b/Parity/src/QwLinearDiodeArray.cc
@@ -777,7 +777,7 @@ void  QwLinearDiodeArray::FillTreeVector(QwRootTreeBranchVector &values) const
 }
 
 #ifdef HAS_RNTUPLE_SUPPORT
-void  QwLinearDiodeArray::ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
+void  QwLinearDiodeArray::ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
 {
   if (GetElementName()==""){
     //  This channel is not used, so skip constructing.

--- a/Parity/src/QwMollerDetector.cc
+++ b/Parity/src/QwMollerDetector.cc
@@ -234,7 +234,7 @@ void QwMollerDetector::FillTreeVector(QwRootTreeBranchVector &values) const {
 }
 
 #ifdef HAS_RNTUPLE_SUPPORT
-void QwMollerDetector::ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
+void QwMollerDetector::ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
 {
   for(size_t i = 0; i < fSTR7200_Channel.size(); i++){
     for(size_t j = 0; j < fSTR7200_Channel[i].size(); j++){

--- a/Parity/src/QwQPD.cc
+++ b/Parity/src/QwQPD.cc
@@ -893,7 +893,7 @@ void  QwQPD::FillTreeVector(QwRootTreeBranchVector &values) const
 }
 
 #ifdef HAS_RNTUPLE_SUPPORT
-void  QwQPD::ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
+void  QwQPD::ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
 {
   if (GetElementName()==""){
     //  This channel is not used, so skip constructing.

--- a/Parity/src/QwScaler.cc
+++ b/Parity/src/QwScaler.cc
@@ -386,7 +386,7 @@ void QwScaler::FillTreeVector(QwRootTreeBranchVector &values) const
 }
 
 #ifdef HAS_RNTUPLE_SUPPORT
-void QwScaler::ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
+void QwScaler::ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
 {
   for (size_t i = 0; i < fScaler.size(); i++) {
     fScaler.at(i)->ConstructNTupleAndVector(model, prefix, values, fieldPtrs);

--- a/Parity/src/VQwDataHandler.cc
+++ b/Parity/src/VQwDataHandler.cc
@@ -374,7 +374,7 @@ void VQwDataHandler::FillTreeVector(QwRootTreeBranchVector &values) const
 }
 
 #ifdef HAS_RNTUPLE_SUPPORT
-void VQwDataHandler::ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
+void VQwDataHandler::ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
 {
   for (size_t i = 0; i < fOutputVar.size(); ++i) {
     fOutputVar.at(i)->ConstructNTupleAndVector(model, prefix, values, fieldPtrs);

--- a/Parity/src/VQwDetectorArray.cc
+++ b/Parity/src/VQwDetectorArray.cc
@@ -1363,7 +1363,7 @@ void VQwDetectorArray::FillTreeVector(QwRootTreeBranchVector &values) const {
 }
 
 #ifdef HAS_RNTUPLE_SUPPORT
-void VQwDetectorArray::ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) {
+void VQwDetectorArray::ConstructNTupleAndVector(ROOT::RNTupleModel *model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) {
 
     for (size_t i=0;i<fIntegrationPMT.size();i++)
      fIntegrationPMT[i].ConstructNTupleAndVector(model, prefix, values, fieldPtrs);


### PR DESCRIPTION
# Issue
`ROOT::RNTupleModel::Create()` returns a unique_ptr. We have several instances of passing the unique_ptr by reference to methods which do not  assume ownership. This obscures the ownership of the RNTupleModel.

# PR
This PR changes the signatures of methods from
`void method(std::unique_ptr<ROOT::RNTupleModel> &ptr>` to `void method(ROOT::RNTupleModel *ptr>`. This change does not affect the use of the RNTupleModel ptr inside the method.

### Comment
The changes were made using sed to edit the nearly-identical signatures in-place
`grep Analysis/ Parity/ -e "& model" -nriI | awk -F ':' '{print $1}' | xargs sed -i 's/std::unique_ptr<ROOT::RNTupleModel>& model/ROOT::RNTupleModel *model/g'`