### PR TITLE
Enable pipefail for better error handling

### DIFF
--- a/Parity/prminput/mock_det_combiner.map
+++ b/Parity/prminput/mock_det_combiner.map
@@ -89,7 +89,7 @@ asym:tq27_r2, 0.03571
 asym:tq28_r2, 0.03571
 
 # Ring 3 all
-[asym:@asym_tq_r1]
+[asym:@asym_tq_r3]
 asym:tq01_r3, 0.03571
 asym:tq02_r3, 0.03571
 asym:tq03_r3, 0.03571


### PR DESCRIPTION
Added pipefail option to ensure command failures are caught. This should fix #251.