### PR TITLE
QwVQWK_Channel Fix

### DIFF
--- a/Analysis/src/QwVQWK_Channel.cc
+++ b/Analysis/src/QwVQWK_Channel.cc
@@ -799,7 +799,7 @@ void  QwVQWK_Channel::ConstructBranchAndVector(TTree *tree, TString &prefix, QwR
 
   fTreeArrayNumEntries = values.size() - fTreeArrayIndex;
 
-  std::string leaf_list = values.LeafList();
+  std::string leaf_list = values.LeafList(fTreeArrayIndex);
 
   if (gQwHists.MatchDeviceParamsFromList(basename.Data())
     && (bHw_sum || bBlock || bNum_samples || bDevice_Error_Code ||

--- a/Parity/src/QwBeamLine.cc
+++ b/Parity/src/QwBeamLine.cc
@@ -1195,7 +1195,7 @@ Int_t QwBeamLine::ProcessEvBuffer(const ROCID_t roc_id, const BankID_t bank_id, 
 		    std::cout<<"word left to read in this buffer:"<<num_words-fBeamDetectorID[i].fWordInSubbank<<std::endl;
 		  }
 		fStripline[fBeamDetectorID[i].fIndex].get()->
-		  ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank - 1]),
+		  ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank]),
 				  num_words-fBeamDetectorID[i].fWordInSubbank,
 				  fBeamDetectorID[i].fSubelement);
 	      }
@@ -1208,7 +1208,7 @@ Int_t QwBeamLine::ProcessEvBuffer(const ROCID_t roc_id, const BankID_t bank_id, 
 		    std::cout<<"word left to read in this buffer:"<<num_words-fBeamDetectorID[i].fWordInSubbank<<std::endl;
 		  }
 		fQPD[fBeamDetectorID[i].fIndex].
-		  ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank - 1]),
+		  ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank]),
 				  num_words-fBeamDetectorID[i].fWordInSubbank,
 				  fBeamDetectorID[i].fSubelement);
 	      }
@@ -1221,7 +1221,7 @@ Int_t QwBeamLine::ProcessEvBuffer(const ROCID_t roc_id, const BankID_t bank_id, 
 		    std::cout<<"word left to read in this buffer:"<<num_words-fBeamDetectorID[i].fWordInSubbank<<std::endl;
 		  }
 		fLinearArray[fBeamDetectorID[i].fIndex].
-		  ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank - 1]),
+		  ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank]),
 				  num_words-fBeamDetectorID[i].fWordInSubbank,
 				  fBeamDetectorID[i].fSubelement);
 
@@ -1235,7 +1235,7 @@ Int_t QwBeamLine::ProcessEvBuffer(const ROCID_t roc_id, const BankID_t bank_id, 
 		    std::cout<<"word left to read in this buffer:"<<num_words-fBeamDetectorID[i].fWordInSubbank<<std::endl;
 		  }
 		fCavity[fBeamDetectorID[i].fIndex].
-		  ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank - 1]),
+		  ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank]),
 				  num_words-fBeamDetectorID[i].fWordInSubbank,
 				  fBeamDetectorID[i].fSubelement);
 	      }
@@ -1248,7 +1248,7 @@ Int_t QwBeamLine::ProcessEvBuffer(const ROCID_t roc_id, const BankID_t bank_id, 
 		    std::cout<<"word left to read in this buffer:"<<num_words-fBeamDetectorID[i].fWordInSubbank<<std::endl;
 		  }
 		fBCM[fBeamDetectorID[i].fIndex].get()->
-		  ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank - 1]),
+		  ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank]),
 				  num_words-fBeamDetectorID[i].fWordInSubbank);
 	      }
 
@@ -1260,7 +1260,7 @@ Int_t QwBeamLine::ProcessEvBuffer(const ROCID_t roc_id, const BankID_t bank_id, 
 		    std::cout<<"word left to read in this buffer:"<<num_words-fBeamDetectorID[i].fWordInSubbank<<std::endl;
 		  }
 		fClock[fBeamDetectorID[i].fIndex].get()->
-		  ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank - 1]),
+		  ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank]),
 				  num_words-fBeamDetectorID[i].fWordInSubbank);
 	      }
 
