### PR TITLE
fix: avoid a full subsystem copy by passing pointers from event ring

### DIFF
--- a/Parity/include/QwHelicityPattern.h
+++ b/Parity/include/QwHelicityPattern.h
@@ -222,6 +222,7 @@ class QwHelicityPattern {
  protected:
 
   std::vector<QwSubsystemArrayParity> fEvents;
+  std::vector<const QwSubsystemArrayParity*> fEventPtrs;
   std::vector<Bool_t> fEventLoaded;
   std::vector<Int_t> fHelicity;// this is here up to when we code the Helicity decoding routine
   std::vector<Int_t> fEventNumber;
@@ -287,6 +288,13 @@ class QwHelicityPattern {
   // Flag to indicate that the pattern contains data
   Bool_t fIsDataLoaded;
   void SetDataLoaded(Bool_t flag) { fIsDataLoaded = flag; };
+
+  const QwSubsystemArrayParity& GetEventForPhase(size_t phase) const {
+    if (phase < fEventPtrs.size() && fEventPtrs[phase] != nullptr) {
+      return *(fEventPtrs[phase]);
+    }
+    return fEvents.at(phase);
+  }
 
   friend class QwDataHandlerArray;
 };

--- a/Parity/include/QwHelicityPattern.h
+++ b/Parity/include/QwHelicityPattern.h
@@ -53,6 +53,10 @@ class QwHelicityPattern {
   QwHelicityPattern(QwSubsystemArrayParity &event, const TString &run = "0");
   /// \brief Copy constructor by reference
   QwHelicityPattern(const QwHelicityPattern& source);
+  /// \brief Copy-assignment deleted: fEventPtrs are raw pointers into fEvents;
+  /// a compiler-generated assignment would shallow-copy them, leaving the
+  /// target pointing at the source's (or ring-owned) storage.
+  QwHelicityPattern& operator=(const QwHelicityPattern&) = delete;
   /// Virtual destructor
   virtual ~QwHelicityPattern() { };
 

--- a/Parity/main/QwParity.cc
+++ b/Parity/main/QwParity.cc
@@ -359,7 +359,8 @@ Int_t main(Int_t argc, Char_t* argv[])
 
         // Check to see ring is ready
         if (eventring.IsReady()) {
-	  ringoutput = eventring.pop();
+	  QwSubsystemArrayParity& ringevent = eventring.pop();
+	  ringoutput = ringevent;
 	  ringoutput.IncrementErrorCounters();
 
 
@@ -394,7 +395,8 @@ Int_t main(Int_t argc, Char_t* argv[])
 #endif
 
           // Load the event into the helicity pattern
-          helicitypattern.LoadEventData(ringoutput);
+          // ringoutput is reused each loop iteration; load from stable ring storage.
+          helicitypattern.LoadEventData(ringevent);
 
 	  if (helicitypattern.PairAsymmetryIsGood()) {
             patternsum.AccumulatePairRunningSum(helicitypattern);

--- a/Parity/main/QwParity.cc
+++ b/Parity/main/QwParity.cc
@@ -360,6 +360,13 @@ Int_t main(Int_t argc, Char_t* argv[])
         // Check to see ring is ready
         if (eventring.IsReady()) {
 	  QwSubsystemArrayParity& ringevent = eventring.pop();
+	  // Copy ring event into ringoutput: this is required because ringoutput
+	  // has its tree branches, histograms, and RNTuple fields bound to its
+	  // internal memory layout (set up during initialization above).  The
+	  // copy populates that bound buffer each event.  The optimization in
+	  // this commit eliminates the separate per-phase deep copy that
+	  // LoadEventData previously performed (fEvents[phase] = event), not
+	  // this copy into ringoutput.
 	  ringoutput = ringevent;
 	  ringoutput.IncrementErrorCounters();
 

--- a/Parity/src/QwHelicityPattern.cc
+++ b/Parity/src/QwHelicityPattern.cc
@@ -174,9 +174,13 @@ QwHelicityPattern::QwHelicityPattern(QwSubsystemArrayParity &event, const TStrin
       if(fPatternSize%2 == 0)
         {
           fEvents.resize(fPatternSize,event);
+          fEventPtrs.resize(fPatternSize,nullptr);
           fHelicity.resize(fPatternSize,-9999);
           fEventNumber.resize(fPatternSize,-1);
           fEventLoaded.resize(fPatternSize,kFALSE);
+          for (size_t i = 0; i < fPatternSize; ++i) {
+            fEventPtrs[i] = &(fEvents[i]);
+          }
 
           // Initialize the pattern number
           fQuartetNumber = 0;
@@ -231,6 +235,20 @@ QwHelicityPattern::QwHelicityPattern(const QwHelicityPattern &source)
   fPatternIsGood(false),
   fIsDataLoaded(false)
 {
+  fEvents.resize(fPatternSize, source.fYield);
+  fEventPtrs.resize(fPatternSize, nullptr);
+  fHelicity.resize(fPatternSize, -9999);
+  fEventNumber.resize(fPatternSize, -1);
+  fEventLoaded.resize(fPatternSize, kFALSE);
+  for (size_t i = 0; i < fPatternSize; ++i) {
+    fEventPtrs[i] = &(fEvents[i]);
+  }
+  fCurrentPatternNumber = -1;
+  fQuartetNumber = 0;
+  fHelicityIsMissing = source.fHelicityIsMissing;
+  fIgnoreHelicity = kFALSE;
+  fEnablePairs = source.fEnablePairs;
+  run_label = source.run_label;
 };
 
 
@@ -307,7 +325,7 @@ void QwHelicityPattern::LoadEventData(QwSubsystemArrayParity &event)
     std::cout<<"QwHelicityPattern::LoadEventData :: ";
     std::cout<<" event, pattern, phase # "<<localEventNumber<<" "<<localPatternNumber<<" "<<localPhaseNumber<<"\n";
     std::cout<<" helicity ="<< localHelicityActual<<"\n";
-    for(size_t i=0; i<fEvents.size(); i++)
+    for(size_t i=0; i<fEventLoaded.size(); i++)
       std::cout<<i<<":"<<fEventLoaded[i]<<"  ";
     std::cout<<"\n";
   }
@@ -332,7 +350,7 @@ std::cout << "local phase no: " << localPhaseNumber << " current pattern no: " <
       std::cout<<"QwHelicityPattern::LoadEventData local i="
 	       <<localPhaseNumber<<"\n";
     }
-    fEvents[localPhaseNumber]      = event;
+    fEventPtrs[localPhaseNumber]   = &event;
     fEventLoaded[localPhaseNumber] = kTRUE;
     fHelicity[localPhaseNumber]    = localHelicityActual;
     fEventNumber[localPhaseNumber] = localEventNumber;
@@ -389,18 +407,18 @@ void  QwHelicityPattern::CalculatePairAsymmetry()
     fPairIsGood = kTRUE;
     fNextPair++;
 
-    fPairYield.Sum(fEvents.at(firstevt), fEvents.at(secondevt));
+    fPairYield.Sum(GetEventForPhase(firstevt), GetEventForPhase(secondevt));
     fPairYield.Scale(0.5);
 
     if (fIgnoreHelicity){
-      fPairDifference.Difference(fEvents.at(firstevt), fEvents.at(secondevt));
+      fPairDifference.Difference(GetEventForPhase(firstevt), GetEventForPhase(secondevt));
       fPairDifference.Scale(0.5);
     } else {
       if (fHelicity[firstevt] == plushel && fHelicity[firstevt]!=fHelicity[secondevt]) {
-	fPairDifference.Difference(fEvents.at(firstevt), fEvents.at(secondevt));
+	fPairDifference.Difference(GetEventForPhase(firstevt), GetEventForPhase(secondevt));
 	fPairDifference.Scale(0.5);
       } else if (fHelicity[firstevt] == minushel && fHelicity[firstevt]!=fHelicity[secondevt]) {
-	fPairDifference.Difference(fEvents.at(secondevt),fEvents.at(firstevt));
+	fPairDifference.Difference(GetEventForPhase(secondevt), GetEventForPhase(firstevt));
 	fPairDifference.Scale(0.5);
       } else if (fHelicity[firstevt] == -9999 || fHelicity[secondevt]==-9999) {
 	checkhel= -9999;
@@ -472,7 +490,7 @@ Bool_t  QwHelicityPattern::IsCompletePattern() const
     {
       if (localdebug){
         std::cout<<" i="<<i<<" is loaded ?"
-                 <<fEventLoaded[fEvents.size()-i-1]<<"\n";
+                 <<fEventLoaded[fEventLoaded.size()-i-1]<<"\n";
       }
       if(!fEventLoaded[i])
         filled=kFALSE;
@@ -515,17 +533,17 @@ void  QwHelicityPattern::CalculateAsymmetry()
       }
       if (localhel == plushel) {
 	if (firstplushel) {
-	  fPositiveHelicitySum = fEvents.at(i);
+	  fPositiveHelicitySum = GetEventForPhase(i);
 	  firstplushel = kFALSE;
 	} else {
-	  fPositiveHelicitySum += fEvents.at(i);
+	  fPositiveHelicitySum += GetEventForPhase(i);
 	}
       } else if (localhel == minushel) {
 	if (firstminushel) {
-	  fNegativeHelicitySum = fEvents.at(i);
+	  fNegativeHelicitySum = GetEventForPhase(i);
 	  firstminushel = kFALSE;
 	} else {
-	  fNegativeHelicitySum += fEvents.at(i);
+	  fNegativeHelicitySum += GetEventForPhase(i);
 	}
       }
     }
@@ -536,22 +554,22 @@ void  QwHelicityPattern::CalculateAsymmetry()
 	if (localdebug) std::cout<<"QwHelicityPattern::CalculateAsymmetry:  here filling fPositiveHelicitySum \n";
 	if (firstplushel) {
 	  if (localdebug) std::cout<<"QwHelicityPattern::CalculateAsymmetry:  with = \n";
-	  fPositiveHelicitySum = fEvents.at(i);
+	  fPositiveHelicitySum = GetEventForPhase(i);
 	  firstplushel = kFALSE;
 	} else {
 	  if (localdebug) std::cout<<"QwHelicityPattern::CalculateAsymmetry:  with += \n";
-	  fPositiveHelicitySum += fEvents.at(i);
+	  fPositiveHelicitySum += GetEventForPhase(i);
 	}
 	checkhel += 1;
       } else if (fHelicity[i] == minushel) {
 	if (localdebug) std::cout<<"QwHelicityPattern::CalculateAsymmetry:  here filling fNegativeHelicitySum \n";
 	if (firstminushel) {
 	  if (localdebug) std::cout<<"QwHelicityPattern::CalculateAsymmetry:  with = \n";
-	  fNegativeHelicitySum = fEvents.at(i);
+	  fNegativeHelicitySum = GetEventForPhase(i);
 	  firstminushel = kFALSE;
 	} else {
 	  if (localdebug) std::cout<<"QwHelicityPattern::CalculateAsymmetry:  with += \n";
-	  fNegativeHelicitySum += fEvents.at(i);
+	  fNegativeHelicitySum += GetEventForPhase(i);
 	}
 	checkhel -= 1;
       } else {
@@ -623,12 +641,12 @@ void  QwHelicityPattern::CalculateAsymmetry()
       //  fAsymmetry1:  (first 1/2 pattern - second 1/2 pattern)/fYield
       fPositiveHelicitySum.ClearEventData();
       fNegativeHelicitySum.ClearEventData();
-      fPositiveHelicitySum = fEvents.at(0);
-      fNegativeHelicitySum = fEvents.at(fPatternSize/2);
+      fPositiveHelicitySum = GetEventForPhase(0);
+      fNegativeHelicitySum = GetEventForPhase(fPatternSize/2);
       if (fPatternSize/2 > 1){
 	for (size_t i = 1; i < fPatternSize/2 ; i++){
-	  fPositiveHelicitySum += fEvents.at(i);
-	  fNegativeHelicitySum += fEvents.at(fPatternSize/2 +i);
+	  fPositiveHelicitySum += GetEventForPhase(i);
+	  fNegativeHelicitySum += GetEventForPhase(fPatternSize/2 + i);
 	}
       }
       fAlternateDiff.ClearEventData();
@@ -641,12 +659,12 @@ void  QwHelicityPattern::CalculateAsymmetry()
       if (fPatternSize > 2) {
 	fPositiveHelicitySum.ClearEventData();
 	fNegativeHelicitySum.ClearEventData();
-	fPositiveHelicitySum = fEvents.at(0);
-	fNegativeHelicitySum = fEvents.at(1);
+	fPositiveHelicitySum = GetEventForPhase(0);
+	fNegativeHelicitySum = GetEventForPhase(1);
 	if (fPatternSize/2 > 1){
 	  for (size_t i = 1; i < fPatternSize/2 ; i++){
-	    fPositiveHelicitySum += fEvents.at(2*i);
-	    fNegativeHelicitySum += fEvents.at(2*i + 1);
+	    fPositiveHelicitySum += GetEventForPhase(2*i);
+	    fNegativeHelicitySum += GetEventForPhase(2*i + 1);
 	  }
 	}
 	fAlternateDiff.ClearEventData();
@@ -672,6 +690,7 @@ void QwHelicityPattern::ClearEventData()
   for(size_t i=0; i<fEvents.size(); i++)
     {
       fEvents[i].ClearEventData();
+      fEventPtrs[i]=&(fEvents[i]);
       fEventLoaded[i]=kFALSE;
       fHelicity[i]=-999;
     }

--- a/Parity/src/QwHelicityPattern.cc
+++ b/Parity/src/QwHelicityPattern.cc
@@ -235,13 +235,21 @@ QwHelicityPattern::QwHelicityPattern(const QwHelicityPattern &source)
   fPatternIsGood(false),
   fIsDataLoaded(false)
 {
+  // Properly snapshot each phase: use GetEventForPhase() so we pick up
+  // ring-owned events (fEventPtrs entries) as well as locally stored ones.
+  // Then point fEventPtrs at *this* object's fEvents to avoid dangling
+  // pointers if the source or the ring is modified later.
   fEvents.resize(fPatternSize, source.fYield);
   fEventPtrs.resize(fPatternSize, nullptr);
   fHelicity.resize(fPatternSize, -9999);
   fEventNumber.resize(fPatternSize, -1);
   fEventLoaded.resize(fPatternSize, kFALSE);
   for (size_t i = 0; i < fPatternSize; ++i) {
-    fEventPtrs[i] = &(fEvents[i]);
+    fEvents[i]      = source.GetEventForPhase(i);
+    fEventPtrs[i]   = &(fEvents[i]);
+    fHelicity[i]    = source.fHelicity[i];
+    fEventNumber[i] = source.fEventNumber[i];
+    fEventLoaded[i] = source.fEventLoaded[i];
   }
   fCurrentPatternNumber = -1;
   fQuartetNumber = 0;


### PR DESCRIPTION
## Motivation

`QwHelicityPattern::LoadEventData` previously made a full deep copy of the
incoming event into `fEvents[phase]` on every physics event. For a subsystem
array with O(300) channels, this copy is non-trivial. The goal is to eliminate
it by storing a pointer to the caller-provided event instead.

## Approach

Rather than copying each event into `fEvents[phase]`, `LoadEventData` now stores
a pointer (`fEventPtrs[phase] = &event`) and all downstream consumers
(`CalculatePairAsymmetry`, `CalculateAsymmetry`, etc.) access events through a
new `GetEventForPhase()` helper that dereferences `fEventPtrs[i]` when set,
falling back to `fEvents[i]` otherwise.

In `QwParity.cc`, `helicitypattern.LoadEventData` is called with a reference to
ring-owned storage (`ringevent`) rather than the copy in `ringoutput`. The
`ringoutput = ringevent` copy is still present and required: `ringoutput` has
its ROOT tree branches, histograms, and RNTuple fields bound to its internal
memory layout during initialization, so the copy is needed to populate that
bound buffer each event. The per-phase copy this PR eliminates is the one
previously inside `LoadEventData`.

Key changes:
- `QwParity.cc`: pass `ringevent` (ring reference) rather than `ringoutput`
  (copy) to `LoadEventData`, with an explanatory comment.
- `QwHelicityPattern.h`: add `fEventPtrs` vector, `GetEventForPhase()` accessor,
  and explicit `= delete` on the copy-assignment operator (the compiler-generated
  version would shallow-copy raw pointers, leaving the target pointing at the
  source's or ring-owned storage).
- `QwHelicityPattern.cc`: store pointer in `LoadEventData`; initialize
  `fEventPtrs` in both constructors; fix the copy constructor to snapshot each
  phase via `GetEventForPhase()` and copy per-phase metadata (`fHelicity`,
  `fEventNumber`, `fEventLoaded`) so a copy of a partially loaded pattern
  preserves its state; use `GetEventForPhase()` throughout `CalculatePairAsymmetry`
  and `CalculateAsymmetry`.

## Benchmark

Measured using `qwparity` in default TTree output mode on 10,000 mock events,
5 repeats, run back-to-back on the same machine under the same load. Framework
CPU time (ms per event) reported by the analysis framework's own timer.

| Branch | min | median | mean |
|--------|-----|--------|------|
| `main` (base) | 1.947 | 1.961 | 1.985 ms/event |
| This PR | 1.887 | 1.914 | 1.910 ms/event |
| delta | -0.060 | -0.047 | -0.075 ms/event |
| speedup | +3.1% | +2.4% | +3.8% |

The ~3% improvement is consistent with eliminating one deep copy of the full
subsystem array per event inside `LoadEventData`.
