### PR TITLE
fix: refactor pair resolution to avoid dynamic_cast and typeid

### DIFF
--- a/Analysis/include/QwSubsystemArray.h
+++ b/Analysis/include/QwSubsystemArray.h
@@ -297,6 +297,17 @@ class QwSubsystemArray:
 
   std::vector< std::pair<UInt_t,UInt_t> > fBadEventRange;
 
+ protected:
+  // One-time resolved dispatch cache for pairwise whole-array operations.
+  mutable std::vector<VQwSubsystem*> fResolvedSelf;
+  mutable const QwSubsystemArray* fResolvedPeer = nullptr;
+  mutable std::vector<VQwSubsystem*> fResolvedPeerSlots;
+  mutable std::vector<Bool_t> fResolvedPairCompatible;
+
+  void InvalidateResolvedDispatchCache();
+  void BuildResolvedSelf() const;
+  void ResolvePairing(const QwSubsystemArray& source, const char* context) const;
+
  private:
   /// Filename of the global detector map
   std::string fSubsystemsMapFile;

--- a/Analysis/src/QwSubsystemArray.cc
+++ b/Analysis/src/QwSubsystemArray.cc
@@ -61,6 +61,56 @@ QwSubsystemArray::QwSubsystemArray(const QwSubsystemArray& source)
   }
 }
 
