### PR TITLE
QwWord::fValue type mismatch for QwTreeBranchVector

### DIFF
--- a/Parity/src/QwBeamMod.cc
+++ b/Parity/src/QwBeamMod.cc
@@ -806,7 +806,7 @@ void QwBeamMod::ConstructBranchAndVector(TTree *tree, TString & prefix, QwRootTr
     // 	  basename = fWord[i].fWordName;
     basename = prefix(0, (prefix.First("|") >= 0)? prefix.First("|"): prefix.Length());
     basename += fWord[i].fWordName;
-    values.push_back(basename.Data(), 'D');
+    values.push_back(basename.Data(), 'I');
     tree->Branch(basename, &(values[fTreeArrayIndex + i]), values.LeafList(fTreeArrayIndex + i).c_str());
   }
 }


### PR DESCRIPTION
# Overview

QwWord::fValue is of type int, however, QwBeamMod::ConstructBranchAndVector treats it as if it were a double. This causes an unhandled exception to be thrown when filling the tree.

# Issue

```
terminate called after throwing an instance of 'std::invalid_argument'
  what():  Type mismatch: entry type 'D' cannot store int value 'cleandata'
(gdb) where
...
#7  0x00007ffff7c54a0b in QwRootTreeBranchVector::SetValue (this=0x5e830b0, index=5132, val=0)
    at /adaqfs/home/moller-onl/users/mrc/japan-MOLLER/Analysis/include/QwRootFile.h:129
#8  0x00007ffff7d45e46 in QwBeamMod::FillTreeVector (this=0x3451c70, values=...) at /adaqfs/home/moller-onl/users/mrc/japan-MOLLER/Parity/src/QwBeamMod.cc:829
...
(gdb) list /adaqfs/home/moller-onl/users/mrc/japan-MOLLER/Parity/src/QwBeamMod.cc:829
824	  for (size_t i = 0; i < fModChannel.size(); i++){
825	    fModChannel[i]->FillTreeVector(values);
826	    // fModChannel[i]->PrintValue();
827	  }
828	  for (size_t i = 0; i < fWord.size(); i++){
829	    values.SetValue(index++, fWord[i].fValue);
830	  }
```