### PR TITLE
Split Root IO files into seperate header & impl. files

### DIFF
--- a/Analysis/include/QwRootFile.h
+++ b/Analysis/include/QwRootFile.h
@@ -25,776 +25,13 @@ using std::type_info;
 #include "TSystem.h"
 #include "TString.h"
 
-// RNTuple headers (modern ROOT namespace) - only if supported
-#ifdef HAS_RNTUPLE_SUPPORT
-#include "ROOT/RNTuple.hxx"
-#include "ROOT/RNTupleModel.hxx"
-#include "ROOT/RField.hxx"
-#include "ROOT/RNTupleWriter.hxx"
-#endif
-
 // Qweak headers
 #include "QwOptions.h"
 #include "TMapFile.h"
+#include "QwRootTreeBranchVector.h"
+#include "QwRootTree.h"
+#include "QwRootNTuple.h"
 
-// If one defines more than this number of words in the full ntuple,
-// the results are going to get very very crazy.
-#define BRANCH_VECTOR_MAX_SIZE 25000
-
-/**
- *  \class QwRootTreeBranchVector
- *  \ingroup QwAnalysis
- *  \brief A helper class to manage a vector of branch entries for ROOT trees
- *
- * This class provides functionality to manage a collection of branch entries,
- * including their names, types, offsets, and sizes. It supports adding new entries,
- * accessing entries by index or name, and generating leaf lists for ROOT trees.
- */
-class QwRootTreeBranchVector {
-public:
-  struct Entry {
-    std::string name;
-    std::size_t offset;
-    std::size_t size;
-    char type;
-  };
-
-  using size_type = std::size_t;
-
-  QwRootTreeBranchVector() = default;
-
-  void reserve(size_type count) {
-    m_entries.reserve(count);
-    m_buffer.reserve(sizeof(double)*count);
-  }
-
-  void shrink_to_fit() {
-    m_entries.shrink_to_fit();
-    m_buffer.shrink_to_fit();
-  }
-
-  void clear() {
-    m_entries.clear();
-    m_buffer.clear();
-  }
-
-  size_type size() const noexcept { return m_entries.size(); }
-  bool empty() const noexcept { return m_entries.empty(); }
-
-  template <typename T = uint8_t>
-  const T& operator[](size_type index) const {
-    return value<T>(index);
-  }
-
-  template <typename T = uint8_t>
-  T& operator[](size_type index) {
-    return value<T>(index);
-  }
-
-  template <typename T>
-  T& value(size_type index) {
-    auto& entry = m_entries.at(index);
-    return *reinterpret_cast<T*>(m_buffer.data() + entry.offset);
-  }
-
-  template <typename T>
-  const T& value(size_type index) const {
-    const auto& entry = m_entries.at(index);
-    return *reinterpret_cast<const T*>(m_buffer.data() + entry.offset);
-  }
-
-  // Explicit SetValue overloads with type checking to prevent automatic conversions
-  // (presence of multiple overloads ensures a compilation error if the types do not match)
-  void SetValue(size_type index, Double_t val) {
-    const auto& entry = m_entries.at(index);
-    if (entry.type != 'D') {
-      throw std::invalid_argument("Type mismatch: entry type '" + std::string(1, entry.type) + "' cannot store double value '" + entry.name + "'");
-    }
-    this->value<Double_t>(index) = val;
-  }
-
-  void SetValue(size_type index, Float_t val) {
-    const auto& entry = m_entries.at(index);
-    if (entry.type != 'F') {
-      throw std::invalid_argument("Type mismatch: entry type '" + std::string(1, entry.type) + "' cannot store float value '" + entry.name + "'");
-    }
-    this->value<Float_t>(index) = val;
-  }
-
-  void SetValue(size_type index, Int_t val) {
-    const auto& entry = m_entries.at(index);
-    if (entry.type != 'I') {
-      throw std::invalid_argument("Type mismatch: entry type '" + std::string(1, entry.type) + "' cannot store int value '" + entry.name + "'");
-    }
-    this->value<Int_t>(index) = val;
-  }
-
-  void SetValue(size_type index, Long64_t val) {
-    const auto& entry = m_entries.at(index);
-    if (entry.type != 'L') {
-      throw std::invalid_argument("Type mismatch: entry type '" + std::string(1, entry.type) + "' cannot store long long value '" + entry.name + "'");
-    }
-    this->value<Long64_t>(index) = val;
-  }
-
-  void SetValue(size_type index, Short_t val) {
-    const auto& entry = m_entries.at(index);
-    if (entry.type != 'S') {
-      throw std::invalid_argument("Type mismatch: entry type '" + std::string(1, entry.type) + "' cannot store short value '" + entry.name + "'");
-    }
-    this->value<Short_t>(index) = val;
-  }
-
-  // Unsigned type overloads
-  void SetValue(size_type index, UShort_t val) {
-    const auto& entry = m_entries.at(index);
-    if (entry.type != 's') {
-      throw std::invalid_argument("Type mismatch: entry type '" + std::string(1, entry.type) + "' cannot store short value '" + entry.name + "'");
-    }
-    this->value<UShort_t>(index) = val;
-  }
-
-  void SetValue(size_type index, UInt_t val) {
-    const auto& entry = m_entries.at(index);
-    if (entry.type != 'i') {
-      throw std::invalid_argument("Type mismatch: entry type '" + std::string(1, entry.type) + "' cannot store unsigned int value '" + entry.name + "'");
-    }
-    this->value<UInt_t>(index) = val;
-  }
-
-  void SetValue(size_type index, ULong64_t val) {
-    const auto& entry = m_entries.at(index);
-    if (entry.type != 'l') {
-      throw std::invalid_argument("Type mismatch: entry type '" + std::string(1, entry.type) + "' cannot store long long value '" + entry.name + "'");
-    }
-    this->value<ULong64_t>(index) = val;
-  }
-
-  void* data() noexcept { return m_buffer.data(); }
-  const void* data() const noexcept { return m_buffer.data(); }
-  size_type data_size() const noexcept { return m_buffer.size(); }
-
-  template <typename T>
-  T& back() {
-    if (m_entries.empty()) {
-      throw std::out_of_range("QwRootTreeBranchVector::back() called on empty container");
-    }
-    const auto& last_entry = m_entries.back();
-    return *reinterpret_cast<T*>(m_buffer.data() + last_entry.offset);
-  }
-
-  template <typename T>
-  const T& back() const {
-    if (m_entries.empty()) {
-      throw std::out_of_range("QwRootTreeBranchVector::back() called on empty container");
-    }
-    const auto& last_entry = m_entries.back();
-    return *reinterpret_cast<const T*>(m_buffer.data() + last_entry.offset);
-  }
-
-  void push_back(const std::string& name, const char type = 'D') {
-    const std::size_t entry_size = GetTypeSize(type);
-    const std::size_t offset = AlignOffset(m_buffer.size());
-
-    if (offset > m_buffer.capacity()) {
-      throw std::out_of_range("QwRootTreeBranchVector::push_back() requires buffer resize beyond reserved capacity");
-    }
-    if (offset > m_buffer.size()) {
-      m_buffer.resize(offset, 0u);
-    }
-
-    Entry entry{name, offset, entry_size, type};
-    m_entries.push_back(entry);
-
-    const std::size_t required = offset + entry_size;
-    if (required > m_buffer.capacity()) {
-      throw std::out_of_range("QwRootTreeBranchVector::push_back() requires buffer resize beyond reserved capacity");
-    }
-    if (required > m_buffer.size()) {
-      m_buffer.resize(required, 0u);
-    }
-  }
-
-  // Overload for TString (ROOT's string class)
-  void push_back(const TString& name, const char type = 'D') {
-    push_back(std::string(name.Data()), type);
-  }
-
-  // Overload for const char* (string literals)
-  void push_back(const char* name, const char type = 'D') {
-    push_back(std::string(name), type);
-  }
-
-  std::string LeafList(size_type start_index = 0) const {
-    static const std::string separator = ":";
-    std::ostringstream stream;
-    bool first = true;
-    for (size_type index = start_index; index < m_entries.size(); ++index) {
-      const auto& entry = m_entries[index];
-      if (!first) {
-        stream << separator;
-      }
-      stream << entry.name << "/" << entry.type;
-      first = false;
-    }
-    return stream.str();
-  }
-
-  std::string Dump(size_type start_index = 0, size_type end_index = 0) const {
-    std::ostringstream stream;
-    stream << "QwRootTreeBranchVector: " << m_entries.size() << " entries, "
-           << m_buffer.size() << " bytes\n";
-    size_t end_offset = (end_index == 0 || end_index > m_entries.size()) ?
-      m_buffer.size()
-      : m_entries[end_index - 1].offset + m_entries[end_index - 1].size;
-    stream << "QwRootTreeBranchVector: buffer at 0x" << std::hex << (void*) &m_buffer[0] << '\n';
-    stream << "QwRootTreeBranchVector: entries at 0x" << std::hex << (void*) &m_entries[0] << '\n';
-    for (size_t offset = m_entries[start_index].offset; offset < end_offset; offset += 4) {
-      stream << std::dec
-             << "  [" << offset << "] "
-             << std::hex
-             << " offset=0x" << offset
-             << " (0x" << std::setw(4) << std::setfill('0')
-                       << offset - m_entries[start_index].offset << ")"
-             << " buff=";
-      // Little-endian
-      for (std::size_t byte = 0; byte < 4; ++byte) {
-        stream << std::hex << std::setw(2) << std::setfill('0')
-               << static_cast<unsigned int>(m_buffer[offset + byte])
-               << " ";
-      }
-      stream << '\n';
-    }
-    end_index = (end_index == 0 || end_index > m_entries.size()) ?
-      m_entries.size()
-      : end_index;
-    for (size_type index = start_index; index < end_index; ++index) {
-      const auto& entry = m_entries[index];
-      stream << std::dec
-             << "  [" << index << "] "
-             << std::hex
-             << " offset=0x" << entry.offset
-             << " (0x" << std::setw(4) << std::setfill('0')
-                       << entry.offset - m_entries[start_index].offset << ")"
-             << " size=0x" << entry.size
-             << " buff=0x";
-      // Little-endian
-      for (std::size_t byte = GetTypeSize(entry.type); byte > 0; --byte) {
-        stream << std::hex << std::setw(2) << std::setfill('0')
-               << static_cast<unsigned int>((m_buffer.data() + entry.offset)[byte - 1]);
-      }
-      stream << std::dec
-             << " name=" << entry.name << "/" << entry.type
-             << " value=" << FormatValue(entry, index);
-      stream << '\n';
-    }
-    return stream.str();
-  }
-
-private:
-  static std::size_t GetTypeSize(char type) {
-    switch (type) {
-      case 'D':
-        return sizeof(double);
-      case 'F':
-        return sizeof(float);
-      case 'L':
-        return sizeof(long long);
-      case 'l':
-        return sizeof(unsigned long long);
-      case 'I':
-        return sizeof(int);
-      case 'i':
-        return sizeof(unsigned int);
-      case 'S':
-        return sizeof(short);
-      case 's':
-        return sizeof(unsigned short);
-      default:
-        throw std::invalid_argument("Unsupported branch type code: " + std::string(1, type));
-    }
-  }
-
-  static std::size_t AlignOffset(std::size_t offset) {
-    const std::size_t alignment = 4u;
-    return (offset + (alignment - 1u)) & ~(alignment - 1u);
-  }
-
-  std::vector<Entry> m_entries;
-  std::vector<std::uint8_t> m_buffer;
-
-  std::string FormatValue(const Entry& entry, size_type index) const {
-    switch (entry.type) {
-      case 'D':
-        return FormatNumeric(value<double>(index));
-      case 'F':
-        return FormatNumeric(value<float>(index));
-      case 'L':
-        return FormatNumeric(value<long long>(index));
-      case 'l':
-        return FormatNumeric(value<unsigned long long>(index));
-      case 'I':
-        return FormatNumeric(value<int>(index));
-      case 'i':
-        return FormatNumeric(value<unsigned int>(index));
-      case 'S':
-        return FormatNumeric(value<short>(index));
-      case 's':
-        return FormatNumeric(value<unsigned short>(index));
-      default:
-        return "<unknown>";
-    }
-  }
-
-  template <typename T>
-  static std::string FormatNumeric(T input) {
-    std::ostringstream stream;
-    stream << input;
-    return stream.str();
-  }
-};
-
-/**
- *  \class QwRootTree
- *  \ingroup QwAnalysis
- *  \brief Wrapper class for ROOT tree management with vector-based data storage
- *
- * Provides functionality to write to ROOT trees using vectors of doubles,
- * with support for branch construction, event filtering, and tree sharing.
- * Handles both new tree creation and attachment to existing trees, enabling
- * multiple subsystems to contribute data to a single ROOT tree.
- */
-class QwRootTree {
-
-  public:
-
-    /// Constructor with name, and description
-    QwRootTree(const std::string& name, const std::string& desc, const std::string& prefix = "")
-    : fName(name),fDesc(desc),fPrefix(prefix),fType("type undefined"),
-      fCurrentEvent(0),fNumEventsCycle(0),fNumEventsToSave(0),fNumEventsToSkip(0) {
-      // Construct tree
-      ConstructNewTree();
-    }
-
-    /// Constructor with existing tree
-    QwRootTree(const QwRootTree* tree, const std::string& prefix = "")
-    : fName(tree->GetName()),fDesc(tree->GetDesc()),fPrefix(prefix),fType("type undefined"),
-      fCurrentEvent(0),fNumEventsCycle(0),fNumEventsToSave(0),fNumEventsToSkip(0) {
-      QwMessage << "Existing tree: " << tree->GetName() << ", " << tree->GetDesc() << QwLog::endl;
-      fTree = tree->fTree;
-    }
-
-    /// Constructor with name, description, and object
-    template < class T >
-    QwRootTree(const std::string& name, const std::string& desc, T& object, const std::string& prefix = "")
-    : fName(name),fDesc(desc),fPrefix(prefix),fType("type undefined"),
-      fCurrentEvent(0),fNumEventsCycle(0),fNumEventsToSave(0),fNumEventsToSkip(0) {
-      // Construct tree
-      ConstructNewTree();
-
-      // Construct branch
-      ConstructUnitsBranch();
-
-      // Construct branches and vector
-      ConstructBranchAndVector(object);
-    }
-
-    /// Constructor with existing tree, and object
-    template < class T >
-    QwRootTree(const QwRootTree* tree, T& object, const std::string& prefix = "")
-    : fName(tree->GetName()),fDesc(tree->GetDesc()),fPrefix(prefix),fType("type undefined"),
-      fCurrentEvent(0),fNumEventsCycle(0),fNumEventsToSave(0),fNumEventsToSkip(0) {
-      QwMessage << "Existing tree: " << tree->GetName() << ", " << tree->GetDesc() << QwLog::endl;
-      fTree = tree->fTree;
-
-      // Construct branches and vector
-      ConstructBranchAndVector(object);
-    }
-
-    /// Destructor
-    virtual ~QwRootTree() { }
-
-
-  private:
-
-    static const TString kUnitsName;
-    static Double_t kUnitsValue[];
-
-    /// Construct the tree
-    void ConstructNewTree() {
-      QwMessage << "New tree: " << fName << ", " << fDesc << QwLog::endl;
-
-      fTree = new TTree(fName.c_str(), fDesc.c_str());
-
-      // Ensure tree is in the current directory
-      if (gDirectory) {
-        fTree->SetDirectory(gDirectory);
-
-      } else {
-
-      }
-    }
-
-    void ConstructUnitsBranch() {
-      std::string name = "units";
-      fTree->Branch(name.c_str(), &kUnitsValue, kUnitsName);
-    }
-
-    /// Construct index from this tree to another tree
-    void ConstructIndexTo(QwRootTree* to) {
-      std::string name = "previous_entry_in_" + to->fName;
-      fTree->Branch(name.c_str(), &(to->fCurrentEvent));
-    }
-
-    /// Construct the branches and vector for generic objects
-    template < class T >
-    void ConstructBranchAndVector(T& object) {
-      // Reserve space for the branch vector
-      fVector.reserve(BRANCH_VECTOR_MAX_SIZE);
-      // Associate branches with vector
-      TString prefix = Form("%s",fPrefix.c_str());
-      object.ConstructBranchAndVector(fTree, prefix, fVector);
-
-      // Store the type of object
-      fType = typeid(object).name();
-
-      // Check memory reservation
-      if (fVector.size() > BRANCH_VECTOR_MAX_SIZE) {
-        QwError << "The branch vector is too large: " << fVector.size() << " leaves!  "
-                << "The maximum size is " << BRANCH_VECTOR_MAX_SIZE << "."
-                << QwLog::endl;
-        exit(-1);
-      }
-    }
-
-
-  public:
-
-    /// Fill the branches for generic objects
-    template < class T >
-    void FillTreeBranches(const T& object) {
-      if (typeid(object).name() == fType) {
-        // Fill the branch vector
-        object.FillTreeVector(fVector);
-      } else {
-        QwError << "Attempting to fill tree vector for type " << fType << " with "
-                << "object of type " << typeid(object).name() << QwLog::endl;
-        exit(-1);
-      }
-    }
-
-    Long64_t AutoSave(Option_t *option){
-      return fTree->AutoSave(option);
-    }
-
-    /// Fill the tree
-    Int_t Fill() {
-      fCurrentEvent++;
-
-      // Tree prescaling
-      if (fNumEventsCycle > 0) {
-        fCurrentEvent %= fNumEventsCycle;
-        if (fCurrentEvent > fNumEventsToSave)
-          return 0;
-      }
-
-      // Fill the tree
-      Int_t retval = fTree->Fill();
-      // Check for errors
-      if (retval < 0) {
-        QwError << "Writing tree failed!  Check disk space or quota." << QwLog::endl;
-        exit(retval);
-      }
-      return retval;
-    }
-
-
-    /// Print the tree name and description
-    void Print() const {
-      QwMessage << GetName() << ", " << GetType();
-      if (fPrefix != "")
-        QwMessage << " (prefix " << GetPrefix() << ")";
-      QwMessage << QwLog::endl;
-    }
-
-    /// Get the tree pointer for low level operations
-    TTree* GetTree() const { return fTree; };
-
-
-  friend class QwRootFile;
-
-  private:
-
-    /// Tree pointer
-    TTree* fTree;
-    /// Vector of leaves
-    QwRootTreeBranchVector fVector;
-
-
-    /// Name, description
-    const std::string fName;
-    const std::string fDesc;
-    const std::string fPrefix;
-
-    /// Get the name of the tree
-    const std::string& GetName() const { return fName; };
-    /// Get the description of the tree
-    const std::string& GetDesc() const { return fDesc; };
-    /// Get the description of the tree
-    const std::string& GetPrefix() const { return fPrefix; };
-
-
-    /// Object type
-    std::string fType;
-
-    /// Get the object type
-    std::string GetType() const { return fType; };
-
-
-    /// Tree prescaling parameters
-    UInt_t fCurrentEvent;
-    UInt_t fNumEventsCycle;
-    UInt_t fNumEventsToSave;
-    UInt_t fNumEventsToSkip;
-
-    /// Set tree prescaling parameters
-    void SetPrescaling(UInt_t num_to_save, UInt_t num_to_skip) {
-      fNumEventsToSave = num_to_save;
-      fNumEventsToSkip = num_to_skip;
-      fNumEventsCycle = fNumEventsToSave + fNumEventsToSkip;
-    }
-
-
-    /// Maximum tree size, autoflush and autosave
-    Long64_t fMaxTreeSize;
-    Long64_t fAutoFlush;
-    Long64_t fAutoSave;
-    Int_t fBasketSize;
-
-    /// Set maximum tree size
-    void SetMaxTreeSize(Long64_t maxsize = 1900000000) {
-      fMaxTreeSize = maxsize;
-      if (fTree) fTree->SetMaxTreeSize(maxsize);
-    }
-
-    /// Set autoflush size
-    void SetAutoFlush(Long64_t autoflush = 30000000) {
-      fAutoFlush = autoflush;
-      #if ROOT_VERSION_CODE >= ROOT_VERSION(5,26,00)
-        if (fTree) fTree->SetAutoFlush(autoflush);
-      #endif
-    }
-
-    /// Set autosave size
-    void SetAutoSave(Long64_t autosave = 300000000) {
-      fAutoSave = autosave;
-      if (fTree) fTree->SetAutoSave(autosave);
-    }
-
-    /// Set basket size
-    void SetBasketSize(Int_t basketsize = 16000) {
-      fBasketSize = basketsize;
-      if (fTree) fTree->SetBasketSize("*",basketsize);
-    }
-
-    //Set circular buffer size for the memory resident tree
-    void SetCircular(Long64_t buff = 100000) {
-      if (fTree) fTree->SetCircular(buff);
-    }
-};
-
-#ifdef HAS_RNTUPLE_SUPPORT
-/**
- *  \class QwRootNTuple
- *  \ingroup QwAnalysis
- *  \brief A wrapper class for a ROOT RNTuple
- *
- * This class provides the functionality to write to ROOT RNTuples using a vector
- * of doubles, similar to QwRootTree but using the newer RNTuple format.
- */
-class QwRootNTuple {
-
-  public:
-
-    /// Constructor with name and description
-    QwRootNTuple(const std::string& name, const std::string& desc, const std::string& prefix = "")
-    : fName(name), fDesc(desc), fPrefix(prefix), fType("type undefined"),
-      fCurrentEvent(0), fNumEventsCycle(0), fNumEventsToSave(0), fNumEventsToSkip(0) {
-      // Create RNTuple model
-      fModel = ROOT::RNTupleModel::Create();
-    }
-
-    /// Constructor with name, description, and object
-    template < class T >
-    QwRootNTuple(const std::string& name, const std::string& desc, T& object, const std::string& prefix = "")
-    : fName(name), fDesc(desc), fPrefix(prefix), fType("type undefined"),
-      fCurrentEvent(0), fNumEventsCycle(0), fNumEventsToSave(0), fNumEventsToSkip(0) {
-      // Create RNTuple model
-      fModel = ROOT::RNTupleModel::Create();
-
-      // Construct fields and vector
-      ConstructFieldsAndVector(object);
-    }
-
-    /// Destructor
-    virtual ~QwRootNTuple() {
-      Close();
-    }
-
-    /// Close and finalize the RNTuple writer
-    void Close() {
-      if (fWriter) {
-        // Explicitly commit any remaining data and close the writer
-        // This ensures all data is written to the file before destruction
-        fWriter.reset();  // This calls the destructor which should finalize the RNTuple
-      }
-    }
-
-  private:
-
-    /// Construct the fields and vector for generic objects
-    template < class T >
-    void ConstructFieldsAndVector(T& object) {
-      // Reserve space for the field vector
-      fVector.reserve(BRANCH_VECTOR_MAX_SIZE);
-
-      // Associate fields with vector - now using shared field pointers
-      TString prefix = Form("%s", fPrefix.c_str());
-      object.ConstructNTupleAndVector(fModel, prefix, fVector, fFieldPtrs);
-
-      // Store the type of object
-      fType = typeid(object).name();
-
-      // Check memory reservation
-      if (fVector.size() > BRANCH_VECTOR_MAX_SIZE) {
-        QwError << "The field vector is too large: " << fVector.size() << " fields!  "
-                << "The maximum size is " << BRANCH_VECTOR_MAX_SIZE << "."
-                << QwLog::endl;
-        exit(-1);
-      }
-
-      // Shrink memory reservation
-      fVector.shrink_to_fit();
-    }
-
-  public:
-
-    /// Initialize the RNTuple writer with a file
-    void InitializeWriter(TFile* file) {
-      if (!fModel) {
-        QwError << "RNTuple model not created for " << fName << QwLog::endl;
-        return;
-      }
-
-      // Before creating the writer, ensure all fields are added to the model
-      if (fVector.empty()) {
-        QwError << "No fields defined in RNTuple model for " << fName << QwLog::endl;
-        return;
-      }
-
-      try {
-        // Create the writer with the model (transfers ownership)
-        // Use Append to add RNTuple to existing TFile
-        fWriter = ROOT::RNTupleWriter::Append(std::move(fModel), fName, *file);
-
-        QwMessage << "Created RNTuple '" << fName << "' in file " << file->GetName() << QwLog::endl;
-
-      } catch (const std::exception& e) {
-        QwError << "Failed to create RNTuple writer for '" << fName << "': " << e.what() << QwLog::endl;
-      }
-    }
-
-    /// Fill the fields for generic objects
-    template < class T >
-    void FillNTupleFields(const T& object) {
-      if (typeid(object).name() == fType) {
-        // Fill the field vector
-        object.FillNTupleVector(fVector);
-
-        // Use the shared field pointers which remain valid
-        if (fWriter) {
-          for (size_t i = 0; i < fVector.size() && i < fFieldPtrs.size(); ++i) {
-            if (fFieldPtrs[i]) {
-              *(fFieldPtrs[i]) = fVector[i];
-            }
-          }
-
-          // CRITICAL: Actually commit the data to the RNTuple
-          fWriter->Fill();
-
-          // Update event counter
-          fCurrentEvent++;
-          // RNTuple prescaling
-          if (fNumEventsCycle > 0) {
-            fCurrentEvent %= fNumEventsCycle;
-          }
-        } else {
-          QwError << "RNTuple writer not initialized for " << fName << QwLog::endl;
-        }
-      } else {
-        QwError << "Attempting to fill RNTuple vector for type " << fType << " with "
-                << "object of type " << typeid(object).name() << QwLog::endl;
-        exit(-1);
-      }
-    }
-
-    /// Fill the RNTuple (called by FillTree wrapper methods)
-    void Fill() {
-      // This method is now called indirectly - the actual filling happens in FillNTupleFields
-      // Just here for compatibility with the tree interface
-    }
-
-    /// Get the name of the RNTuple
-    const std::string& GetName() const { return fName; }
-    /// Get the description of the RNTuple
-    const std::string& GetDesc() const { return fDesc; }
-    /// Get the prefix of the RNTuple
-    const std::string& GetPrefix() const { return fPrefix; }
-    /// Get the object type
-    std::string GetType() const { return fType; }
-
-    /// Set prescaling parameters
-    void SetPrescaling(UInt_t num_to_save, UInt_t num_to_skip) {
-      fNumEventsToSave = num_to_save;
-      fNumEventsToSkip = num_to_skip;
-      fNumEventsCycle = fNumEventsToSave + fNumEventsToSkip;
-    }
-
-    /// Print the RNTuple name and description
-    void Print() const {
-      QwMessage << GetName() << ", " << GetType();
-      if (fPrefix != "")
-        QwMessage << " (prefix " << GetPrefix() << ")";
-      QwMessage << QwLog::endl;
-    }
-
-  private:
-
-    /// RNTuple model and writer
-    std::unique_ptr<ROOT::RNTupleModel> fModel;
-    std::unique_ptr<ROOT::RNTupleWriter> fWriter;
-
-    /// Vector of values and shared field pointers (for RNTuple)
-    std::vector<Double_t> fVector;
-    std::vector<std::shared_ptr<Double_t>> fFieldPtrs;
-
-    /// Name, description, prefix
-    const std::string fName;
-    const std::string fDesc;
-    const std::string fPrefix;
-
-    /// Object type
-    std::string fType;
-
-    /// RNTuple prescaling parameters
-    UInt_t fCurrentEvent;
-    UInt_t fNumEventsCycle;
-    UInt_t fNumEventsToSave;
-    UInt_t fNumEventsToSkip;
-
-  friend class QwRootFile;
-};
-#endif // HAS_RNTUPLE_SUPPORT
 
 /**
  *  \class QwRootFile
@@ -839,19 +76,14 @@ class QwRootFile {
     /// \brief Process the configuration options
     void ProcessOptions(QwOptions &options);
     /// \brief Set default ROOT files dir
-    static void SetDefaultRootFileDir(const std::string& dir) {
-      fDefaultRootFileDir = dir;
-    }
+    static void SetDefaultRootFileDir(const std::string& dir);
     /// \brief Set default ROOT file stem
-    static void SetDefaultRootFileStem(const std::string& stem) {
-      fDefaultRootFileStem = stem;
-    }
-
+    static void SetDefaultRootFileStem(const std::string& stem);
 
     /// Is the ROOT file active?
-    Bool_t IsRootFile() const { return (fRootFile); };
+    Bool_t IsRootFile() const;
     /// Is the map file active?
-    Bool_t IsMapFile()  const { return (fMapFile); };
+    Bool_t IsMapFile()  const;
 
     /// \brief Construct indices from one tree to another tree
     void ConstructIndices(const std::string& from, const std::string& to, bool reverse = true);
@@ -880,7 +112,7 @@ class QwRootFile {
 
 
     template < class T >
-      Int_t WriteParamFileList(const TString& name, T& object);
+    Int_t WriteParamFileList(const TString& name, T& object);
 
 
     /// \brief Construct the histograms of a generic object
@@ -892,225 +124,50 @@ class QwRootFile {
     void ConstructHistograms(const std::string& name, T& object);
     /// Fill histograms of the subsystem array
     template < class T >
-    void FillHistograms(T& object) {
-      // Update regularly
-      static Int_t update_count = 0;
-      update_count++;
-      if ((fUpdateInterval > 0) && ( update_count % fUpdateInterval == 0)) Update();
-
-      // Debug directory registration
-      std::string type = typeid(object).name();
-      bool hasDir = HasDirByType(object);
-
-      if (! hasDir) return;
-      // Fill histograms
-      object.FillHistograms();
-    }
-
+    void FillHistograms(T& object);
 
     /// Create a new tree with name and description
-    void NewTree(const std::string& name, const std::string& desc) {
-      if (IsTreeDisabled(name)) return;
-      this->cd();
-      QwRootTree *tree = 0;
-      if (! HasTreeByName(name)) {
-        tree = new QwRootTree(name,desc);
-      } else {
-        tree = new QwRootTree(fTreeByName[name].front());
-      }
-      fTreeByName[name].push_back(tree);
-    }
+    void NewTree(const std::string& name, const std::string& desc);
 
 #ifdef HAS_RNTUPLE_SUPPORT
     /// Create a new RNTuple with name and description
-    void NewNTuple(const std::string& name, const std::string& desc) {
-      if (IsTreeDisabled(name) || !fEnableRNTuples) return;
-      QwRootNTuple *ntuple = 0;
-      if (! HasNTupleByName(name)) {
-        ntuple = new QwRootNTuple(name, desc);
-        // Initialize the writer with our file
-        ntuple->InitializeWriter(fRootFile);
-      } else {
-        // For simplicity, don't support copying existing RNTuples yet
-        QwError << "Cannot create duplicate RNTuple: " << name << QwLog::endl;
-        return;
-      }
-      fNTupleByName[name].push_back(ntuple);
-    }
+    void NewNTuple(const std::string& name, const std::string& desc);
+    /// Fill the RNTuple with name
+    void FillNTuple(const std::string& name);
+    /// Fill all registered RNTuples
+    void FillNTuples();
 #endif // HAS_RNTUPLE_SUPPORT
 
     /// Get the tree with name
-    TTree* GetTree(const std::string& name) {
-      if (! HasTreeByName(name)) return 0;
-      else return fTreeByName[name].front()->GetTree();
-    }
-
+    TTree* GetTree(const std::string& name);
     /// Fill the tree with name
-    Int_t FillTree(const std::string& name) {
-      if (! HasTreeByName(name)) return 0;
-      else return fTreeByName[name].front()->Fill();
-    }
-
+    Int_t FillTree(const std::string& name);
     /// Fill all registered trees
-    Int_t FillTrees() {
-      // Loop over all registered tree names
-      Int_t retval = 0;
-      std::map< const std::string, std::vector<QwRootTree*> >::iterator iter;
-      for (iter = fTreeByName.begin(); iter != fTreeByName.end(); iter++) {
-        retval += iter->second.front()->Fill();
-      }
-      return retval;
-    }
-
-#ifdef HAS_RNTUPLE_SUPPORT
-    /// Fill the RNTuple with name
-    void FillNTuple(const std::string& name) {
-      if (HasNTupleByName(name)) {
-        fNTupleByName[name].front()->Fill();
-      }
-    }
-#endif // HAS_RNTUPLE_SUPPORT
-
-#ifdef HAS_RNTUPLE_SUPPORT
-    /// Fill all registered RNTuples
-    void FillNTuples() {
-      // Loop over all registered RNTuple names
-      std::map< const std::string, std::vector<QwRootNTuple*> >::iterator iter;
-      for (iter = fNTupleByName.begin(); iter != fNTupleByName.end(); iter++) {
-        iter->second.front()->Fill();
-      }
-    }
-#endif // HAS_RNTUPLE_SUPPORT
+    Int_t FillTrees();
 
     /// Print registered trees
-    void PrintTrees() const {
-      QwMessage << "Trees: " << QwLog::endl;
-      // Loop over all registered tree names
-      std::map< const std::string, std::vector<QwRootTree*> >::const_iterator iter;
-      for (iter = fTreeByName.begin(); iter != fTreeByName.end(); iter++) {
-        QwMessage << iter->first << ": " << iter->second.size()
-                  << " objects registered" << QwLog::endl;
-        // Loop over all registered objects for this tree
-        std::vector<QwRootTree*>::const_iterator tree;
-        for (tree = iter->second.begin(); tree != iter->second.end(); tree++) {
-          (*tree)->Print();
-        }
-      }
-    }
+    void PrintTrees() const;
     /// Print registered histogram directories
-    void PrintDirs() const {
-      QwMessage << "Dirs: " << QwLog::endl;
-      // Loop ove rall registered directories
-      std::map< const std::string, TDirectory* >::const_iterator iter;
-      for (iter = fDirsByName.begin(); iter != fDirsByName.end(); iter++) {
-        QwMessage << iter->first << QwLog::endl;
-      }
-    }
-
+    void PrintDirs() const;
 
     /// Write any object to the ROOT file (only valid for TFile)
     template < class T >
-    Int_t WriteObject(const T* obj, const char* name, Option_t* option = "", Int_t bufsize = 0) {
-      Int_t retval = 0;
-      // TMapFile has no support for WriteObject
-      if (fRootFile) retval = fRootFile->WriteObject(obj,name,option,bufsize);
-      return retval;
-    }
+    Int_t WriteObject(const T* obj, const char* name, Option_t* option = "", Int_t bufsize = 0);
 
 
     // Wrapped functionality
-    void Update() {
-      if (fMapFile) {
-        QwMessage << "TMapFile memory resident size: "
-                  << ((int*)fMapFile->GetBreakval() - (int*)fMapFile->GetBaseAddr()) *
-                     4 / sizeof(int32_t) / 1024 / 1024 << " MiB"
-                  << QwLog::endl;
-        fMapFile->Update();
-      }else{
-	// this option will allow for reading the tree during write
-	Long64_t nBytes(0);
-	for (auto iter = fTreeByName.begin(); iter != fTreeByName.end(); iter++)
-	  nBytes += iter->second.front()->AutoSave("SaveSelf");
-
-	QwMessage << "TFile saved: "
-                  << nBytes/1000000 << "MB (inaccurate number)" //FIXME this calculation is inaccurate
-                  << QwLog::endl;
-      }
-    }
-    void Print()  { if (fMapFile) fMapFile->Print();  if (fRootFile) fRootFile->Print(); }
-    void ls()     { if (fMapFile) fMapFile->ls();     if (fRootFile) fRootFile->ls(); }
-    void Map()    { if (fRootFile) fRootFile->Map(); }
-    void Close()  {
-
-      // Check if we should make the file permanent - restore original logic
-      if (!fMakePermanent) fMakePermanent = HasAnyFilled();
-
-
-#ifdef HAS_RNTUPLE_SUPPORT
-      // Close all RNTuples before closing the file
-      for (auto& pair : fNTupleByName) {
-        for (auto& ntuple : pair.second) {
-          if (ntuple) ntuple->Close();
-        }
-      }
-#endif // HAS_RNTUPLE_SUPPORT
-
-      // CRITICAL FIX: Explicitly write all trees before closing!
-      if (fRootFile) {
-
-        for (auto iter = fTreeByName.begin(); iter != fTreeByName.end(); iter++) {
-          if (!iter->second.empty() && iter->second.front()) {
-            TTree* tree = iter->second.front()->GetTree();
-            if (tree && tree->GetEntries() > 0) {
-
-              tree->Write();
-            }
-          }
-        }
-      }
-
-      // Close the file and handle renaming
-      if (fRootFile) {
-        TString rootfilename = fRootFile->GetName();
-
-        fRootFile->Close();
-
-      }
-
-      if (fMapFile) fMapFile->Close();
-
-
-    }
-
-    // Wrapped functionality
-    Bool_t cd(const char* path = 0) {
-      Bool_t status = kTRUE;
-      if (fMapFile)  status &= fMapFile->cd(path);
-      if (fRootFile) status &= fRootFile->cd(path);
-      return status;
-    }
-
-    // Wrapped functionality
-    TDirectory* mkdir(const char* name, const char* title = "") {
-      // TMapFile has no support for mkdir
-      if (fRootFile) return fRootFile->mkdir(name, title);
-      else return 0;
-    }
-
-    // Wrapped functionality
-    Int_t Write(const char* name = 0, Int_t option = 0, Int_t bufsize = 0) {
-      Int_t retval = 0;
-      // TMapFile has no support for Write
-      if (fRootFile) retval = fRootFile->Write(name, option, bufsize);
-      return retval;
-    }
-
+    void Update();
+    void Print() const;
+    void ls()    const;
+    void Map();
+    void Close();
+    Bool_t cd(const char* path = 0);
+    TDirectory* mkdir(const char* name, const char* title = "");
+    Int_t Write(const char* name = 0, Int_t option = 0, Int_t bufsize = 0);
 
   private:
-
     /// Private default constructor
     QwRootFile();
-
 
     /// ROOT file
     TFile* fRootFile;
@@ -1148,35 +205,21 @@ class QwRootFile {
 
 
   private:
-
     /// List of excluded trees
     std::vector< TPRegexp > fDisabledTrees;
     std::vector< TPRegexp > fDisabledHistos;
 
     /// Add regexp to list of disabled trees names
-    void DisableTree(const TString& regexp) {
-      fDisabledTrees.push_back(regexp);
-    }
+    void DisableTree(const TString& regexp);
     /// Does this tree name match a disabled tree name?
-    bool IsTreeDisabled(const std::string& name) {
-      for (size_t i = 0; i < fDisabledTrees.size(); i++)
-        if (fDisabledTrees.at(i).Match(name)) return true;
-      return false;
-    }
+    bool IsTreeDisabled(const std::string& name);
     /// Add regexp to list of disabled histogram directories
-    void DisableHisto(const TString& regexp) {
-      fDisabledHistos.push_back(regexp);
-    }
+    void DisableHisto(const TString& regexp);
     /// Does this histogram directory match a disabled histogram directory?
-    bool IsHistoDisabled(const std::string& name) {
-      for (size_t i = 0; i < fDisabledHistos.size(); i++)
-        if (fDisabledHistos.at(i).Match(name)) return true;
-      return false;
-    }
+    bool IsHistoDisabled(const std::string& name);
 
 
   private:
-
     /// Tree names, addresses, and types
     std::map< const std::string, std::vector<QwRootTree*> > fTreeByName;
     std::map< const void*      , std::vector<QwRootTree*> > fTreeByAddr;
@@ -1194,45 +237,23 @@ class QwRootFile {
 #endif // HAS_RNTUPLE_SUPPORT
 
     /// Is a tree registered for this name
-    bool HasTreeByName(const std::string& name) {
-      if (fTreeByName.count(name) == 0) return false;
-      else return true;
-    }
+    bool HasTreeByName(const std::string& name);
     /// Is a tree registered for this type
     template < class T >
-    bool HasTreeByType(const T& object) {
-      const std::type_index type = typeid(object);
-      if (fTreeByType.count(type) == 0) return false;
-      else return true;
-    }
+    bool HasTreeByType(const T& object);
     /// Is a tree registered for this object
     template < class T >
-    bool HasTreeByAddr(const T& object) {
-      const void* addr = static_cast<const void*>(&object);
-      if (fTreeByAddr.count(addr) == 0) return false;
-      else return true;
-    }
+    bool HasTreeByAddr(const T& object);
 
 #ifdef HAS_RNTUPLE_SUPPORT
     /// Is an RNTuple registered for this name
-    bool HasNTupleByName(const std::string& name) {
-      if (fNTupleByName.count(name) == 0) return false;
-      else return true;
-    }
+    bool HasNTupleByName(const std::string& name);
     /// Is an RNTuple registered for this type
     template < class T >
-    bool HasNTupleByType(const T& object) {
-      const std::type_index type = typeid(object);
-      if (fNTupleByType.count(type) == 0) return false;
-      else return true;
-    }
+    bool HasNTupleByType(const T& object);
     /// Is an RNTuple registered for this object
     template < class T >
-    bool HasNTupleByAddr(const T& object) {
-      const void* addr = static_cast<const void*>(&object);
-      if (fNTupleByAddr.count(addr) == 0) return false;
-      else return true;
-    }
+    bool HasNTupleByAddr(const T& object);
 #endif // HAS_RNTUPLE_SUPPORT
 
     /// Directories
@@ -1240,21 +261,12 @@ class QwRootFile {
     std::map< const std::string, std::vector<std::string> > fDirsByType;
 
     /// Is a tree registered for this name
-    bool HasDirByName(const std::string& name) {
-      if (fDirsByName.count(name) == 0) return false;
-      else return true;
-    }
+    bool HasDirByName(const std::string& name);
     /// Is a directory registered for this type
     template < class T >
-    bool HasDirByType(const T& object) {
-      std::string type = typeid(object).name();
-      if (fDirsByType.count(type) == 0) return false;
-      else return true;
-    }
-
+    bool HasDirByType(const T& object);
 
   private:
-
     /// Prescaling of events written to tree
     UInt_t fNumMpsEventsToSkip;
     UInt_t fNumMpsEventsToSave;
@@ -1267,6 +279,8 @@ class QwRootFile {
     static const Long64_t kMaxTreeSize;
     static const Int_t    kMaxMapFileSize;
 };
+
+/// Template Implementation ///
 
 /**
  * Construct the indices from one tree to another tree, and optionally in reverse as well.
@@ -1587,3 +601,70 @@ Int_t QwRootFile::WriteParamFileList(const TString &name, T& object)
   }
   return retval;
 }
+template < class T >
+void QwRootFile::FillHistograms(T& object)
+{
+  // Update regularly
+  static Int_t update_count = 0;
+  update_count++;
+  if ((fUpdateInterval > 0) && ( update_count % fUpdateInterval == 0)) Update();
+
+  // Debug directory registration
+  std::string type = typeid(object).name();
+  bool hasDir = HasDirByType(object);
+
+  if (! hasDir) return;
+  // Fill histograms
+  object.FillHistograms();
+}
+
+template < class T >
+Int_t QwRootFile::WriteObject(const T* obj, const char* name, Option_t* option, Int_t bufsize)
+{
+  Int_t retval = 0;
+  // TMapFile has no support for WriteObject
+  if (fRootFile) retval = fRootFile->WriteObject(obj,name,option,bufsize);
+  return retval;
+}
+
+template < class T >
+bool QwRootFile::HasTreeByType(const T& object)
+{
+  const std::type_index type = typeid(object);
+  if (fTreeByType.count(type) == 0) return false;
+  else return true;
+}
+
+template < class T >
+bool QwRootFile::HasTreeByAddr(const T& object)
+{
+  const void* addr = static_cast<const void*>(&object);
+  if (fTreeByAddr.count(addr) == 0) return false;
+  else return true;
+}
+
+template < class T >
+bool QwRootFile::HasDirByType(const T& object)
+{
+  std::string type = typeid(object).name();
+  if (fDirsByType.count(type) == 0) return false;
+  else return true;
+}
+
+#ifdef HAS_RNTUPLE_SUPPORT
+template < class T >
+bool QwRootFile::HasNTupleByType(const T& object)
+{
+  const std::type_index type = typeid(object);
+  if (fNTupleByType.count(type) == 0) return false;
+  else return true;
+}
+/// Is an RNTuple registered for this object
+template < class T >
+bool QwRootFile::HasNTupleByAddr(const T& object)
+{
+  const void* addr = static_cast<const void*>(&object);
+  if (fNTupleByAddr.count(addr) == 0) return false;
+  else return true;
+}
+#endif // HAS_RNTUPLE_SUPPORT

--- a/Analysis/include/QwRootNTuple.h
+++ b/Analysis/include/QwRootNTuple.h
@@ -1,0 +1,184 @@
+#pragma once
+
+#ifdef HAS_RNTUPLE_SUPPORT
+// System Headers
+#include <string>
+
+// ROOT Headers
+#include "TString.h"
+#include "TFile.h"
+#include "ROOT/RNTuple.hxx"
+#include "ROOT/RNTupleModel.hxx"
+#include "ROOT/RField.hxx"
+#include "ROOT/RNTupleWriter.hxx"
+
+// QWeak Headers
+#include "QwLog.h"
+
+
+// If one defines more than this number of words in the full ntuple,
+// the results are going to get very very crazy.
+constexpr std::size_t RNTUPLE_MAX_SIZE = 25000;
+
+/**
+ *  \class QwRootNTuple
+ *  \ingroup QwAnalysis
+ *  \brief A wrapper class for a ROOT RNTuple
+ *
+ * This class provides the functionality to write to ROOT RNTuples using a vector
+ * of doubles, similar to QwRootTree but using the newer RNTuple format.
+ */
+class QwRootNTuple {
+
+public:
+  /// Constructor with name and description
+  QwRootNTuple(const std::string& name, const std::string& desc, const std::string& prefix = "");
+  virtual ~QwRootNTuple();
+
+  /// Constructor with name, description, and object
+  template < class T >
+  QwRootNTuple(const std::string& name, const std::string& desc, T& object, const std::string& prefix = "");
+
+  /// Close and finalize the RNTuple writer
+  void Close();
+
+private:
+  /// Construct the fields and vector for generic objects
+  template < class T >
+  void ConstructFieldsAndVector(T& object);
+
+public:
+
+  /// Initialize the RNTuple writer with a file
+  void InitializeWriter(TFile* file);
+
+  /// Fill the fields for generic objects
+  template < class T >
+  void FillNTupleFields(const T& object);
+  /// Fill the RNTuple (called by FillTree wrapper methods)
+  void Fill() {
+    // This method is now called indirectly - the actual filling happens in FillNTupleFields
+    // Just here for compatibility with the tree interface
+  }
+
+  /// Get the name of the RNTuple
+  const std::string& GetName()  const;
+  /// Get the description of the RNTuple
+  const std::string& GetDesc()  const;
+  /// Get the prefix of the RNTuple
+  const std::string& GetPrefix()const;
+  /// Get the object type
+  const std::string& GetType()  const;
+
+  /// Set prescaling parameters
+  void SetPrescaling(UInt_t num_to_save, UInt_t num_to_skip);
+
+  /// Print the RNTuple name and description
+  void Print() const;
+
+  ROOT::RNTupleWriter* GetWriter() const { return fWriter.get(); };
+  uint64_t GetNEntriesFilled() const { return fWriter->GetNEntries(); }
+
+
+private:
+  /// RNTuple model and writer
+  std::unique_ptr<ROOT::RNTupleModel> fModel;
+  std::unique_ptr<ROOT::RNTupleWriter> fWriter;
+
+  /// Vector of values and shared field pointers (for RNTuple)
+  std::vector<Double_t> fVector;
+  std::vector<std::shared_ptr<Double_t>> fFieldPtrs;
+
+  /// Name, description, prefix
+  const std::string fName;
+  const std::string fDesc;
+  const std::string fPrefix;
+
+  /// Object type
+  std::string fType;
+
+  /// RNTuple prescaling parameters
+  UInt_t fCurrentEvent;
+  UInt_t fNumEventsCycle;
+  UInt_t fNumEventsToSave;
+  UInt_t fNumEventsToSkip;
+
+};
+
+/// Template Implementation ///
+template <typename T>
+QwRootNTuple::QwRootNTuple(const std::string& name, const std::string& desc, T& object, const std::string& prefix)
+: fName(name)
+, fDesc(desc)
+, fPrefix(prefix)
+, fType("type undefined")
+, fCurrentEvent(0)
+, fNumEventsCycle(0)
+, fNumEventsToSave(0)
+, fNumEventsToSkip(0)
+{
+  fModel = ROOT::RNTupleModel::Create();
+  ConstructFieldsAndVector(object);
+}
+
+template < class T >
+void QwRootNTuple::ConstructFieldsAndVector(T& object)
+{
+  // TODO:
+  // Reserve space for the field vector
+  fVector.reserve(RNTUPLE_MAX_SIZE);
+
+  // Associate fields with vector - now using shared field pointers
+  TString prefix = Form("%s", fPrefix.c_str());
+  object.ConstructNTupleAndVector(fModel, prefix, fVector, fFieldPtrs);
+
+  // Store the type of object
+  fType = typeid(object).name();
+
+  // Check memory reservation
+  if (fVector.size() > RNTUPLE_MAX_SIZE) {
+    QwError << "The field vector is too large: " << fVector.size() << " fields!  "
+            << "The maximum size is " << RNTUPLE_MAX_SIZE << "."
+            << QwLog::endl;
+    exit(-1);
+  }
+
+  // Shrink memory reservation
+  fVector.shrink_to_fit();
+}
+
+template < class T >
+void QwRootNTuple::FillNTupleFields(const T& object)
+{
+  if (typeid(object).name() == fType) {
+    // Fill the field vector
+    object.FillNTupleVector(fVector);
+
+    // Use the shared field pointers which remain valid
+    if (fWriter) {
+      for (size_t i = 0; i < fVector.size() && i < fFieldPtrs.size(); ++i) {
+        if (fFieldPtrs[i]) {
+          *(fFieldPtrs[i]) = fVector[i];
+        }
+      }
+
+      // CRITICAL: Actually commit the data to the RNTuple
+      fWriter->Fill();
+
+      // Update event counter
+      fCurrentEvent++;
+      // RNTuple prescaling
+      if (fNumEventsCycle > 0) {
+        fCurrentEvent %= fNumEventsCycle;
+      }
+    } else {
+      QwError << "RNTuple writer not initialized for " << fName << QwLog::endl;
+    }
+  } else {
+    QwError << "Attempting to fill RNTuple vector for type " << fType << " with "
+            << "object of type " << typeid(object).name() << QwLog::endl;
+    exit(-1);
+  }
+}
+
+#endif // HAS_RNTUPLE_SUPPORT