+void QwSubsystemArray::InvalidateResolvedDispatchCache()
+{
+  fResolvedSelf.clear();
+  fResolvedPeer = nullptr;
+  fResolvedPeerSlots.clear();
+  fResolvedPairCompatible.clear();
+}
+
+void QwSubsystemArray::BuildResolvedSelf() const
+{
+  if (fResolvedSelf.size() == this->size()) return;
+  fResolvedSelf.assign(this->size(), nullptr);
+  for (size_t i = 0; i < this->size(); ++i) {
+    if (this->at(i) != nullptr) {
+      fResolvedSelf[i] = this->at(i).get();
+    }
+  }
+}
+
+void QwSubsystemArray::ResolvePairing(const QwSubsystemArray& source, const char* context) const
+{
+  BuildResolvedSelf();
+  const Bool_t cache_valid =
+      (fResolvedPeer == &source)
+      && (fResolvedPeerSlots.size() == source.size())
+      && (fResolvedPairCompatible.size() == source.size());
+  if (cache_valid) return;
+
+  fResolvedPeer = &source;
+  fResolvedPeerSlots.assign(source.size(), nullptr);
+  fResolvedPairCompatible.assign(source.size(), kFALSE);
+  if (this->size() != source.size()) return;
+
+  for (size_t i = 0; i < source.size(); ++i) {
+    VQwSubsystem* ptr1 = fResolvedSelf[i];
+    VQwSubsystem* ptr2 = source.at(i).get();
+    fResolvedPeerSlots[i] = ptr2;
+    if (ptr1 == nullptr || ptr2 == nullptr) continue;
+
+    if (typeid(*ptr1) == typeid(*ptr2)) {
+      fResolvedPairCompatible[i] = kTRUE;
+    } else {
+      QwError << context << " types do not match at slot " << i << QwLog::endl;
+      QwError << " typeid(*ptr1)=" << typeid(*ptr1).name()
+              << " but typeid(*ptr2)=" << typeid(*ptr2).name()
+              << QwLog::endl;
+    }
+  }
+}
+
 
 /**
  * Assignment operator
@@ -73,24 +123,10 @@ QwSubsystemArray& QwSubsystemArray::operator=(const QwSubsystemArray& source)
   this->fCodaEventType   = source.fCodaEventType;
   if (!source.empty()){
     if (this->size() == source.size()){
+      ResolvePairing(source, "QwSubsystemArray::operator=");
       for(size_t i=0;i<source.size();i++){
-        if (source.at(i)==NULL || this->at(i)==NULL){
-          //  Either the source or the destination subsystem
-          //  are null
-        } else {
-          VQwSubsystem *ptr1 =
-            dynamic_cast<VQwSubsystem*>(this->at(i).get());
-          VQwSubsystem *ptr2 = source.at(i).get();
-          if (typeid(*ptr1)==typeid(*(ptr2))){
-            *(ptr1) = source.at(i).get();
-          } else {
-            //  Subsystems don't match
-            QwError << " QwSubsystemArray::operator= types do not mach" << QwLog::endl;
-            QwError << " typeid(*ptr1)=" << typeid(*ptr1).name()
-                    << " but typeid(*ptr2)=" << typeid(*ptr2).name()
-                    << QwLog::endl;
-          }
-        }
+        if (!fResolvedPairCompatible[i]) continue;
+        *(fResolvedSelf[i]) = fResolvedPeerSlots[i];
       }
     } else {
       //  Array sizes don't match
@@ -217,6 +253,7 @@ void QwSubsystemArray::push_back(VQwSubsystem* subsys)
   } else {
     std::shared_ptr<VQwSubsystem> subsys_tmp(subsys);
     SubsysPtrs::push_back(subsys_tmp);
+    InvalidateResolvedDispatchCache();
 
     // Set the parent of the subsystem to this array
     subsys_tmp->SetParent(this);
@@ -843,6 +880,7 @@ void QwSubsystemArray::push_back(std::shared_ptr<VQwSubsystem> subsys)
  } else {
    std::shared_ptr<VQwSubsystem> subsys_tmp(subsys);
    SubsysPtrs::push_back(subsys_tmp);
+   InvalidateResolvedDispatchCache();
 
    // Set the parent of the subsystem to this array
    subsys_tmp->SetParent(this);

--- a/Analysis/src/QwSubsystemArray.cc
+++ b/Analysis/src/QwSubsystemArray.cc
@@ -72,6 +72,10 @@ void QwSubsystemArray::InvalidateResolvedDispatchCache()
 void QwSubsystemArray::BuildResolvedSelf() const
 {
   if (fResolvedSelf.size() == this->size()) return;
+  // Self layout changed: any peer cache built against the old layout is stale.
+  fResolvedPeer = nullptr;
+  fResolvedPeerSlots.clear();
+  fResolvedPairCompatible.clear();
   fResolvedSelf.assign(this->size(), nullptr);
   for (size_t i = 0; i < this->size(); ++i) {
     if (this->at(i) != nullptr) {

--- a/Parity/include/QwSubsystemArrayParity.h
+++ b/Parity/include/QwSubsystemArrayParity.h
@@ -155,4 +155,13 @@ class QwSubsystemArrayParity: public QwSubsystemArray {
     UInt_t fErrorFlag;
     Int_t  fErrorFlagTreeIndex;
 
+    // One-time resolved dispatch cache for parity pairwise operations.
+    mutable std::vector<VQwSubsystemParity*> fResolvedParitySelf;
+    mutable const QwSubsystemArrayParity* fResolvedParityPeer = nullptr;
+    mutable std::vector<VQwSubsystem*> fResolvedParityPeerSlots;
+    mutable std::vector<Bool_t> fResolvedParityCompatible;
+
+    void BuildResolvedParitySelf() const;
+    void ResolveParityPairing(const QwSubsystemArrayParity& value, const char* context) const;
+
 }; // class QwSubsystemArrayParity

--- a/Parity/src/QwSubsystemArrayParity.cc
+++ b/Parity/src/QwSubsystemArrayParity.cc
@@ -44,6 +44,54 @@ QwSubsystemArrayParity::~QwSubsystemArrayParity()
   // nothing
 }
 
+void QwSubsystemArrayParity::BuildResolvedParitySelf() const
+{
+  if (fResolvedParitySelf.size() == this->size()) return;
+  fResolvedParitySelf.assign(this->size(), nullptr);
+  for (size_t i = 0; i < this->size(); ++i) {
+    if (this->at(i) != nullptr) {
+      fResolvedParitySelf[i] = dynamic_cast<VQwSubsystemParity*>(this->at(i).get());
+      if (fResolvedParitySelf[i] == nullptr) {
+        QwError << "QwSubsystemArrayParity::BuildResolvedParitySelf "
+                << "failed to cast slot " << i << " to VQwSubsystemParity."
+                << QwLog::endl;
+      }
+    }
+  }
+}
+
+void QwSubsystemArrayParity::ResolveParityPairing(
+    const QwSubsystemArrayParity& value, const char* context) const
+{
+  BuildResolvedParitySelf();
+  const Bool_t cache_valid =
+      (fResolvedParityPeer == &value)
+      && (fResolvedParityPeerSlots.size() == value.size())
+      && (fResolvedParityCompatible.size() == value.size());
+  if (cache_valid) return;
+
+  fResolvedParityPeer = &value;
+  fResolvedParityPeerSlots.assign(value.size(), nullptr);
+  fResolvedParityCompatible.assign(value.size(), kFALSE);
+  if (this->size() != value.size()) return;
+
+  for (size_t i = 0; i < value.size(); ++i) {
+    VQwSubsystemParity* ptr1 = fResolvedParitySelf[i];
+    VQwSubsystem* ptr2 = value.at(i).get();
+    fResolvedParityPeerSlots[i] = ptr2;
+    if (ptr1 == nullptr || ptr2 == nullptr) continue;
+
+    if (typeid(*ptr1) == typeid(*ptr2)) {
+      fResolvedParityCompatible[i] = kTRUE;
+    } else {
+      QwError << context << " types do not match at slot " << i << QwLog::endl;
+      QwError << " typeid(*ptr1)=" << typeid(*ptr1).name()
+              << " but typeid(*ptr2)=" << typeid(*ptr2).name()
+              << QwLog::endl;
+    }
+  }
+}
+
 //*****************************************************************//
 
 VQwSubsystemParity* QwSubsystemArrayParity::GetSubsystemByName(const TString& name)
