### PR TITLE
Added the '#include "TMath.h' line to two class definition files.

### DIFF
--- a/Analysis/src/QwMollerADC_Channel.cc
+++ b/Analysis/src/QwMollerADC_Channel.cc
@@ -7,6 +7,7 @@
 
 // System headers
 #include <stdexcept>
+#include "TMath.h"
 
 // Qweak headers
 #include "QwLog.h"
@@ -1695,11 +1696,11 @@ void QwMollerADC_Channel::CalculateRunningAverage()
       // Stability check 83951872
       if ((fStability>0) &&( (fErrorConfigFlag & kStabilityCut) == kStabilityCut)) {
         // check to see the channel has stability cut activated in the event cut file
-	if (GetValueWidth() > fStability){
-	  // if the width is greater than the stability required flag the event
-	  fErrorFlag = kBeamStabilityError;
-	} else
-	  fErrorFlag = 0;
+        if (GetValueWidth() > fStability){
+          // if the width is greater than the stability required flag the event
+          fErrorFlag = kBeamStabilityError;
+        } else
+          fErrorFlag = 0;
       }
     }
 }
@@ -1753,7 +1754,7 @@ void QwMollerADC_Channel::Blind(const QwBlinder *blinder)
     } else {
       blinder->ModifyThisErrorCode(fErrorFlag);
       for (Int_t i = 0; i < fBlocksPerEvent; i++)
-	fBlock[i] = QwBlinder::kValue_BlinderFail;
+        fBlock[i] = QwBlinder::kValue_BlinderFail;
       fHardwareBlockSum =  QwBlinder::kValue_BlinderFail;
     }
   }
@@ -1775,7 +1776,7 @@ void QwMollerADC_Channel::Blind(const QwBlinder *blinder, const QwMollerADC_Chan
     } else {
       blinder->ModifyThisErrorCode(fErrorFlag);//update the HW error code
       for (Int_t i = 0; i < fBlocksPerEvent; i++)
-	fBlock[i] = QwBlinder::kValue_BlinderFail * yield.fBlock[i];
+        fBlock[i] = QwBlinder::kValue_BlinderFail * yield.fBlock[i];
       fHardwareBlockSum = QwBlinder::kValue_BlinderFail * yield.fHardwareBlockSum;
     }
   }

--- a/Analysis/src/QwVQWK_Channel.cc
+++ b/Analysis/src/QwVQWK_Channel.cc
@@ -7,6 +7,7 @@
 
 // System headers
 #include <stdexcept>
+#include "TMath.h"
 
 // Qweak headers
 #include "QwLog.h"
@@ -1741,11 +1742,11 @@ void QwVQWK_Channel::CalculateRunningAverage()
       // Stability check 83951872
       if ((fStability>0) &&( (fErrorConfigFlag & kStabilityCut) == kStabilityCut)) {
         // check to see the channel has stability cut activated in the event cut file
-	if (GetValueWidth() > fStability){
-	  // if the width is greater than the stability required flag the event
-	  fErrorFlag = kBeamStabilityError;
-	} else
-	  fErrorFlag = 0;
+        if (GetValueWidth() > fStability){
+          // if the width is greater than the stability required flag the event
+          fErrorFlag = kBeamStabilityError;
+        } else
+          fErrorFlag = 0;
       }
     }
 }
@@ -1799,7 +1800,7 @@ void QwVQWK_Channel::Blind(const QwBlinder *blinder)
     } else {
       blinder->ModifyThisErrorCode(fErrorFlag);
       for (Int_t i = 0; i < fBlocksPerEvent; i++)
-	fBlock[i] = QwBlinder::kValue_BlinderFail;
+        fBlock[i] = QwBlinder::kValue_BlinderFail;
       fHardwareBlockSum =  QwBlinder::kValue_BlinderFail;
     }
   }
@@ -1821,7 +1822,7 @@ void QwVQWK_Channel::Blind(const QwBlinder *blinder, const QwVQWK_Channel& yield
     } else {
       blinder->ModifyThisErrorCode(fErrorFlag);//update the HW error code
       for (Int_t i = 0; i < fBlocksPerEvent; i++)
-	fBlock[i] = QwBlinder::kValue_BlinderFail * yield.fBlock[i];
+        fBlock[i] = QwBlinder::kValue_BlinderFail * yield.fBlock[i];
       fHardwareBlockSum = QwBlinder::kValue_BlinderFail * yield.fHardwareBlockSum;
     }
   }


### PR DESCRIPTION
The QwMollerADC_Channel and QwVQWK_Channel classes were the only ones which used TMath without having the include line.  This should now resolve issue #261.  It was tested on my Ubuntu machine with 6.38.00.

Additional changes were made by the pre-commit routines to adjust tabs/whitespace.