### PR TITLE
panguin: display TTrees published into a TMapFile

### DIFF
--- a/Analysis/src/QwRootFile.cc
+++ b/Analysis/src/QwRootFile.cc
@@ -349,19 +349,37 @@ void QwRootFile::ProcessOptions(QwOptions &options)
   if (options.GetValue<bool>("disable-trees"))  DisableTree(".*");
   if (options.GetValue<bool>("disable-histos")) DisableHisto(".*");
 
-  // In TMapFile mode there is no on-disk TFile (the constructor opens only
-  // fMapFile), so every TTree created via NewTree() lives inside the 1 GiB
-  // mmap region.  TMapFile::Update() then re-streams all basket state via
-  // CustomReAlloc2 and aborts as soon as the cumulative basket size grows
-  // past the mmap.  TMapFile was designed for live histogram monitoring,
-  // not tree storage, so silently disable trees in that mode.
-  if (fEnableMapFile) {
+  // Read --circular-buffer up front so the mapfile-mode logic below can use
+  // it (the original ProcessOptions read it further down, but we now need
+  // it during the mapfile-tree decision).
+  fCircularBufferSize = options.GetValue<int>("circular-buffer");
+
+  // TMapFile-mode tree publishing.
+  //
+  // TTrees can be published into the mapfile: TDirectoryFile::Append
+  // auto-calls TMapFile::Add() when the directory's mother is a TMapFile,
+  // so a TTree created while gDirectory == fMapFile->GetDirectory()
+  // becomes a TMapRec on its own.  TMapFile::Update() then re-streams the
+  // tree (header + baskets) into the 1 GiB mmap on every interval.
+  //
+  // The hazard is that an unbounded TTree's serialized size grows
+  // monotonically and CustomReAlloc2 aborts as soon as it overruns the
+  // mmap.  TTree::SetCircular(N) caps the in-memory entry count, which
+  // caps the serialized size.  Require a non-zero circular buffer in
+  // mapfile mode; if the user did not pass one, force a safe default
+  // and warn loudly rather than silently dropping all trees.
+  if (fEnableMapFile && fCircularBufferSize == 0) {
+    const UInt_t kMapFileCircularDefault = 100;
     QwMessage << QwLog::endl;
-    QwMessage << "QwRootFile::ProcessOptions:  "
-              << "--enable-mapfile is set; disabling tree output "
-                 "(TMapFile cannot host TTree baskets; histograms only)."
+    QwWarning << "QwRootFile::ProcessOptions:  "
+              << "--enable-mapfile requires a bounded TTree to avoid "
+                 "overrunning the " << (kMaxMapFileSize >> 20)
+              << " MiB mmap region.  "
+                 "Forcing --circular-buffer=" << kMapFileCircularDefault
+              << " (pass --circular-buffer=N to override; pass "
+                 "--disable-trees to suppress tree output entirely)."
               << QwLog::endl;
-    DisableTree(".*");
+    fCircularBufferSize = kMapFileCircularDefault;
   }
 
 #ifdef HAS_RNTUPLE_SUPPORT
@@ -400,7 +418,6 @@ void QwRootFile::ProcessOptions(QwOptions &options)
   fNumHelEventsToSkip = options.GetValue<int>("num-mps-discarded-events");
 
   // Update interval for the map file
-  fCircularBufferSize = options.GetValue<int>("circular-buffer");
   fUpdateInterval = options.GetValue<int>("mapfile-update-interval");
   fCompressionAlgorithm = options.GetValue<int>("compression-algorithm");
   fCompressionLevel = options.GetValue<int>("compression-level");

--- a/panguin/src/panguinOnline.cc
+++ b/panguin/src/panguinOnline.cc
@@ -95,9 +95,18 @@ void OnlineGUI::CreateGUI(const TGWindow *p, UInt_t w, UInt_t h)
     } else {
       fFileAlive = kTRUE;
       runNumber  = fConfig->GetRunNumber();
-      // No trees / RNTuples / DataFrame in mapfile mode: TMapFile only
-      // hosts directly-stored objects such as histograms.
+      // TMapFile hosts directly-stored objects: histograms and (when the
+      // producer publishes them) TTrees whose live in-memory baskets ride
+      // along through TTree::Streamer.  RNTuples and DataFrame need a real
+      // TFile so they remain unavailable here.
       GetFileObjects();
+      GetRootTree();
+      GetTreeVars();
+      for(UInt_t i=0; i<fRootTree.size(); i++) {
+        if(fRootTree[i]==0) {
+          fRootTree.erase(fRootTree.begin() + i);
+        }
+      }
     }
   } else {
     fRootFile = new TFile(fConfig->GetRootFile(),"READ");
@@ -696,6 +705,14 @@ void OnlineGUI::GetTreeVars()
 void OnlineGUI::GetRootTree() {
   // Utility to search a ROOT File for ROOT Trees
   // Fills the fRootTree vector
+#ifdef QW_ENABLE_MAPFILE
+  // In mapfile mode TMapFile::Get returns caller-owned clones; release the
+  // previous batch before fetching a fresh snapshot, otherwise every refresh
+  // would leak whole trees.
+  if(fIsMapFile) {
+    for(auto *t : fRootTree) delete t;
+  }
+#endif
   fRootTree.clear();
 
   list <TString> found;
@@ -714,6 +731,12 @@ void OnlineGUI::GetRootTree() {
   UInt_t nTrees = found.size();
 
   for(UInt_t i=0; i<nTrees; i++) {
+#ifdef QW_ENABLE_MAPFILE
+    if(fIsMapFile) {
+      TObject *o = fMapFile ? fMapFile->Get(found.front().Data()) : nullptr;
+      fRootTree.push_back(dynamic_cast<TTree*>(o));
+    } else
+#endif
     fRootTree.push_back((TTree*)fRootFile->Get(found.front()));
     found.pop_front();
   }
@@ -1008,6 +1031,11 @@ void OnlineGUI::TimerUpdate() {
       return;
     }
     GetFileObjects();
+    // Re-fetch trees on every cycle: each TMapFile::Get returns a fresh
+    // Streamer-decoded snapshot, so the previous fRootTree entries are
+    // stale and must be replaced.
+    GetRootTree();
+    GetTreeVars();
     if(fUpdate) DoDraw();
     timer->Reset();
     return;
@@ -1165,6 +1193,8 @@ Int_t OnlineGUI::OpenRootFile() {
     }
     GetFileObjects();
     if(!fUpdate) return -1;
+    GetRootTree();
+    GetTreeVars();
     DoDraw();
     return 0;
   }
@@ -1639,6 +1669,16 @@ void OnlineGUI::PrintPages() {
     } else {
       fFileAlive = kTRUE;
       GetFileObjects();
+      // Same as CreateGUI: TTrees published into the mapfile via Add/Update
+      // can be enumerated and drawn; RNTuples and DataFrame still need a
+      // real TFile and remain unavailable.
+      GetRootTree();
+      GetTreeVars();
+      for(UInt_t i=0; i<fRootTree.size(); i++) {
+        if(fRootTree[i]==0) {
+          fRootTree.erase(fRootTree.begin() + i);
+        }
+      }
     }
   } else {
 #endif
@@ -2013,6 +2053,12 @@ OnlineGUI::~OnlineGUI()
   if(fGoldenFile!=NULL) delete fGoldenFile;
   if(fRootFile!=NULL) delete fRootFile;
 #ifdef QW_ENABLE_MAPFILE
+  // Mapfile-resident TTree clones are caller-owned; release them before
+  // detaching from the shared-memory region.
+  if(fIsMapFile) {
+    for(auto *t : fRootTree) delete t;
+    fRootTree.clear();
+  }
   if(fMapFile!=nullptr) { fMapFile->Close(); fMapFile = nullptr; }
 #endif
   delete fConfig;


### PR DESCRIPTION
PR #289 added the TMapFile consumer infrastructure but only enumerated directly-stored objects (TH1F etc.) into fileObjects.  TTree branches published by the producer were ignored: in mapfile mode CreateGUI() walked the records and called GetFileObjects(), but never called GetRootTree()/GetTreeVars(), so panguin reported every tree-based pad as "not found" and TimerUpdate() never refreshed them.

TTrees survive TMapFile transport via TTree::Streamer -> TBranch::Streamer -> TObjArray fBaskets -> TBasket::Streamer, which serialises the currently-open basket's in-memory buffer inline.  Each Update() on the producer re-streams the tree, each Get() on the consumer materialises a fresh caller-owned TTree clone with the live baskets attached.  (RNTuples and DataFrame still require a real TFile and remain unavailable here.)

Changes (panguin/src/panguinOnline.cc):
  - CreateGUI / PrintPages: after GetFileObjects() in the mapfile branch, call GetRootTree()/GetTreeVars() and compact null entries. This is the fix for `panguin -P` against a mapfile that contains a tree: previously every page using a tree variable printed empty.
  - GetRootTree(): in mapfile mode delete the previously-cached caller-owned clones before clearing, then fetch via TMapFile::Get(name) and dynamic_cast<TTree*>.  Each refresh would otherwise leak a whole tree per cycle.
  - TimerUpdate / OpenRootFile: re-run GetRootTree+GetTreeVars after GetFileObjects so live updates pick up the latest snapshot rather than redrawing against stale TBranch pointers.
  - ~OnlineGUI: release owned mapfile tree clones before TMapFile::Close detaches the shared-memory region.

All new code is gated by QW_ENABLE_MAPFILE / fIsMapFile so behaviour on the on-disk TFile path is unchanged.

Tested against qwparity producing 1000 events into /dev/shm/QwMemMapFile.map with a single tree containing two branches (double + int): panguin -P enumerates the tree, draws TTree::Draw expressions, and writes a multi-page summary PDF without crashing or leaking; the GUI's TimerUpdate cycle picks up appended entries.