@@ -1272,7 +1272,7 @@ Int_t QwBeamLine::ProcessEvBuffer(const ROCID_t roc_id, const BankID_t bank_id, 
 		    std::cout<<"word left to read in this buffer:"<<num_words-fBeamDetectorID[i].fWordInSubbank<<std::endl;
 		  }
 		fHaloMonitor[fBeamDetectorID[i].fIndex].
-		  ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank - 1]),
+		  ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank]),
 				  num_words-fBeamDetectorID[i].fWordInSubbank);
 	      }
 

--- a/Parity/src/QwBeamLine.cc
+++ b/Parity/src/QwBeamLine.cc
@@ -1195,7 +1195,7 @@ Int_t QwBeamLine::ProcessEvBuffer(const ROCID_t roc_id, const BankID_t bank_id, 
 		    std::cout<<"word left to read in this buffer:"<<num_words-fBeamDetectorID[i].fWordInSubbank<<std::endl;
 		  }
 		fStripline[fBeamDetectorID[i].fIndex].get()->
-		  ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank]),
+		  ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank - 1]),
 				  num_words-fBeamDetectorID[i].fWordInSubbank,
 				  fBeamDetectorID[i].fSubelement);
 	      }
@@ -1208,7 +1208,7 @@ Int_t QwBeamLine::ProcessEvBuffer(const ROCID_t roc_id, const BankID_t bank_id, 
 		    std::cout<<"word left to read in this buffer:"<<num_words-fBeamDetectorID[i].fWordInSubbank<<std::endl;
 		  }
 		fQPD[fBeamDetectorID[i].fIndex].
-		  ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank]),
+		  ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank - 1]),
 				  num_words-fBeamDetectorID[i].fWordInSubbank,
 				  fBeamDetectorID[i].fSubelement);
 	      }
@@ -1221,7 +1221,7 @@ Int_t QwBeamLine::ProcessEvBuffer(const ROCID_t roc_id, const BankID_t bank_id, 
 		    std::cout<<"word left to read in this buffer:"<<num_words-fBeamDetectorID[i].fWordInSubbank<<std::endl;
 		  }
 		fLinearArray[fBeamDetectorID[i].fIndex].
-		  ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank]),
+		  ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank - 1]),
 				  num_words-fBeamDetectorID[i].fWordInSubbank,
 				  fBeamDetectorID[i].fSubelement);
 
@@ -1235,7 +1235,7 @@ Int_t QwBeamLine::ProcessEvBuffer(const ROCID_t roc_id, const BankID_t bank_id, 
 		    std::cout<<"word left to read in this buffer:"<<num_words-fBeamDetectorID[i].fWordInSubbank<<std::endl;
 		  }
 		fCavity[fBeamDetectorID[i].fIndex].
-		  ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank]),
+		  ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank - 1]),
 				  num_words-fBeamDetectorID[i].fWordInSubbank,
 				  fBeamDetectorID[i].fSubelement);
 	      }
@@ -1248,7 +1248,7 @@ Int_t QwBeamLine::ProcessEvBuffer(const ROCID_t roc_id, const BankID_t bank_id, 
 		    std::cout<<"word left to read in this buffer:"<<num_words-fBeamDetectorID[i].fWordInSubbank<<std::endl;
 		  }
 		fBCM[fBeamDetectorID[i].fIndex].get()->
-		  ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank]),
+		  ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank - 1]),
 				  num_words-fBeamDetectorID[i].fWordInSubbank);
 	      }
 
@@ -1260,7 +1260,7 @@ Int_t QwBeamLine::ProcessEvBuffer(const ROCID_t roc_id, const BankID_t bank_id, 
 		    std::cout<<"word left to read in this buffer:"<<num_words-fBeamDetectorID[i].fWordInSubbank<<std::endl;
 		  }
 		fClock[fBeamDetectorID[i].fIndex].get()->
-		  ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank]),
+		  ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank - 1]),
 				  num_words-fBeamDetectorID[i].fWordInSubbank);
 	      }
 
@@ -1272,7 +1272,7 @@ Int_t QwBeamLine::ProcessEvBuffer(const ROCID_t roc_id, const BankID_t bank_id, 
 		    std::cout<<"word left to read in this buffer:"<<num_words-fBeamDetectorID[i].fWordInSubbank<<std::endl;
 		  }
 		fHaloMonitor[fBeamDetectorID[i].fIndex].
