### PR TITLE
Fix missing trees in multi-file output mode

### DIFF
--- a/Parity/main/QwParity.cc
+++ b/Parity/main/QwParity.cc
@@ -398,10 +398,10 @@ Int_t main(Int_t argc, Char_t* argv[])
             patternsum.AccumulatePairRunningSum(helicitypattern);
 
 	    // Fill pair tree branches
-	    treerootfile->FillTreeBranches(helicitypattern.GetPairYield());
-	    treerootfile->FillTreeBranches(helicitypattern.GetPairAsymmetry());
-	    treerootfile->FillTreeBranches(helicitypattern.GetPairDifference());
-	    treerootfile->FillTree("pr");
+	    burstrootfile->FillTreeBranches(helicitypattern.GetPairYield());
+	    burstrootfile->FillTreeBranches(helicitypattern.GetPairAsymmetry());
+	    burstrootfile->FillTreeBranches(helicitypattern.GetPairDifference());
+	    burstrootfile->FillTree("pr");
 
 	    // Fill pair RNTuples if enabled
 #ifdef HAS_RNTUPLE_SUPPORT
@@ -632,7 +632,7 @@ Int_t main(Int_t argc, Char_t* argv[])
 #endif
 
     //  Construct objects
-    treerootfile->ConstructObjects("objects", helicitypattern);
+    burstrootfile->ConstructObjects("objects", helicitypattern);
 
     /*  Write to the root file, being sure to delete the old cycles  *
      *  which were written by Autosave.                              *


### PR DESCRIPTION
Pair trees were not being
written to the correct output files in multi-file mode, resulting in missing data (823.52 MB of TTrees for 20000 sample events). Changed pr tree filling from treerootfile to burstrootfile so pair data is written to the bursts.root file.

The multi-file mode now produces identical data to single-file mode.