### PR TITLE
fix: address compilation errors and warnings with gcc-15

### DIFF
--- a/Analysis/include/QwParameterFile.h
+++ b/Analysis/include/QwParameterFile.h
@@ -8,6 +8,7 @@
 #pragma once
 
 // System headers
+#include <algorithm>
 #include <vector>
 #include <iostream>
 #include <sstream>

--- a/Analysis/include/QwParameterFile.h
+++ b/Analysis/include/QwParameterFile.h
@@ -9,6 +9,7 @@
 
 // System headers
 #include <algorithm>
+#include <cctype>
 #include <vector>
 #include <iostream>
 #include <sstream>

--- a/Parity/src/GrandCorrelator.cc
+++ b/Parity/src/GrandCorrelator.cc
@@ -120,8 +120,8 @@ void GrandCorrelator::ProcessData()
   //TVectorD Y(fDependentValues.size(),   fDependentValues.data());
   //operator+= (std::make_pair(P, Y));
 
-  for(int i = 0; i<fAllVar.size(); ++i){
-    for(int j = i; j<fAllVar.size(); ++j){
+  for(size_t i = 0; i<fAllVar.size(); ++i){
+    for(size_t j = i; j<fAllVar.size(); ++j){
         if(!fAllGood[i] || !fAllGood[j]) continue;
 
         double xi = fAllValues[i];
@@ -1220,8 +1220,8 @@ void GrandCorrelator::solve()
 {
 //==========================================================
 //Solve step 1
-for(int i = 0; i < fAllVar.size(); ++i){
-    for(int j = i; j < fAllVar.size(); ++j){
+for(size_t i = 0; i < fAllVar.size(); ++i){
+    for(size_t j = i; j < fAllVar.size(); ++j){
       if(mNij(i,j) >= 2){
         mVij(i,j) = mCij(i,j) / (mNij(i,j) - 1.);
         sigma_ij(i,j) = sqrt((mSij(i,j)) / (mNij(i,j) - 1.));
@@ -1297,8 +1297,8 @@ for(int i = 0; i < fAllVar.size(); ++i){
   mVY = TMatrixDDiag(sigmaY);
 
   // "Clean" matrices
-  for(int i = 0; i < fAllVar.size(); ++i){
-    for(int j = i; j < fAllVar.size(); ++j){
+  for(size_t i = 0; i < fAllVar.size(); ++i){
+    for(size_t j = i; j < fAllVar.size(); ++j){
       if(i < 5 && j < 5){
       }
         mVFULL_clean(i,j) = mRij(i,j) * sigma_ij(i,j) * sigma_ji(j,i) * (fGoodEventNumber - 1);

--- a/Parity/src/GrandCorrelator.cc
+++ b/Parity/src/GrandCorrelator.cc
@@ -749,10 +749,10 @@ GrandCorrelator::GrandCorrelator()
 //=================================================
 //=================================================
 GrandCorrelator::GrandCorrelator(const GrandCorrelator& source)
-: nP(source.nP),nY(source.nY),
+: VQwDataHandler(source),
+  nP(source.nP),nY(source.nY),
   fErrorFlag(-1),
   fGoodEventNumber(0),
-  VQwDataHandler(source),
   fBlock(source.fBlock),
   fDisableHistos(source.fDisableHistos),
   fAlphaOutputFileBase(source.fAlphaOutputFileBase),

--- a/Parity/src/GrandCorrelator.cc
+++ b/Parity/src/GrandCorrelator.cc
@@ -750,9 +750,6 @@ GrandCorrelator::GrandCorrelator()
 //=================================================
 GrandCorrelator::GrandCorrelator(const GrandCorrelator& source)
 : VQwDataHandler(source),
-  nP(source.nP),nY(source.nY),
-  fErrorFlag(-1),
-  fGoodEventNumber(0),
   fBlock(source.fBlock),
   fDisableHistos(source.fDisableHistos),
   fAlphaOutputFileBase(source.fAlphaOutputFileBase),
@@ -763,7 +760,10 @@ GrandCorrelator::GrandCorrelator(const GrandCorrelator& source)
   fAliasOutputFileBase(source.fAliasOutputFileBase),
   fAliasOutputFileSuff(source.fAliasOutputFileSuff),
   fAliasOutputPath(source.fAliasOutputPath),
-  fCycleCounter(source.fCycleCounter)
+  nP(source.nP),nY(source.nY),
+  fCycleCounter(source.fCycleCounter),
+  fErrorFlag(-1),
+  fGoodEventNumber(0)
 {
   QwMessage << fGoodEventNumber << QwLog::endl;
 

--- a/Parity/src/QwCorrelatorNew.cc
+++ b/Parity/src/QwCorrelatorNew.cc
@@ -707,10 +707,10 @@ QwCorrelatorNew::QwCorrelatorNew()
 //=================================================
 //=================================================
 QwCorrelatorNew::QwCorrelatorNew(const QwCorrelatorNew& source)
-: nP(source.nP),nY(source.nY),
+: VQwDataHandler(source),
+  nP(source.nP),nY(source.nY),
   fErrorFlag(-1),
   fGoodEventNumber(0),
-  VQwDataHandler(source),
   fBlock(source.fBlock),
   fDisableHistos(source.fDisableHistos),
   fAlphaOutputFileBase(source.fAlphaOutputFileBase),

--- a/Parity/src/QwCorrelatorNew.cc
+++ b/Parity/src/QwCorrelatorNew.cc
@@ -708,9 +708,6 @@ QwCorrelatorNew::QwCorrelatorNew()
 //=================================================
 QwCorrelatorNew::QwCorrelatorNew(const QwCorrelatorNew& source)
 : VQwDataHandler(source),
-  nP(source.nP),nY(source.nY),
-  fErrorFlag(-1),
-  fGoodEventNumber(0),
   fBlock(source.fBlock),
   fDisableHistos(source.fDisableHistos),
   fAlphaOutputFileBase(source.fAlphaOutputFileBase),
@@ -721,7 +718,10 @@ QwCorrelatorNew::QwCorrelatorNew(const QwCorrelatorNew& source)
   fAliasOutputFileBase(source.fAliasOutputFileBase),
   fAliasOutputFileSuff(source.fAliasOutputFileSuff),
   fAliasOutputPath(source.fAliasOutputPath),
-  fCycleCounter(source.fCycleCounter)
+  nP(source.nP),nY(source.nY),
+  fCycleCounter(source.fCycleCounter),
+  fErrorFlag(-1),
+  fGoodEventNumber(0)
 {
   QwMessage << fGoodEventNumber << QwLog::endl;
 


### PR DESCRIPTION
This PR addresses three compilation errors and warnings with gcc-15:
- missing `algorithm` header for use of `std::transform`,
- warnings for comparison of signed `int` with `size()` in for loops,
- warnings for incorrect copy constructor initializer ordering.

No impact on outputs expected.