--- a/Analysis/include/QwRootNTuple.h
+++ b/Analysis/include/QwRootNTuple.h
@@ -124,7 +124,6 @@ QwRootNTuple::QwRootNTuple(const std::string& name, const std::string& desc, T& 
 template < class T >
 void QwRootNTuple::ConstructFieldsAndVector(T& object)
 {
-  // TODO:
   // Reserve space for the field vector
   fVector.reserve(RNTUPLE_MAX_SIZE);
 

--- a/Analysis/include/QwRootTree.h
+++ b/Analysis/include/QwRootTree.h
@@ -1,0 +1,205 @@
+#pragma once
+
+// System Headers
+#include <cstddef>
+#include <string>
+#include <sstream>
+#include <iomanip>
+
+// ROOT Headers
+#include "TSystem.h"
+#include "TTree.h"
+#include "TString.h"
+
+// QWEAK Headers
+#include "QwOptions.h"
+#include "QwRootTreeBranchVector.h"
+
+
+/**
+ *  \class QwRootTree
+ *  \ingroup QwAnalysis
+ *  \brief Wrapper class for ROOT tree management with vector-based data storage
+ *
+ * Provides functionality to write to ROOT trees using vectors of doubles,
+ * with support for branch construction, event filtering, and tree sharing.
+ * Handles both new tree creation and attachment to existing trees, enabling
+ * multiple subsystems to contribute data to a single ROOT tree.
+ */
+
+// If one defines more than this number of words in the full ttree,
+// the results are going to get very very crazy.
+constexpr std::size_t BRANCH_VECTOR_MAX_SIZE = 25000;
+class QwRootTree {
+
+public:
+  /// Constructor with name, and description
+  QwRootTree(const std::string& name, const std::string& desc, const std::string& prefix = "");
+  /// Constructor with existing tree
+  QwRootTree(const QwRootTree* tree, const std::string& prefix = "");
+
+  /// Constructor with name, description, and object
+  template < class T >
+  QwRootTree(const std::string& name, const std::string& desc, T& object, const std::string& prefix = "");
+  /// Constructor with existing tree, and object
+  template < class T >
+  QwRootTree(const QwRootTree* tree, T& object, const std::string& prefix = "");
+
+  /// Destructor
+  virtual ~QwRootTree() { }
+
+
+private:
+  static const TString kUnitsName;
+  static Double_t kUnitsValue[];
+
+  /// Construct the tree
+  void ConstructNewTree();
+  void ConstructUnitsBranch();
+  /// Construct the branches and vector for generic objects
+  template < class T >
+  void ConstructBranchAndVector(T& object);
+
+public:
+  /// Construct index from this tree to another tree
+  void ConstructIndexTo(QwRootTree* to);
+
+  /// Fill the branches for generic objects
+  template < class T >
+  void FillTreeBranches(const T& object);
+  Long64_t AutoSave(Option_t *option);
+
+  /// Fill the tree
+  [[nodiscard]]
+  Int_t Fill();
+
+  /// Print the tree name and description
+  void Print() const;
+  /// Get the tree pointer for low level operations
+  TTree* GetTree() const { return fTree; };
+
+  uint64_t GetNEntriesFilled() const { return fTree->GetEntries(); }
+
+  /// Set tree prescaling parameters
+  void SetPrescaling(UInt_t num_to_save, UInt_t num_to_skip);
+  /// Set maximum tree size
+  void SetMaxTreeSize(Long64_t maxsize = 1900000000);
+  /// Set autoflush size
+  void SetAutoFlush(Long64_t autoflush = 30000000);
+  /// Set autosave size
+  void SetAutoSave(Long64_t autosave = 300000000);
+  /// Set basket size
+  void SetBasketSize(Int_t basketsize = 16000);
+  //Set circular buffer size for the memory resident tree
+  void SetCircular(Long64_t buff = 100000);
+
+private:
+  /// Tree pointer
+  TTree* fTree;
+  /// Vector of leaves
+  QwRootTreeBranchVector fVector;
+
+
+  /// Name, description, Obj. Type
+  const std::string fName;
+  const std::string fDesc;
+  const std::string fPrefix;
+  std::string fType;
+
+  /// Get the name of the tree
+  const std::string& GetName()  const;
+  /// Get the description of the tree
+  const std::string& GetDesc()  const;
+  /// Get the description of the tree
+  const std::string& GetPrefix()const;
+  /// Get the object type
+  const std::string& GetType()  const;
+
+
+  /// Tree prescaling parameters
+  UInt_t fCurrentEvent;
+  UInt_t fNumEventsCycle;
+  UInt_t fNumEventsToSave;
+  UInt_t fNumEventsToSkip;
+
+
+
+  /// Maximum tree size, autoflush and autosave
+  Long64_t fMaxTreeSize;
+  Long64_t fAutoFlush;
+  Long64_t fAutoSave;
+  Int_t fBasketSize;
+
+};
+
+/// Template Implementation ///
+template < class T >
+QwRootTree::QwRootTree(const std::string& name, const std::string& desc, T& object, const std::string& prefix)
+: fName(name)
+, fDesc(desc)
+, fPrefix(prefix)
+, fType("type undefined")
+, fCurrentEvent(0)
+, fNumEventsCycle(0)
+, fNumEventsToSave(0)
+, fNumEventsToSkip(0)
+{
+  ConstructNewTree();
+  ConstructUnitsBranch();
+  ConstructBranchAndVector(object);
+}
+
+template < class T >
+QwRootTree::QwRootTree(const QwRootTree* tree, T& object, const std::string& prefix)
+: fName(tree->GetName())
+, fDesc(tree->GetDesc())
+, fPrefix(prefix)
+, fType("type undefined")
+, fCurrentEvent(0)
+, fNumEventsCycle(0)
+, fNumEventsToSave(0)
+, fNumEventsToSkip(0)
+{
+  QwMessage << "Existing tree: " << tree->GetName() << ", " << tree->GetDesc() << QwLog::endl;
+  fTree = tree->fTree;
+
+  ConstructBranchAndVector(object);
+}
+
+template < class T >
+void QwRootTree::ConstructBranchAndVector(T& object)
+{
+  // TODO:
+  // Reserve space for the branch vector
+  fVector.reserve(BRANCH_VECTOR_MAX_SIZE);
+  // Associate branches with vector
+
+  TString prefix = Form("%s",fPrefix.c_str());
+  object.ConstructBranchAndVector(fTree, prefix, fVector);
+
+  // Store the type of object
+  fType = typeid(object).name();
+
+  // Check memory reservation
+  /*
+  if (fVector.size() > BRANCH_VECTOR_MAX_SIZE) {
+    QwError << "The branch vector is too large: " << fVector.size() << " leaves!  "
+            << "The maximum size is " << BRANCH_VECTOR_MAX_SIZE << "."
+            << QwLog::endl;
+    exit(-1);
+  }
+  */
+}
+
+template < class T >
+void QwRootTree::FillTreeBranches(const T& object)
+{
+  if (typeid(object).name() == fType) {
+    // Fill the branch vector
+    object.FillTreeVector(fVector);
+  } else {
+    QwError << "Attempting to fill tree vector for type " << fType << " with "
+            << "object of type " << typeid(object).name() << QwLog::endl;
+    exit(-1);
+  }
+}

--- a/Analysis/include/QwRootTree.h
+++ b/Analysis/include/QwRootTree.h
@@ -93,6 +93,15 @@ public:
   //Set circular buffer size for the memory resident tree
   void SetCircular(Long64_t buff = 100000);
 
+  /// Get the name of the tree
+  const std::string& GetName()  const;
+  /// Get the description of the tree
+  const std::string& GetDesc()  const;
+  /// Get the description of the tree
+  const std::string& GetPrefix()const;
+  /// Get the object type
+  const std::string& GetType()  const;
+
 private:
   /// Tree pointer
   TTree* fTree;
@@ -105,16 +114,6 @@ private:
   const std::string fDesc;
   const std::string fPrefix;
   std::string fType;
-
-  /// Get the name of the tree
-  const std::string& GetName()  const;
-  /// Get the description of the tree
-  const std::string& GetDesc()  const;
-  /// Get the description of the tree
-  const std::string& GetPrefix()const;
-  /// Get the object type
-  const std::string& GetType()  const;
-
 
   /// Tree prescaling parameters
   UInt_t fCurrentEvent;

--- a/Analysis/include/QwRootTree.h
+++ b/Analysis/include/QwRootTree.h
@@ -169,7 +169,6 @@ QwRootTree::QwRootTree(const QwRootTree* tree, T& object, const std::string& pre
 template < class T >
 void QwRootTree::ConstructBranchAndVector(T& object)
 {
-  // TODO:
   // Reserve space for the branch vector
   fVector.reserve(BRANCH_VECTOR_MAX_SIZE);
   // Associate branches with vector
@@ -181,14 +180,12 @@ void QwRootTree::ConstructBranchAndVector(T& object)
   fType = typeid(object).name();
 
   // Check memory reservation
-  /*
   if (fVector.size() > BRANCH_VECTOR_MAX_SIZE) {
     QwError << "The branch vector is too large: " << fVector.size() << " leaves!  "
             << "The maximum size is " << BRANCH_VECTOR_MAX_SIZE << "."
             << QwLog::endl;
     exit(-1);
   }
-  */
 }
 
 template < class T >

--- a/Analysis/include/QwRootTreeBranchVector.h
+++ b/Analysis/include/QwRootTreeBranchVector.h
@@ -53,7 +53,7 @@ public:
   template <typename T>
   const T& value(size_type index) const;
 
-  // Disble Implicit Conversion
+  // Disable Implicit Conversion
   template<typename T>
   void SetValue(size_type index, T val) = delete;
   void SetValue(size_type index, Double_t val);

--- a/Analysis/include/QwRootTreeBranchVector.h
+++ b/Analysis/include/QwRootTreeBranchVector.h
@@ -94,12 +94,12 @@ private:
 };
 
 /// IMPLEMENTATION ///
-template <typename T = uint8_t>
+template <typename T>
 const T& QwRootTreeBranchVector::operator[](size_type index) const
 {
   return value<T>(index);
 }
-template <typename T = uint8_t>
+template <typename T>
 T& QwRootTreeBranchVector::operator[](size_type index)
 {
   return value<T>(index);

--- a/Analysis/include/QwRootTreeBranchVector.h
+++ b/Analysis/include/QwRootTreeBranchVector.h
@@ -1,0 +1,146 @@
+#pragma once
+
+// System Headers
+#include <cstddef>
+#include <string>
+#include <sstream>
+#include <iomanip>
+
+// ROOT Headers
+#include "TSystem.h"
+#include "TTree.h"
+#include "TString.h"
+
+// QWEAK Headers
+#include "QwOptions.h"
+/**
+ *  \class QwRootTreeBranchVector
+ *  \ingroup QwAnalysis
+ *  \brief A helper class to manage a vector of branch entries for ROOT trees
+ *
+ * This class provides functionality to manage a collection of branch entries,
+ * including their names, types, offsets, and sizes. It supports adding new entries,
+ * accessing entries by index or name, and generating leaf lists for ROOT trees.
+ */
+
+using size_type = std::size_t;
+class QwRootTreeBranchVector {
+public:
+  struct Entry {
+    std::string name;
+    std::size_t offset;
+    std::size_t size;
+    char type;
+  };
+
+  QwRootTreeBranchVector() = default;
+
+  void reserve(size_type count);
+  void shrink_to_fit();
+  void clear();
+  size_type size() const noexcept;
+  bool empty()     const noexcept;
+
+  template <typename T = uint8_t>
+  const T& operator[](size_type index) const;
+
+  template <typename T = uint8_t>
+  T& operator[](size_type index);
+
+  template <typename T>
+  T& value(size_type index);
+
+  template <typename T>
+  const T& value(size_type index) const;
+
+  // Disble Implicit Conversion
+  template<typename T>
+  void SetValue(size_type index, T val) = delete;
+  void SetValue(size_type index, Double_t val);
+  void SetValue(size_type index, Float_t val);
+  void SetValue(size_type index, Int_t val);
+  void SetValue(size_type index, Long64_t val);
+  void SetValue(size_type index, Short_t val);
+  void SetValue(size_type index, UShort_t val);
+  void SetValue(size_type index, UInt_t val);
+  void SetValue(size_type index, ULong64_t val);
+
+  void* data() noexcept;
+  const void* data() const noexcept;
+  size_type data_size() const noexcept;
+
+  template <typename T> T& back();
+  template <typename T> const T& back() const;
+
+  // Overload for TString (ROOT's string class)
+  void push_back(const   TString   &name, const char type = 'D');
+  void push_back(const std::string &name, const char type = 'D');
+  void push_back(const    char*     name, const char type = 'D');
+
+  std::string LeafList(size_type start_index = 0) const;
+  std::string Dump(size_type start_index = 0, size_type end_index = 0) const;
+
+private:
+  static std::size_t GetTypeSize(char type);
+  static std::size_t AlignOffset(std::size_t offset);
+
+  std::vector<Entry> m_entries;
+  std::vector<std::uint8_t> m_buffer;
+
+  std::string FormatValue(const Entry& entry, size_type index) const;
+
+  template <typename T>
+  static std::string FormatNumeric(T input);
+};
+
+/// IMPLEMENTATION ///
+template <typename T = uint8_t>
+const T& QwRootTreeBranchVector::operator[](size_type index) const
+{
+  return value<T>(index);
+}
+template <typename T = uint8_t>
+T& QwRootTreeBranchVector::operator[](size_type index)
+{
+  return value<T>(index);
+}
+
+template <typename T>
+T& QwRootTreeBranchVector::value(size_type index)
+{
+  auto& entry = m_entries.at(index);
+  return *reinterpret_cast<T*>(m_buffer.data() + entry.offset);
+}
+
+template <typename T>
+const T& QwRootTreeBranchVector::value(size_type index) const
+{
+  const auto& entry = m_entries.at(index);
+  return *reinterpret_cast<const T*>(m_buffer.data() + entry.offset);
+}
+template <typename T>
+T& QwRootTreeBranchVector::back()
+{
+  if (m_entries.empty()) {
+    throw std::out_of_range("QwRootTreeBranchVector::back() called on empty container");
+  }
+  const auto& last_entry = m_entries.back();
+  return *reinterpret_cast<T*>(m_buffer.data() + last_entry.offset);
+}
+
+template <typename T>
+const T& QwRootTreeBranchVector::back() const
+{
+  if (m_entries.empty()) {
+    throw std::out_of_range("QwRootTreeBranchVector::back() called on empty container");
+  }
+  const auto& last_entry = m_entries.back();
+  return *reinterpret_cast<const T*>(m_buffer.data() + last_entry.offset);
+}
+template <typename T>
+std::string QwRootTreeBranchVector::FormatNumeric(T input) {
+  std::ostringstream stream;
+  stream << input;
+  return stream.str();
+}
+

--- a/Analysis/src/QwRootFile.cc
+++ b/Analysis/src/QwRootFile.cc
@@ -342,7 +342,7 @@ Bool_t QwRootFile::HasAnyFilled(TDirectory* d) {
   // First check if any in-memory trees have been filled
   for (auto& pair : fTreeByName) {
     for (auto& tree : pair.second) {
-      if (tree && tree->GetTree()) { // GetWriter should be replaced with IsInit()
+      if (tree && tree->GetTree()) {
         if (tree->GetNEntriesFilled() > 0) {
           return true;
         }
@@ -354,8 +354,8 @@ Bool_t QwRootFile::HasAnyFilled(TDirectory* d) {
   // Then check if any RNTuples have been filled
   for (auto& pair : fNTupleByName) {
     for (auto& ntuple : pair.second) {
-      if (ntuple && ntuple->GetWriter()) { // GetWriter should be replaced with IsInit()
-		if(ntuple->GetNEntriesFilled())
+      if (ntuple && ntuple->GetWriter()) {
+		if(ntuple->GetNEntriesFilled() > 0)
         	return true;
       }
     }

--- a/Analysis/src/QwRootFile.cc
+++ b/Analysis/src/QwRootFile.cc
@@ -16,9 +16,6 @@ std::string QwRootFile::fDefaultRootFileStem = "Qweak_";
 const Long64_t QwRootFile::kMaxTreeSize = 100000000000LL;
 const Int_t QwRootFile::kMaxMapFileSize = 0x3fffffff; // 1 GiB
 
-const TString QwRootTree::kUnitsName = "ppm/D:ppb/D:um/D:mm/D:mV_uA/D:V_uA/D";
-Double_t QwRootTree::kUnitsValue[] = { 1e-6, 1e-9, 1e-3, 1 , 1e-3, 1};
-
 /**
  * Constructor with relative filename
  */
@@ -345,10 +342,8 @@ Bool_t QwRootFile::HasAnyFilled(TDirectory* d) {
   // First check if any in-memory trees have been filled
   for (auto& pair : fTreeByName) {
     for (auto& tree : pair.second) {
-      if (tree && tree->GetTree()) {
-        Long64_t entries = tree->GetTree()->GetEntries();
-        if (entries > 0) {
-
+      if (tree && tree->GetTree()) { // GetWriter should be replaced with IsInit()
+        if (tree->GetNEntriesFilled() > 0) {
           return true;
         }
       }
@@ -359,9 +354,9 @@ Bool_t QwRootFile::HasAnyFilled(TDirectory* d) {
   // Then check if any RNTuples have been filled
   for (auto& pair : fNTupleByName) {
     for (auto& ntuple : pair.second) {
-      if (ntuple && ntuple->fCurrentEvent > 0) {
-
-        return true;
+      if (ntuple && ntuple->GetWriter()) { // GetWriter should be replaced with IsInit()
+		if(ntuple->GetNEntriesFilled())
+        	return true;
       }
     }
   }
@@ -415,3 +410,250 @@ Bool_t QwRootFile::HasAnyFilled(TDirectory* d) {
   }
   return false;
 }
+
+void QwRootFile::SetDefaultRootFileDir(const std::string& dir)
+{
+  fDefaultRootFileDir = dir;
+}
+void QwRootFile::SetDefaultRootFileStem(const std::string& stem)
+{
+      fDefaultRootFileStem = stem;
+}
+
+Bool_t QwRootFile::IsRootFile() const { return (fRootFile); }
+Bool_t QwRootFile::IsMapFile()  const { return (fMapFile);  }
+
+void QwRootFile::NewTree(const std::string& name, const std::string& desc)
+{
+  if (IsTreeDisabled(name)) return;
+  this->cd();
+  QwRootTree *tree = 0;
+  if (! HasTreeByName(name)) {
+    tree = new QwRootTree(name,desc);
+  } else {
+    tree = new QwRootTree(fTreeByName[name].front());
+  }
+  fTreeByName[name].push_back(tree);
+}
+
+TTree* QwRootFile::GetTree(const std::string& name)
+{
+  if (! HasTreeByName(name)) return 0;
+  else return fTreeByName[name].front()->GetTree();
+}
+
+Int_t QwRootFile::FillTree(const std::string& name)
+{
+  if (! HasTreeByName(name)) return 0;
+  else return fTreeByName[name].front()->Fill();
+}
+
+Int_t QwRootFile::FillTrees()
+{
+  // Loop over all registered tree names
+  Int_t retval = 0;
+  std::map< const std::string, std::vector<QwRootTree*> >::iterator iter;
+  for (iter = fTreeByName.begin(); iter != fTreeByName.end(); iter++) {
+    retval += iter->second.front()->Fill();
+  }
+  return retval;
+}
+
+void QwRootFile::PrintTrees() const
+{
+  QwMessage << "Trees: " << QwLog::endl;
+  // Loop over all registered tree names
+  std::map< const std::string, std::vector<QwRootTree*> >::const_iterator iter;
+  for (iter = fTreeByName.begin(); iter != fTreeByName.end(); iter++) {
+    QwMessage << iter->first << ": " << iter->second.size()
+              << " objects registered" << QwLog::endl;
+    // Loop over all registered objects for this tree
+    std::vector<QwRootTree*>::const_iterator tree;
+    for (tree = iter->second.begin(); tree != iter->second.end(); tree++) {
+      (*tree)->Print();
+    }
+  }
+}
+
+
+void QwRootFile::PrintDirs() const
+{
+  QwMessage << "Dirs: " << QwLog::endl;
+  // Loop ove rall registered directories
+  std::map< const std::string, TDirectory* >::const_iterator iter;
+  for (iter = fDirsByName.begin(); iter != fDirsByName.end(); iter++) {
+    QwMessage << iter->first << QwLog::endl;
+  }
+}
+
+void QwRootFile::Update()
+{
+	if (fMapFile) {
+		QwMessage << "TMapFile memory resident size: "
+			      << ((int*)fMapFile->GetBreakval() - (int*)fMapFile->GetBaseAddr()) * 4 / sizeof(int32_t) / 1024 / 1024 << " MiB"
+			      << QwLog::endl;
+		fMapFile->Update();
+	} else {
+		// this option will allow for reading the tree during write
+		Long64_t nBytes(0);
+		for (auto iter = fTreeByName.begin(); iter != fTreeByName.end(); iter++)
+			nBytes += iter->second.front()->AutoSave("SaveSelf");
+
+		QwMessage << "TFile saved: "
+			<< nBytes/1000000 << "MB (inaccurate number)" //FIXME this calculation is inaccurate
+			<< QwLog::endl;
+	}
+}
+
+void QwRootFile::Print() const
+{
+	if (fMapFile) fMapFile->Print();
+	if (fRootFile) fRootFile->Print();
+}
+void QwRootFile::ls() const
+{
+	if (fMapFile) fMapFile->ls();
+	if (fRootFile) fRootFile->ls();
+}
+void QwRootFile::Map()
+{
+	if (fRootFile) fRootFile->Map();
+}
+void QwRootFile::Close()
+{
+
+  // Check if we should make the file permanent - restore original logic
+  if (!fMakePermanent) fMakePermanent = HasAnyFilled();
+
+#ifdef HAS_RNTUPLE_SUPPORT
+  // Close all RNTuples before closing the file
+  for (auto& pair : fNTupleByName) {
+    for (auto& ntuple : pair.second) {
+      if (ntuple) ntuple->Close();
+    }
+  }
+#endif // HAS_RNTUPLE_SUPPORT
+
+  // CRITICAL FIX: Explicitly write all trees before closing!
+  if (fRootFile) {
+
+    for (auto iter = fTreeByName.begin(); iter != fTreeByName.end(); iter++) {
+      if (!iter->second.empty() && iter->second.front()) {
+        TTree* tree = iter->second.front()->GetTree();
+        if (tree && tree->GetEntries() > 0) {
+          tree->Write();
+        }
+      }
+    }
+  }
+
+  // Close the file and handle renaming
+  if (fRootFile) {
+    TString rootfilename = fRootFile->GetName();
+    fRootFile->Close();
+  }
+  if (fMapFile) fMapFile->Close();
+}
+
+Bool_t QwRootFile::cd(const char* path)
+{
+  Bool_t status = kTRUE;
+  if (fMapFile)  status &= fMapFile->cd(path);
+  if (fRootFile) status &= fRootFile->cd(path);
+  return status;
+}
+
+TDirectory* QwRootFile::mkdir(const char* name, const char* title)
+{
+  // TMapFile has no support for mkdir
+  if (fRootFile) return fRootFile->mkdir(name, title);
+  else return 0;
+}
+
+Int_t QwRootFile::Write(const char* name, Int_t option, Int_t bufsize)
+{
+  Int_t retval = 0;
+  // TMapFile has no support for Write
+  if (fRootFile) retval = fRootFile->Write(name, option, bufsize);
+  return retval;
+}
+
+void QwRootFile::DisableTree(const TString& regexp)
+{
+  fDisabledTrees.push_back(regexp);
+}
+
+bool QwRootFile::IsTreeDisabled(const std::string& name)
+{
+  for (size_t i = 0; i < fDisabledTrees.size(); i++)
+    if (fDisabledTrees.at(i).Match(name)) return true;
+  return false;
+}
+
+void QwRootFile::DisableHisto(const TString& regexp)
+{
+  fDisabledHistos.push_back(regexp);
+}
+
+bool QwRootFile::IsHistoDisabled(const std::string& name)
+{
+  for (size_t i = 0; i < fDisabledHistos.size(); i++)
+    if (fDisabledHistos.at(i).Match(name)) return true;
+  return false;
+}
+
+/// Is a tree registered for this name
+bool QwRootFile::HasTreeByName(const std::string& name)
+{
+  if (fTreeByName.count(name) == 0) return false;
+  else return true;
+}
+
+bool QwRootFile::HasDirByName(const std::string& name)
+{
+  if (fDirsByName.count(name) == 0) return false;
+  else return true;
+}
+
+
+#ifdef HAS_RNTUPLE_SUPPORT
+void QwRootFile::NewNTuple(const std::string& name, const std::string& desc)
+{
+  if (IsTreeDisabled(name) || !fEnableRNTuples) return;
+  QwRootNTuple *ntuple = 0;
+  if (! HasNTupleByName(name)) {
+    ntuple = new QwRootNTuple(name, desc);
+    // Initialize the writer with our file
+    ntuple->InitializeWriter(fRootFile);
+  } else {
+    // For simplicity, don't support copying existing RNTuples yet
+    QwError << "Cannot create duplicate RNTuple: " << name << QwLog::endl;
+    return;
+  }
+  fNTupleByName[name].push_back(ntuple);
+}
+
+void QwRootFile::FillNTuple(const std::string& name)
+{
+  if (HasNTupleByName(name)) {
+    fNTupleByName[name].front()->Fill();
+  }
+}
+
+void QwRootFile::FillNTuples()
+{
+  // Loop over all registered RNTuple names
+  std::map< const std::string, std::vector<QwRootNTuple*> >::iterator iter;
+  for (iter = fNTupleByName.begin(); iter != fNTupleByName.end(); iter++) {
+    iter->second.front()->Fill();
+  }
+}
+
+bool QwRootFile::HasNTupleByName(const std::string& name)
+{
+  if (fNTupleByName.count(name) == 0) return false;
+  else return true;
+}
+
+
+#endif // HAS_RNTUPLE_SUPPORT

--- a/Analysis/src/QwRootNTuple.cc
+++ b/Analysis/src/QwRootNTuple.cc
@@ -1,4 +1,16 @@
+#ifdef HAS_RNTUPLE_SUPPORT
 #include "QwRootNTuple.h"
+
+// System Headers
+#include <string>
+
+// ROOT Headers
+#include "Rtypes.h"
+#include "TFile.h"
+
+// QWeak Headers
+#include "QwLog.h"
+
 
 QwRootNTuple::QwRootNTuple(const std::string& name, const std::string& desc, const std::string& prefix)
 : fName(name)
@@ -72,4 +84,4 @@ void QwRootNTuple::Print() const
     QwMessage << " (prefix " << GetPrefix() << ")";
   QwMessage << QwLog::endl;
 }
-
+#endif // HAS_RNTUPLE_SUPPORT

--- a/Analysis/src/QwRootNTuple.cc
+++ b/Analysis/src/QwRootNTuple.cc
@@ -1,0 +1,75 @@
+#include "QwRootNTuple.h"
+
+QwRootNTuple::QwRootNTuple(const std::string& name, const std::string& desc, const std::string& prefix)
+: fName(name)
+, fDesc(desc)
+, fPrefix(prefix)
+, fType("type undefined")
+, fCurrentEvent(0)
+, fNumEventsCycle(0)
+, fNumEventsToSave(0)
+, fNumEventsToSkip(0)
+{
+  fModel = ROOT::RNTupleModel::Create();
+}
+
+QwRootNTuple::~QwRootNTuple()
+{
+    Close();
+}
+
+void QwRootNTuple::Close()
+{
+  if (fWriter) {
+    // ROOT::~RNTupleWriter writes to disk
+    fWriter.reset();
+  }
+}
+
+void QwRootNTuple::InitializeWriter(TFile* file)
+{
+  if (!fModel) {
+    QwError << "RNTuple model not created for " << fName << QwLog::endl;
+    return;
+  }
+
+  // Before creating the writer, ensure all fields are added to the model
+  if (fVector.empty()) {
+    QwError << "No fields defined in RNTuple model for " << fName << QwLog::endl;
+    return;
+  }
+
+  try {
+    // Create the writer with the model (transfers ownership)
+    // Use Append to add RNTuple to existing TFile
+    fWriter = ROOT::RNTupleWriter::Append(std::move(fModel), fName, *file);
+    QwMessage << "Created RNTuple '" << fName << "' in file " << file->GetName() << QwLog::endl;
+
+  } catch (const std::exception& e) {
+    QwError << "Failed to create RNTuple writer for '" << fName << "': " << e.what() << QwLog::endl;
+  }
+}
+
+const std::string& QwRootNTuple::GetName()  const { return fName;  }
+/// Get the description of the RNTuple
+const std::string& QwRootNTuple::GetDesc()  const { return fDesc;  }
+/// Get the prefix of the RNTuple
+const std::string& QwRootNTuple::GetPrefix()const { return fPrefix;}
+/// Get the object type
+const std::string& QwRootNTuple::GetType()  const { return fType;  }
+
+void QwRootNTuple::SetPrescaling(UInt_t num_to_save, UInt_t num_to_skip)
+{
+  fNumEventsToSave = num_to_save;
+  fNumEventsToSkip = num_to_skip;
+  fNumEventsCycle = fNumEventsToSave + fNumEventsToSkip;
+}
+
+void QwRootNTuple::Print() const
+{
+  QwMessage << GetName() << ", " << GetType();
+  if (fPrefix != "")
+    QwMessage << " (prefix " << GetPrefix() << ")";
+  QwMessage << QwLog::endl;
+}
+

--- a/Analysis/src/QwRootTree.cc
+++ b/Analysis/src/QwRootTree.cc
@@ -36,13 +36,9 @@ void QwRootTree::ConstructNewTree()
 
   fTree = new TTree(fName.c_str(), fDesc.c_str());
   // Ensure tree is in the current directory
-  if (gDirectory) { // Is gDirectory ever NULL?
-  	QwMessage << "gDirectory is not NULL!\n";
+  if (gDirectory) {
     fTree->SetDirectory(gDirectory);
-  } else {
-  	QwMessage << "gDirectory is NULL!\n";
   }
-  getchar();
 }
 
 void QwRootTree::ConstructUnitsBranch()

--- a/Analysis/src/QwRootTree.cc
+++ b/Analysis/src/QwRootTree.cc
@@ -1,0 +1,136 @@
+#include "QwRootTree.h"
+
+const TString QwRootTree::kUnitsName = "ppm/D:ppb/D:um/D:mm/D:mV_uA/D:V_uA/D";
+Double_t QwRootTree::kUnitsValue[] = { 1e-6, 1e-9, 1e-3, 1 , 1e-3, 1};
+
+QwRootTree::QwRootTree(const std::string& name, const std::string& desc, const std::string& prefix)
+: fName(name)
+, fDesc(desc)
+, fPrefix(prefix)
+, fType("type undefined")
+, fCurrentEvent(0)
+, fNumEventsCycle(0)
+, fNumEventsToSave(0)
+, fNumEventsToSkip(0)
+{
+  ConstructNewTree();
+}
+
+QwRootTree::QwRootTree(const QwRootTree* tree, const std::string& prefix)
+: fName(tree->GetName())
+, fDesc(tree->GetDesc())
+, fPrefix(prefix)
+, fType("type undefined")
+, fCurrentEvent(0)
+, fNumEventsCycle(0)
+, fNumEventsToSave(0)
+, fNumEventsToSkip(0)
+{
+  QwMessage << "Existing tree: " << tree->GetName() << ", " << tree->GetDesc() << QwLog::endl;
+  fTree = tree->fTree;
+}
+
+void QwRootTree::ConstructNewTree()
+{
+  QwMessage << "New tree: " << fName << ", " << fDesc << QwLog::endl;
+
+  fTree = new TTree(fName.c_str(), fDesc.c_str());
+  // Ensure tree is in the current directory
+  if (gDirectory) { // Is gDirectory ever NULL?
+  	QwMessage << "gDirectory is not NULL!\n";
+    fTree->SetDirectory(gDirectory);
+  } else {
+  	QwMessage << "gDirectory is NULL!\n";
+  }
+  getchar();
+}
+
+void QwRootTree::ConstructUnitsBranch()
+{
+  std::string name = "units";
+  fTree->Branch(name.c_str(), &kUnitsValue, kUnitsName);
+}
+
+void QwRootTree::ConstructIndexTo(QwRootTree* to)
+{
+  std::string name = "previous_entry_in_" + to->fName;
+  fTree->Branch(name.c_str(), &(to->fCurrentEvent));
+}
+
+Long64_t QwRootTree::AutoSave(Option_t *option)
+{
+  return fTree->AutoSave(option);
+}
+
+
+Int_t QwRootTree::Fill()
+{
+  fCurrentEvent++;
+
+  // Tree prescaling
+  if (fNumEventsCycle > 0) {
+    fCurrentEvent %= fNumEventsCycle;
+    if (fCurrentEvent > fNumEventsToSave)
+      return 0;
+  }
+
+  // Fill the tree
+  Int_t retval = fTree->Fill();
+  // Check for errors
+  if (retval < 0) {
+    QwError << "Writing tree failed!  Check disk space or quota." << QwLog::endl;
+    exit(retval);
+  }
+  return retval;
+}
+
+void QwRootTree::Print() const
+{
+  QwMessage << GetName() << ", " << GetType();
+  if (fPrefix != "")
+    QwMessage << " (prefix " << GetPrefix() << ")";
+  QwMessage << QwLog::endl;
+}
+
+const std::string& QwRootTree::GetName()   const { return fName  ; };
+const std::string& QwRootTree::GetDesc()   const { return fDesc  ; };
+const std::string& QwRootTree::GetPrefix() const { return fPrefix; };
+const std::string& QwRootTree::GetType()   const { return fType  ; };
+
+void QwRootTree::SetPrescaling(UInt_t num_to_save, UInt_t num_to_skip)
+{
+  fNumEventsToSave = num_to_save;
+  fNumEventsToSkip = num_to_skip;
+  fNumEventsCycle = fNumEventsToSave + fNumEventsToSkip;
+}
+
+void QwRootTree::SetMaxTreeSize(Long64_t maxsize)
+{
+  fMaxTreeSize = maxsize;
+  if (fTree) fTree->SetMaxTreeSize(maxsize);
+}
+
+void QwRootTree::SetAutoFlush(Long64_t autoflush)
+{
+  fAutoFlush = autoflush;
+#if ROOT_VERSION_CODE >= ROOT_VERSION(5,26,00)
+    if (fTree) fTree->SetAutoFlush(autoflush);
+ #endif
+}
+
+void QwRootTree::SetAutoSave(Long64_t autosave)
+{
+  fAutoSave = autosave;
+  if (fTree) fTree->SetAutoSave(autosave);
+}
+
+void QwRootTree::SetBasketSize(Int_t basketsize)
+{
+  fBasketSize = basketsize;
+  if (fTree) fTree->SetBasketSize("*",basketsize);
+}
+
+void QwRootTree::SetCircular(Long64_t buff)
+{
+  if (fTree) fTree->SetCircular(buff);
+}

--- a/Analysis/src/QwRootTreeBranchVector.cc
+++ b/Analysis/src/QwRootTreeBranchVector.cc
@@ -1,0 +1,253 @@
+#include "QwRootTreeBranchVector.h"
+
+
+void QwRootTreeBranchVector::reserve(size_type count)
+{
+	m_entries.reserve(count);
+	m_buffer.reserve(sizeof(double)*count);
+}
+
+void QwRootTreeBranchVector::shrink_to_fit()
+{
+	m_entries.shrink_to_fit();
+	m_buffer.shrink_to_fit();
+}
+void QwRootTreeBranchVector::clear()
+{
+    m_entries.clear();
+    m_buffer.clear();
+}
+
+size_type QwRootTreeBranchVector::size()  const noexcept { return m_entries.size() ; }
+bool      QwRootTreeBranchVector::empty() const noexcept { return m_entries.empty(); }
+
+void QwRootTreeBranchVector::SetValue(size_type index, Double_t val)
+{
+  const auto& entry = m_entries.at(index);
+  if (entry.type != 'D') {
+    throw std::invalid_argument("Type mismatch: entry type '" + std::string(1, entry.type) + "' cannot store double value '" + entry.name + "'");
+  }
+  this->value<Double_t>(index) = val;
+}
+
+void QwRootTreeBranchVector::SetValue(size_type index, Float_t val)
+{
+  const auto& entry = m_entries.at(index);
+  if (entry.type != 'F') {
+    throw std::invalid_argument("Type mismatch: entry type '" + std::string(1, entry.type) + "' cannot store float value '" + entry.name + "'");
+  }
+  this->value<Float_t>(index) = val;
+}
+
+void QwRootTreeBranchVector::SetValue(size_type index, Int_t val)
+{
+  const auto& entry = m_entries.at(index);
+  if (entry.type != 'I') {
+    throw std::invalid_argument("Type mismatch: entry type '" + std::string(1, entry.type) + "' cannot store int value '" + entry.name + "'");
+  }
+  this->value<Int_t>(index) = val;
+}
+
+void QwRootTreeBranchVector::SetValue(size_type index, Long64_t val)
+{
+  const auto& entry = m_entries.at(index);
+  if (entry.type != 'L') {
+    throw std::invalid_argument("Type mismatch: entry type '" + std::string(1, entry.type) + "' cannot store long long value '" + entry.name + "'");
+  }
+  this->value<Long64_t>(index) = val;
+}
+
+void QwRootTreeBranchVector::SetValue(size_type index, Short_t val)
+{
+  const auto& entry = m_entries.at(index);
+  if (entry.type != 'S') {
+    throw std::invalid_argument("Type mismatch: entry type '" + std::string(1, entry.type) + "' cannot store short value '" + entry.name + "'");
+  }
+  this->value<Short_t>(index) = val;
+}
+
+void QwRootTreeBranchVector::SetValue(size_type index, UShort_t val)
+{
+  const auto& entry = m_entries.at(index);
+  if (entry.type != 's') {
+    throw std::invalid_argument("Type mismatch: entry type '" + std::string(1, entry.type) + "' cannot store short value '" + entry.name + "'");
+  }
+  this->value<UShort_t>(index) = val;
+}
+
+void QwRootTreeBranchVector::SetValue(size_type index, UInt_t val)
+{
+  const auto& entry = m_entries.at(index);
+  if (entry.type != 'i') {
+    throw std::invalid_argument("Type mismatch: entry type '" + std::string(1, entry.type) + "' cannot store unsigned int value '" + entry.name + "'");
+  }
+  this->value<UInt_t>(index) = val;
+}
+
+void QwRootTreeBranchVector::SetValue(size_type index, ULong64_t val)
+{
+  const auto& entry = m_entries.at(index);
+  if (entry.type != 'l') {
+    throw std::invalid_argument("Type mismatch: entry type '" + std::string(1, entry.type) + "' cannot store long long value '" + entry.name + "'");
+  }
+  this->value<ULong64_t>(index) = val;
+}
+
+void*       QwRootTreeBranchVector::data()           noexcept { return m_buffer.data(); }
+const void* QwRootTreeBranchVector::data()     const noexcept { return m_buffer.data(); }
+size_type   QwRootTreeBranchVector::data_size()const noexcept { return m_buffer.size(); }
+
+void QwRootTreeBranchVector::push_back(const std::string &name, const char type)
+{
+  const std::size_t entry_size = GetTypeSize(type);
+  const std::size_t offset = AlignOffset(m_buffer.size());
+
+  if (offset > m_buffer.capacity()) {
+    throw std::out_of_range("QwRootTreeBranchVector::push_back() requires buffer resize beyond reserved capacity");
+  }
+  if (offset > m_buffer.size()) {
+    m_buffer.resize(offset, 0u);
+  }
+
+  Entry entry{name, offset, entry_size, type};
+  m_entries.push_back(entry);
+
+  const std::size_t required = offset + entry_size;
+  if (required > m_buffer.capacity()) {
+    throw std::out_of_range("QwRootTreeBranchVector::push_back() requires buffer resize beyond reserved capacity");
+  }
+  if (required > m_buffer.size()) {
+    m_buffer.resize(required, 0u);
+  }
+}
+void QwRootTreeBranchVector::push_back(const TString& name, const char type)
+{
+  push_back(std::string(name.Data()), type);
+}
+
+void QwRootTreeBranchVector::push_back(const char* name, const char type)
+{
+	push_back(std::string(name), type);
+}
+
+std::string QwRootTreeBranchVector::LeafList(size_type start_index) const
+{
+  static const std::string separator = ":";
+  std::ostringstream stream;
+  bool first = true;
+  for (size_type index = start_index; index < m_entries.size(); ++index) {
+    const auto& entry = m_entries[index];
+    if (!first) {
+      stream << separator;
+    }
+    stream << entry.name << "/" << entry.type;
+    first = false;
+  }
+  return stream.str();
+}
+
+std::string QwRootTreeBranchVector::Dump(size_type start_index, size_type end_index) const
+{
+  std::ostringstream stream;
+  stream << "QwRootTreeBranchVector: " << m_entries.size() << " entries, "
+         << m_buffer.size() << " bytes\n";
+  size_t end_offset = (end_index == 0 || end_index > m_entries.size()) ?
+    m_buffer.size()
+    : m_entries[end_index - 1].offset + m_entries[end_index - 1].size;
+  stream << "QwRootTreeBranchVector: buffer at 0x" << std::hex << (void*) &m_buffer[0] << '\n';
+  stream << "QwRootTreeBranchVector: entries at 0x" << std::hex << (void*) &m_entries[0] << '\n';
+  for (size_t offset = m_entries[start_index].offset; offset < end_offset; offset += 4) {
+    stream << std::dec
+           << "  [" << offset << "] "
+           << std::hex
+           << " offset=0x" << offset
+           << " (0x" << std::setw(4) << std::setfill('0')
+                     << offset - m_entries[start_index].offset << ")"
+           << " buff=";
+    // Little-endian
+    for (std::size_t byte = 0; byte < 4; ++byte) {
+      stream << std::hex << std::setw(2) << std::setfill('0')
+             << static_cast<unsigned int>(m_buffer[offset + byte])
+             << " ";
+    }
+    stream << '\n';
+  }
+  end_index = (end_index == 0 || end_index > m_entries.size()) ?
+    m_entries.size()
+    : end_index;
+  for (size_type index = start_index; index < end_index; ++index) {
+    const auto& entry = m_entries[index];
+    stream << std::dec
+           << "  [" << index << "] "
+           << std::hex
+           << " offset=0x" << entry.offset
+           << " (0x" << std::setw(4) << std::setfill('0')
+                     << entry.offset - m_entries[start_index].offset << ")"
+           << " size=0x" << entry.size
+           << " buff=0x";
+    // Little-endian
+    for (std::size_t byte = GetTypeSize(entry.type); byte > 0; --byte) {
+      stream << std::hex << std::setw(2) << std::setfill('0')
+             << static_cast<unsigned int>((m_buffer.data() + entry.offset)[byte - 1]);
+    }
+    stream << std::dec
+           << " name=" << entry.name << "/" << entry.type
+           << " value=" << FormatValue(entry, index);
+    stream << '\n';
+  }
+  return stream.str();
+}
+
+std::size_t QwRootTreeBranchVector::GetTypeSize(char type)
+{
+  switch (type) {
+    case 'D':
+      return sizeof(double);
+    case 'F':
+      return sizeof(float);
+    case 'L':
+      return sizeof(long long);
+    case 'l':
+      return sizeof(unsigned long long);
+    case 'I':
+      return sizeof(int);
+    case 'i':
+      return sizeof(unsigned int);
+    case 'S':
+      return sizeof(short);
+    case 's':
+      return sizeof(unsigned short);
+    default:
+      throw std::invalid_argument("Unsupported branch type code: " + std::string(1, type));
+  }
+}
+std::size_t QwRootTreeBranchVector::AlignOffset(std::size_t offset)
+{
+  const std::size_t alignment = 4u;
+  return (offset + (alignment - 1u)) & ~(alignment - 1u);
+}
+
+std::string QwRootTreeBranchVector::FormatValue(const Entry& entry, size_type index) const
+{
+  switch (entry.type) {
+    case 'D':
+      return FormatNumeric(value<double>(index));
+    case 'F':
+      return FormatNumeric(value<float>(index));
+    case 'L':
+      return FormatNumeric(value<long long>(index));
+    case 'l':
+      return FormatNumeric(value<unsigned long long>(index));
+    case 'I':
+      return FormatNumeric(value<int>(index));
+    case 'i':
+      return FormatNumeric(value<unsigned int>(index));
+    case 'S':
+      return FormatNumeric(value<short>(index));
+    case 's':
+      return FormatNumeric(value<unsigned short>(index));
+    default:
+      return "<unknown>";
+  }
+}
+


### PR DESCRIPTION
# Issue
QwRootFile.h declares and defines four classes:
 - class QwRootFile
 - class QwRootNTuple
  - class QwRootTree
  - class QwTreeTreeBranchVector
 
all of which contain function templates. Function definitions are organized dis-jointly in the .cc and the .h file with the vast majority defined inline inside the class declaration. Furthermore, each writer implementation (QwRootNTuple, QwRootTree, and QwTreeTreeBranchVector) have similar method signatures, making it difficult to determine which class a method belongs to.

Overall, QwRootFile.h is 1589 lines of code making it extremely hard to navigate, reason about, and understand. 

# PR
 This PR aims to make the IO file(s) more manageable and easier to understand. This PR breaks QwRootFile.h into four separate files, each with their own implementation (6 new files, 8 files total)
 - QwRootTree.[h,cc]
 - QwRootRNTuple.[h,cc]
  - QwTreeTreeBranchVector.[h,cc]
  
 Function defintions are re-arranged accordingly: function templates are defined at the bottom of the header file and member functions are defined inside the implementation file. 
 
 This PR consists of superficial changes -- no feature or logic changes are intentional. 
 
 ### Caveats: 
 - End of the friendship
 The QwRootTree and QwRootRNTuple are no longer friend classes to QwRootFile. Friend classes make it harder to reason when a class' state may change. The use of friends for these classes were arguable unnecessary; it was used to access methods/members that either should be public to begin with, or have should have a public accessor function. 
 
 Examples:
 ```
 - Long64_t entries = tree->GetTree()->GetEntries(); // Requires friendship
        if (entries > 0) {...}
  + if (tree->GetNEntriesFilled() > 0) {                       // No friendship required
 ```
 and
 ```
 QwRootTree
 {
- private:
+ public:
  void SetPrescaling();
  void SetMaxTreeSize();
  void SetAutoFlush();
  void SetAutoSave();
  void SetBasketSize();
  ...;
  
}
 ```
 
 - Slight Function Signature Changes
 Some function signatures are tweaked to make them more consistent with similar functions 

 ```
 const std::string& QwRootNTuple::GetName()  const { return fName;  }
/// Get the description of the RNTuple
const std::string& QwRootNTuple::GetDesc()  const { return fDesc;  }
/// Get the prefix of the RNTuple
const std::string& QwRootNTuple::GetPrefix()const { return fPrefix;}
/// Get the object type
- std::string QwRootNTuple::GetType()  const { return fType; } 
+ const std::string& QwRootNTuple::GetType()  const { return fType; } 
 ```

To the best of my knowledge, none of these changes should have any effect. 


# Tests
This PR generates identical regalias with japan-MOLLER (latest commit 1adc28757b8f46f39498078defa85c6d23ed431a)
```
mrc@dell-xps:~/Github/Split_IO_Files$ diff regalias_4.C ../japan-MOLLER/regalias_4.C  -s
Files regalias_4.C and ../japan-MOLLER/regalias_4.C are identical
```

RNTuple output appears to be identical to TTree output from japan-MOLLER HEAD

TTree (TBrowser): bcm1h02a.block1_raw
<img width="1905" height="1068" alt="Screenshot 2025-11-17 201126" src="https://github.com/user-attachments/assets/433ae495-021a-48bf-9d31-f6ea42350b4a" />

RNTuple (uproot-browser): bcm1h02a.block1_raw
<img width="1893" height="1065" alt="Screenshot 2025-11-17 201339" src="https://github.com/user-attachments/assets/6a904f8f-f3bc-42aa-9633-d4e384dcd05a" />


TTree (TBrowser): asym_sm22
<img width="1917" height="1072" alt="Screenshot 2025-11-17 201528" src="https://github.com/user-attachments/assets/6cf81843-1192-4339-9112-632bf0abf5f0" />

RNTuple (uproot-browser): asym_sm22
<img width="1901" height="1106" alt="Screenshot 2025-11-17 201443" src="https://github.com/user-attachments/assets/195ffc81-5b93-42ab-80e6-4144307f26b2" />