-		  ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank]),
+		  ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank - 1]),
 				  num_words-fBeamDetectorID[i].fWordInSubbank);
 	      }
 


### PR DESCRIPTION
# Overview
japan-MOLLER is being tested on a Linux-based crate that contains VQWK modules. Two issues were noticed when trying to decode VQWK data:

1. The data decoded did not match the raw data
2. The branch list was not what was expected

~~#### 1) Incorrect Decoding~~
~~How we select the buffer location is 1-index rather than 0-index. This results in an off-by-one error~~
```
 ProcessEvBuffer(&(buffer[fBeamDetectorID[i].fWordInSubbank ]), <--- fWordInSubbank starts at 1
                num_words-fBeamDetectorID[i].fWordInSubbank,
                   fBeamDetectorID[i].fSubelement);
```
##### Update
The channel mapfile used, at_chan.map, included the line `vqwk_buffer_offset=1`. This causes the fWordInSubbank to start from 1. Removing this line and reverting commit 431fa42 gives the expected output.

#### 2) VQWK Branch Error
The VQWK Branch erroneously included
```
CodaEventNumber
CodaEventType
Coda_CleanData1
Coda_CleanData1
[ Actual Data Structure ]
```
When constructing the branch list in QwVQWK_Channel::ConstructBranchAndVector, and index argument was missing
```
  std::string leaf_list = values.LeafList(); <-- missing starting index argument
```
This also resulted in the ROOT file storing garbage data.

# Pre-PR
<img width="241" height="367" alt="image" src="https://github.com/user-attachments/assets/018c2a94-7573-46ec-80a0-78b1cbb6ba9b" />

Data structure is 6 data words where `(word[5] & 0xFFFF000) >> 16` is the number of samples. Expected is 2000 samples (0x07d0)

<img width="945" height="97" alt="image" src="https://github.com/user-attachments/assets/7f64397b-0a0b-40c9-a9d3-091e5527f346" />

# After PR
<img width="225" height="333" alt="image" src="https://github.com/user-attachments/assets/b81a920f-ee29-4fda-b965-93b7f2e6c165" />

Expected is 2000 samples (0x07d0)

<img width="939" height="115" alt="image" src="https://github.com/user-attachments/assets/0fb3a545-c334-4050-90d2-32d67f6a14a7" />

#### Possible outstanding issue...?
The first entry in the tree appears to be an empty entry. 


```
root [4] evt->Scan("qwk_bcm0.hw_sum:qwk_bcm0.num_samples:qwk_bcm0.sequence_number")
************************************************
*    Row   * qwk_bcm0. * qwk_bcm0. * qwk_bcm0. *
************************************************
*        0 *         0 *         0 *         0 *
*        1 * -0.012736 *      2000 *         0 *
*        2 * -0.012715 *      2000 *         1 *
*        3 * -0.012734 *      2000 *         2 *
*        4 * -0.012767 *      2000 *         3 *
*        5 * -0.012764 *      2000 *         4 *
*        6 * -0.012713 *      2000 *         5 *
*        7 * -0.012783 *      2000 *         6 *
*        8 * -0.012736 *      2000 *         7 *
*        9 * -0.012737 *      2000 *         8 *
*       10 * -0.012739 *      2000 *         9 *
*       11 * -0.012733 *      2000 *        10 *
*       12 * -0.012776 *      2000 *        11 *
*       13 * -0.012751 *      2000 *        12 *
*       14 * -0.012749 *      2000 *        13 *
*       15 * -0.012741 *      2000 *        14 *
*       16 * -0.012793 *      2000 *        15 *
*       17 * -0.012759 *      2000 *        16 *
*       18 * -0.012729 *      2000 *        17 *
*       19 * -0.012713 *      2000 *        18 *
*       20 * -0.012677 *      2000 *        19 *
*       21 * -0.012722 *      2000 *        20 *
*       22 * -0.012695 *      2000 *        21 *
*       23 * -0.012757 *      2000 *        22 *
*       24 * -0.012749 *      2000 *        23 *
```

### Test Program
Command
```
./build/qwparity -c at.conf --data ./ -r 15
```
Required config files and example data file are located in 
[test.tar.gz](https://github.com/user-attachments/files/29069451/test.tar.gz)
`test/`