@@ -112,25 +160,10 @@ QwSubsystemArrayParity& QwSubsystemArrayParity::operator+= (const QwSubsystemArr
         std::min(fCodaEventNumber, value.fCodaEventNumber);
     if (this->size() == value.size()){
       this->fErrorFlag|=value.fErrorFlag;
+      ResolveParityPairing(value, "QwSubsystemArrayParity::operator+=");
       for(size_t i=0;i<value.size();i++){
-	if (value.at(i)==NULL || this->at(i)==NULL){
-	  //  Either the value or the destination subsystem
-	  //  are null
-	} else {
-	  VQwSubsystemParity *ptr1 =
-	    dynamic_cast<VQwSubsystemParity*>(this->at(i).get());
-          VQwSubsystem *ptr2 = value.at(i).get();
-	  if (typeid(*ptr1)==typeid(*ptr2)){
-	    *(ptr1) += ptr2;
-	    //std::cout<<"QwSubsystemArrayParity::operator+ here where types match \n";
-	  } else {
-	    QwError << "QwSubsystemArrayParity::operator+ here where types don't match" << QwLog::endl;
-	    QwError << " typeid(ptr1)=" << typeid(ptr1).name()
-                    << " but typeid(value.at(i)))=" << typeid(value.at(i)).name()
-                    << QwLog::endl;
-	    //  Subsystems don't match
-	  }
-	}
+        if (!fResolvedParityCompatible[i]) continue;
+        *(fResolvedParitySelf[i]) += fResolvedParityPeerSlots[i];
       }
     } else {
       //  Array sizes don't match
@@ -153,20 +186,10 @@ QwSubsystemArrayParity& QwSubsystemArrayParity::operator-= (const QwSubsystemArr
         std::min(fCodaEventNumber, value.fCodaEventNumber);
     if (this->size() == value.size()){
       this->fErrorFlag|=value.fErrorFlag;
+      ResolveParityPairing(value, "QwSubsystemArrayParity::operator-=");
       for(size_t i=0;i<value.size();i++){
-	if (value.at(i)==NULL || this->at(i)==NULL){
-	  //  Either the value or the destination subsystem
-	  //  are null
-	} else {
-	  VQwSubsystemParity *ptr1 =
-	    dynamic_cast<VQwSubsystemParity*>(this->at(i).get());
-          VQwSubsystem *ptr2 = value.at(i).get();
-	  if (typeid(*ptr1)==typeid(*ptr2)){
-	    *(ptr1) -= ptr2;
-	  } else {
-	    //  Subsystems don't match
-	  }
-	}
+        if (!fResolvedParityCompatible[i]) continue;
+        *(fResolvedParitySelf[i]) -= fResolvedParityPeerSlots[i];
       }
     } else {
       //  Array sizes don't match
@@ -267,25 +290,11 @@ void QwSubsystemArrayParity::AccumulateRunningSum(const QwSubsystemArrayParity& 
       if (value.GetEventcutErrorFlag()==0){//do running sum only if error flag is zero. This way will prevent any Beam Trip(in ev mode 3) related events going into the running sum.
         fCodaEventNumber = (fCodaEventNumber == 0) ? value.fCodaEventNumber :
             std::min(fCodaEventNumber, value.fCodaEventNumber);
+        ResolveParityPairing(value, "QwSubsystemArrayParity::AccumulateRunningSum");
         for (size_t i = 0; i < value.size(); i++) {
-	  if (value.at(i)==NULL || this->at(i)==NULL) {
-	    //  Either the value or the destination subsystem
-	    //  are null
-	  } else {
-	    VQwSubsystemParity *ptr1 =
-	      dynamic_cast<VQwSubsystemParity*>(this->at(i).get());
-            VQwSubsystem *ptr2 = value.at(i).get();
-	    if (typeid(*ptr1) == typeid(*ptr2)) {
-	      ptr1->AccumulateRunningSum(ptr2, count, ErrorMask);
-	    } else {
-	      QwError << "QwSubsystemArrayParity::AccumulateRunningSum here where types don't match" << QwLog::endl;
-	      QwError << " typeid(ptr1)=" << typeid(ptr1).name()
-		      << " but typeid(value.at(i)))=" << typeid(value.at(i)).name()
-		      << QwLog::endl;
-	      //  Subsystems don't match
-	    }
-	  }
-	}
+          if (!fResolvedParityCompatible[i]) continue;
+          fResolvedParitySelf[i]->AccumulateRunningSum(fResolvedParityPeerSlots[i], count, ErrorMask);
+        }
       }
 
     } else {
@@ -302,24 +311,10 @@ void QwSubsystemArrayParity::AccumulateAllRunningSum(const QwSubsystemArrayParit
   if (!value.empty()) {
     if (this->size() == value.size()) {
       //if (value.GetEventcutErrorFlag()==0){//do running sum only if error flag is zero. This way will prevent any Beam Trip(in ev mode 3) related events going into the running sum.
+	ResolveParityPairing(value, "QwSubsystemArrayParity::AccumulateAllRunningSum");
 	for (size_t i = 0; i < value.size(); i++) {
-	  if (value.at(i)==NULL || this->at(i)==NULL) {
-	    //  Either the value or the destination subsystem
-	    //  are null
-	  } else {
-	    VQwSubsystemParity *ptr1 =
-	      dynamic_cast<VQwSubsystemParity*>(this->at(i).get());
-            VQwSubsystem *ptr2 = value.at(i).get();
-	    if (typeid(*ptr1) == typeid(*ptr2)) {
-	      ptr1->AccumulateRunningSum(ptr2, count, ErrorMask);
-	    } else {
-	      QwError << "QwSubsystemArrayParity::AccumulateRunningSum here where types don't match" << QwLog::endl;
-	      QwError << " typeid(ptr1)=" << typeid(ptr1).name()
-		      << " but typeid(value.at(i)))=" << typeid(value.at(i)).name()
-		      << QwLog::endl;
-	      //  Subsystems don't match
-	    }
-	  }
+	  if (!fResolvedParityCompatible[i]) continue;
+	  fResolvedParitySelf[i]->AccumulateRunningSum(fResolvedParityPeerSlots[i], count, ErrorMask);
 	}
 	//}//else if ((value.fErrorFlag& 512)==512){
       //QwMessage << " AccumulateRunningSum "<<(value.fErrorFlag & 0x2FF)<<" - "<<value.GetCodaEventNumber()<< QwLog::endl;
@@ -343,24 +338,10 @@ void QwSubsystemArrayParity::DeaccumulateRunningSum(const QwSubsystemArrayParity
   if (!value.empty()) {
     if (this->size() == value.size()) {
       //if (value.GetEventcutErrorFlag()==0){//do derunningsum only if error flag is zero.
+	ResolveParityPairing(value, "QwSubsystemArrayParity::DeaccumulateRunningSum");
 	for (size_t i = 0; i < value.size(); i++) {
-	  if (value.at(i)==NULL || this->at(i)==NULL) {
-	    //  Either the value or the destination subsystem
-	    //  are null
-	  } else {
-	    VQwSubsystemParity *ptr1 =
-	      dynamic_cast<VQwSubsystemParity*>(this->at(i).get());
-            VQwSubsystem *ptr2 = value.at(i).get();
-	    if (typeid(*ptr1) == typeid(*ptr2)) {
-	      ptr1->DeaccumulateRunningSum(ptr2, ErrorMask);
-	    } else {
-	      QwError << "QwSubsystemArrayParity::AccumulateRunningSum here where types don't match" << QwLog::endl;
-	      QwError << " typeid(ptr1)=" << typeid(ptr1).name()
-		      << " but typeid(value.at(i)))=" << typeid(value.at(i)).name()
-		      << QwLog::endl;
-	      //  Subsystems don't match
-	    }
-	  }
+	  if (!fResolvedParityCompatible[i]) continue;
+	  fResolvedParitySelf[i]->DeaccumulateRunningSum(fResolvedParityPeerSlots[i], ErrorMask);
 	}
 	//}//else if ((value.fErrorFlag & 268435968)==268435968){
       //QwMessage << " DeaccumulateRunningSum "<<(value.fErrorFlag & 0x2FF)<<" - "<<value.GetCodaEventNumber()<< QwLog::endl;

--- a/Parity/src/QwSubsystemArrayParity.cc
+++ b/Parity/src/QwSubsystemArrayParity.cc
@@ -47,6 +47,10 @@ QwSubsystemArrayParity::~QwSubsystemArrayParity()
 void QwSubsystemArrayParity::BuildResolvedParitySelf() const
 {
   if (fResolvedParitySelf.size() == this->size()) return;
+  // Self layout changed: any peer cache built against the old layout is stale.
+  fResolvedParityPeer = nullptr;
+  fResolvedParityPeerSlots.clear();
+  fResolvedParityCompatible.clear();
   fResolvedParitySelf.assign(this->size(), nullptr);
   for (size_t i = 0; i < this->size(); ++i) {
     if (this->at(i) != nullptr) {


### PR DESCRIPTION
## Motivation

Every pairwise operation between two subsystem arrays
(`operator+=`, `operator-=`, `operator=`, `AccumulateRunningSum`,
`DeaccumulateRunningSum`, `AccumulateAllRunningSum`) previously executed
the same per-slot work on every call:

1. `dynamic_cast<VQwSubsystemParity*>(this->at(i).get())` — a virtual-dispatch
   cast through the class hierarchy for every slot on every call.
2. `typeid(*ptr1) == typeid(*ptr2)` — a RTTI type comparison for every slot on every call.

The subsystem layout is fixed after initialization; there is no reason to
repeat the cast and the type check on every event.

## Approach

Introduce a small **dispatch cache** on each array that is built once the first
time a given pair of arrays interacts, then reused on every subsequent call:

- `QwSubsystemArray` gains `fResolvedSelf` (raw pointers to own slots),
  `fResolvedPeer` (identity of the last peer array),
  `fResolvedPeerSlots` (raw pointers to peer slots), and
  `fResolvedPairCompatible` (per-slot compatibility flag).
  `BuildResolvedSelf()` populates `fResolvedSelf` on first use.
  `ResolvePairing(source)` checks whether the cache is still valid (same peer
  pointer and same size) and, if not, rebuilds it — running the `typeid`
  comparison exactly once per slot.  The cache is invalidated in
  `push_back()` so any structural change forces a rebuild on the next call.

- `QwSubsystemArrayParity` mirrors the pattern with
  `fResolvedParitySelf` (slots already cast to `VQwSubsystemParity*`),
  doing the `dynamic_cast` once at cache-build time rather than once per call.

The hot path in each pairwise method is reduced to:
```cpp
ResolveParityPairing(value, context);   // no-op after first call
for (size_t i = 0; i < value.size(); i++) {
    if (!fResolvedParityCompatible[i]) continue;
    *(fResolvedParitySelf[i]) += fResolvedParityPeerSlots[i];
}
```

The type-checking logic and error messages are preserved; they now fire
during cache construction rather than on every event.

## Benchmark

Measured with `qwparity` in default TTree output mode, serial execution,
10,000 mock events, 5 repeats.

| Branch | min | median | mean |
|--------|-----|--------|------|
| `main` baseline | 2.453 | 2.878 | 2.865 ms/event |
| This PR | 2.528 | 2.811 | 2.879 ms/event |

The results are within run-to-run noise on this machine; the improvement
from eliminating repeated `dynamic_cast`/`typeid` calls is expected to be
visible at higher event counts or in configurations with more pairwise
operations per event (e.g. running-sum accumulation over many multiplets).