### PR TITLE
Adds QwWord Subsystem

### DIFF
--- a/Analysis/include/QwWord.h
+++ b/Analysis/include/QwWord.h
@@ -29,17 +29,13 @@
  */
 class QwWord
 {
-  public:
-    QwWord()
-    : fSubbankIndex(-1),fWordInSubbank(-1),fModuleType(""),
-      fWordName(""),fWordType(""),fValue(-1){};
-
-    Int_t fSubbankIndex;
-    Int_t fWordInSubbank;
-    TString fModuleType;
-    TString fWordName;
-    TString fWordType;
-    Int_t fValue;
+public:
+    Int_t fSubbankIndex{-1};
+    Int_t fWordInSubbank{-1};
+    TString fModuleType{""};
+    TString fWordName{""};
+    TString fWordType{""};
+    Int_t fValue{-1};
 
     Double_t GetValue() const       {return this->GetValue(0);};
     Double_t GetValue(size_t element) const      { return fValue; };

--- a/Analysis/include/QwWord.h
+++ b/Analysis/include/QwWord.h
@@ -42,7 +42,25 @@ public:
     TString GetModType() const {return fModuleType;};
 
 
-
+	QwWord& operator=(QwWord const&) = default;
+	QwWord& operator+=(QwWord const& other) {
+		fValue += other.fValue;
+		return *this;
+	}
+	QwWord& operator-=(QwWord const& other) {
+		fValue -= other.fValue;
+		return *this;
+	}
+	QwWord operator+(QwWord const& other) const{
+		QwWord tmp = *this;
+		tmp.fValue += other.fValue;
+		return tmp;
+	}
+	QwWord operator-(QwWord const& other) const {
+		QwWord tmp = *this;
+		tmp.fValue -= other.fValue;
+		return tmp;
+	}
 
 
     void PrintID() const {

--- a/Parity/include/QwHelicityDecoder.h
+++ b/Parity/include/QwHelicityDecoder.h
@@ -65,7 +65,7 @@ class QwHelicityDecoder: public QwHelicityBase, public MQwSubsystemCloneable<QwH
   };
 
   Int_t  ProcessConfigurationBuffer(const ROCID_t roc_id, const BankID_t bank_id,
-				   UInt_t* buffer, UInt_t num_words) override;
+                                   UInt_t* buffer, UInt_t num_words) override;
   Int_t  ProcessEvBuffer(const ROCID_t roc_id, const BankID_t bank_id, UInt_t* buffer, UInt_t num_words) {
     return ProcessEvBuffer(0x1,roc_id,bank_id,buffer,num_words);
   };
@@ -112,7 +112,7 @@ class QwHelicityDecoder: public QwHelicityBase, public MQwSubsystemCloneable<QwH
 // protected:
   void CheckPatternNum(VQwSubsystem *value);
   void MergeCounters(VQwSubsystem *value);
-  
+
   Bool_t CheckIORegisterMask(const UInt_t& ioregister, const UInt_t& mask) const {
     return ((mask != 0)&&((ioregister & mask) == mask));
   };

--- a/Parity/include/QwWords.h
+++ b/Parity/include/QwWords.h
@@ -1,0 +1,77 @@
+#pragma once
+
+
+#include "VQwSubsystemParity.h"
+#include "QwWord.h"
+#include "QwFactory.h"
+#include <vector>
+#include <TString.h>
+
+// Forward Declerations
+class QwRootTreeBranchVector;
+
+
+class QwWords : public VQwSubsystemParity, public MQwSubsystemCloneable<QwWords>
+{
+	std::vector<QwWord> fWords;
+	Int_t fTreeArrayIndex{-1};
+public:
+	QwWords(TString const& name);
+	QwWords(QwWords const& other);
+	~QwWords() = default;
+
+
+
+	void FillDB_MPS(QwParityDB*, TString) override { throw std::runtime_error("QwWords::FillDB_MPS() is not supported"); }
+	void FillDB(QwParityDB*    , TString) override { throw std::runtime_error("QwWords::FillDB() is not supported"    ); }
+	void FillErrDB(QwParityDB* , TString) override { throw std::runtime_error("QwWords::FillErrDB() is not supported");  }
+
+	void Ratio(VQwSubsystem *numer, VQwSubsystem *denom) override { throw std::runtime_error("QwWords::Ratio() is not supported");  }
+	void Scale(Double_t factor) override { throw std::runtime_error("QwWords::Scale() is not supported");  }
+	void AccumulateRunningSum(VQwSubsystem* value, Int_t count=0, Int_t ErrorMask=0xFFFFFFF) override { throw std::runtime_error("QwWords::AccumulateRunningSum() is not supported");  }
+	void DeaccumulateRunningSum(VQwSubsystem* value, Int_t ErrorMask=0xFFFFFFF) override { throw std::runtime_error("QwWords::DeaccumulateRunningSum() is not supported");  }
+	void CalculateRunningAverage() override { throw std::runtime_error("QwWords::CalculateRunningAverage() is not supported");  }
+	using VQwSubsystemParity::LoadEventCuts;
+	using VQwSubsystemParity::LoadEventCuts_Init;
+	using VQwSubsystemParity::LoadEventCuts_Line;
+	using VQwSubsystemParity::LoadEventCuts_Fin;
+
+	VQwSubsystem&  operator=  (VQwSubsystem *value) override;
+	VQwSubsystem&  operator+= (VQwSubsystem *value) override;
+	VQwSubsystem&  operator-= (VQwSubsystem *value) override;
+
+
+	Int_t LoadChannelMap(TString mapfile) override;
+	/// Mandatory parameter file definition
+	Int_t LoadInputParameters(TString mapfile) override { throw std::runtime_error("QwWords::LoadInputParameters() is not supported"); return 0; }
+	Int_t ProcessConfigurationBuffer(const ROCID_t roc_id, const BankID_t bank_id, UInt_t* buffer, UInt_t num_words) override { throw std::runtime_error("QwWords::ProcessConfigurationBuffer() is not supported"); return 0; }
+    Int_t ProcessEvBuffer(const ROCID_t roc_id, const BankID_t bank_id, UInt_t *buffer, UInt_t num_words) override;
+	void ProcessEvent() override { throw std::runtime_error("QwWords::ProcessEvent() is not supported"); }
+    void ConstructHistograms() override { std::runtime_error("QwWords::ConstructHistograms() is not supported"); }
+    void ConstructHistograms(TDirectory *folder, TString &prefix) override { std::runtime_error("QwWords::ConstructHistograms() is not supported"); }
+	void FillHistograms() override { std::runtime_error("QwWords::FillHistograms() is not supported"); }
+
+
+    void ConstructBranchAndVector(TTree *tree, TString &prefix, QwRootTreeBranchVector &values) override;
+	void FillTreeVector(QwRootTreeBranchVector &values) const override;
+	void ConstructBranch(TTree *tree, TString& prefix) override { throw std::runtime_error("QwWords::ConstructBranch() is not supported"); };
+	void ConstructBranch(TTree *tree, TString& prefix, QwParameterFile& trim_file) override { throw std::runtime_error("QwWords::ConstructBranch() is not supported"); };
+
+#ifdef HAS_RNTUPLE_SUPPORT
+	void ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs) override;
+	void FillNTupleVector(std::vector<Double_t>& values) const override;
+#endif
+
+    void  ClearEventData() override;
+    Bool_t ApplySingleEventCuts() override { throw std::runtime_error("QwWords::ApplySingleEventCuts() is not supported"); return true; }
+    Bool_t CheckForBurpFail(const VQwSubsystem *subsys) override { throw std::runtime_error("QwWords::CheckForBurpFail() is not supported"); return true; }
+    void PrintErrorCounters() const override { throw std::runtime_error("QwWords::PrintErrorCounters() is not supported"); }
+    void IncrementErrorCounters() override { throw std::runtime_error("QwWords::IncrementErrorCounters() is not supported"); }
+    UInt_t GetEventcutErrorFlag() override { throw std::runtime_error("QwWords::GetEventcutErrorFlag() is not supported"); return 0; }
+    void UpdateErrorFlag(const VQwSubsystem *ev_error) override { throw std::runtime_error("QwWords::UpdateErrorFlag() is not supported"); }
+
+
+
+};
+// Register this subsystem with the factory
+REGISTER_SUBSYSTEM_FACTORY(QwWords);

--- a/Parity/include/QwWords.h
+++ b/Parity/include/QwWords.h
@@ -26,11 +26,11 @@ public:
 	void FillDB(QwParityDB*    , TString) override { throw std::runtime_error("QwWords::FillDB() is not supported"    ); }
 	void FillErrDB(QwParityDB* , TString) override { throw std::runtime_error("QwWords::FillErrDB() is not supported");  }
 
-	void Ratio(VQwSubsystem *numer, VQwSubsystem *denom) override { throw std::runtime_error("QwWords::Ratio() is not supported");  }
-	void Scale(Double_t factor) override { throw std::runtime_error("QwWords::Scale() is not supported");  }
-	void AccumulateRunningSum(VQwSubsystem* value, Int_t count=0, Int_t ErrorMask=0xFFFFFFF) override { throw std::runtime_error("QwWords::AccumulateRunningSum() is not supported");  }
-	void DeaccumulateRunningSum(VQwSubsystem* value, Int_t ErrorMask=0xFFFFFFF) override { throw std::runtime_error("QwWords::DeaccumulateRunningSum() is not supported");  }
-	void CalculateRunningAverage() override { throw std::runtime_error("QwWords::CalculateRunningAverage() is not supported");  }
+	void Ratio(VQwSubsystem *numer, VQwSubsystem *denom) override;
+	void Scale(Double_t factor) override;
+	void AccumulateRunningSum(VQwSubsystem* value, Int_t count=0, Int_t ErrorMask=0xFFFFFFF) override;
+	void DeaccumulateRunningSum(VQwSubsystem* value, Int_t ErrorMask=0xFFFFFFF) override;
+	void CalculateRunningAverage() override;
 	using VQwSubsystemParity::LoadEventCuts;
 	using VQwSubsystemParity::LoadEventCuts_Init;
 	using VQwSubsystemParity::LoadEventCuts_Line;
@@ -46,7 +46,7 @@ public:
 	Int_t LoadInputParameters(TString mapfile) override { throw std::runtime_error("QwWords::LoadInputParameters() is not supported"); return 0; }
 	Int_t ProcessConfigurationBuffer(const ROCID_t roc_id, const BankID_t bank_id, UInt_t* buffer, UInt_t num_words) override { throw std::runtime_error("QwWords::ProcessConfigurationBuffer() is not supported"); return 0; }
     Int_t ProcessEvBuffer(const ROCID_t roc_id, const BankID_t bank_id, UInt_t *buffer, UInt_t num_words) override;
-	void ProcessEvent() override { throw std::runtime_error("QwWords::ProcessEvent() is not supported"); }
+	void ProcessEvent() override;
     void ConstructHistograms() override { std::runtime_error("QwWords::ConstructHistograms() is not supported"); }
     void ConstructHistograms(TDirectory *folder, TString &prefix) override { std::runtime_error("QwWords::ConstructHistograms() is not supported"); }
 	void FillHistograms() override { std::runtime_error("QwWords::FillHistograms() is not supported"); }
@@ -62,16 +62,13 @@ public:
 	void FillNTupleVector(std::vector<Double_t>& values) const override;
 #endif
 
-    void  ClearEventData() override;
-    Bool_t ApplySingleEventCuts() override { throw std::runtime_error("QwWords::ApplySingleEventCuts() is not supported"); return true; }
-    Bool_t CheckForBurpFail(const VQwSubsystem *subsys) override { throw std::runtime_error("QwWords::CheckForBurpFail() is not supported"); return true; }
-    void PrintErrorCounters() const override { throw std::runtime_error("QwWords::PrintErrorCounters() is not supported"); }
-    void IncrementErrorCounters() override { throw std::runtime_error("QwWords::IncrementErrorCounters() is not supported"); }
-    UInt_t GetEventcutErrorFlag() override { throw std::runtime_error("QwWords::GetEventcutErrorFlag() is not supported"); return 0; }
-    void UpdateErrorFlag(const VQwSubsystem *ev_error) override { throw std::runtime_error("QwWords::UpdateErrorFlag() is not supported"); }
-
-
-
+	void  ClearEventData() override;
+	Bool_t ApplySingleEventCuts() override;
+	Bool_t CheckForBurpFail(const VQwSubsystem *subsys) override;
+	void PrintErrorCounters() const override;
+	void IncrementErrorCounters() override;
+	UInt_t GetEventcutErrorFlag() override;
+	void UpdateErrorFlag(const VQwSubsystem *ev_error) override;
 };
 // Register this subsystem with the factory
 REGISTER_SUBSYSTEM_FACTORY(QwWords);

--- a/Parity/src/QwHelicityDecoder.cc
+++ b/Parity/src/QwHelicityDecoder.cc
@@ -105,9 +105,9 @@ void QwHelicityDecoder::ProcessOptions(QwOptions &options)
   }
 
   if (options.HasValue("helicity.bitpattern")) {
-    QwMessage << " Helicity Pattern =" 
-	      << options.GetValue<std::string>("helicity.bitpattern") 
-	      << QwLog::endl;
+    QwMessage << " Helicity Pattern ="
+              << options.GetValue<std::string>("helicity.bitpattern")
+              << QwLog::endl;
     std::string hex = options.GetValue<std::string>("helicity.bitpattern");
     //UInt_t bits = QwParameterFile::GetUInt(hex);
     SetHelicityBitPattern(hex);
@@ -143,12 +143,12 @@ void QwHelicityDecoder::ClearEventData()
   for (size_t i=0;i<fWord.size();i++)
     fWord[i].ClearEventData();
 
-  /**Reset data by setting the old event number, pattern number and pattern phase 
+  /**Reset data by setting the old event number, pattern number and pattern phase
      to the values of the previous event.*/
   if (fEventNumberFirst==-1 && fEventNumberOld!= -1){
     fEventNumberFirst = fEventNumberOld;
   }
-  if (fPatternNumberFirst==-1 && fPatternNumberOld!=-1 
+  if (fPatternNumberFirst==-1 && fPatternNumberOld!=-1
       && fPatternNumber==fPatternNumberOld+1){
     fPatternNumberFirst = fPatternNumberOld;
   }
@@ -187,7 +187,7 @@ Bool_t QwHelicityDecoder::ApplySingleEventCuts(){
 
 void  QwHelicityDecoder::ProcessEvent()
 {
-  Bool_t ldebug = kTRUE;
+  Bool_t ldebug = kFALSE;
   fErrorFlag = 0;
 
   if (! HasDataLoaded()) return;
@@ -197,16 +197,16 @@ void  QwHelicityDecoder::ProcessEvent()
   if(firstpattern && fPatternNumber > fPatternNumberOld){
     firstpattern = kFALSE;
   }
-  
-  if(fEventNumber!=(fEventNumberOld+1)){
+
+  if((fEventNumberFirst!=-1) && (fEventNumber!=(fEventNumberOld+1))){
     Int_t nummissed(fEventNumber - (fEventNumberOld+1));
     QwError << "QwHelicityDecoder::ProcessEvent read event# ("
-	    << fEventNumber << ") is not  old_event#+1; missed "
-	    << nummissed << " gates" << QwLog::endl;
+            << fEventNumber << ") is not  old_event#+1; missed "
+            << nummissed << " gates" << QwLog::endl;
     fNumMissedGates += nummissed;
     fNumMissedEventBlocks++;
   }
-  
+
   fHelicityReported=fBit_Helicity;
 
   if (fHelicityReported == 1){
@@ -220,7 +220,7 @@ void  QwHelicityDecoder::ProcessEvent()
 
   if(fHelicityBitPlus==fHelicityBitMinus)
     fHelicityReported=-1;
-    
+
   // Predict helicity if delay is non zero.
   if(fUsePredictor && !fIgnoreHelicity){
     PredictHelicity();
@@ -229,8 +229,8 @@ void  QwHelicityDecoder::ProcessEvent()
     fHelicityActual  = fHelicityReported;
     fHelicityDelayed = fHelicityReported;
   }
-  
-  fPatternSeed = fSeed_Reported & 0x7fffffff;  
+
+  fPatternSeed = fSeed_Reported & 0x7fffffff;
 
   if(ldebug){
     std::cout<<"\nevent number= "<<fEventNumber<<std::endl;
@@ -238,6 +238,9 @@ void  QwHelicityDecoder::ProcessEvent()
     std::cout<<"pattern phase = "<<fPatternPhaseNumber<<std::endl;
     std::cout<<"max pattern phase = "<<fMaxPatternPhase<<std::endl;
     std::cout<<"min pattern phase = "<<fMinPatternPhase<<std::endl;
+    std::cout << "Helicity Info: [Reported = " << fHelicityReported
+          << ", Delayed = " << fHelicityDelayed
+          << ", Actual = " << fHelicityActual << "]" << std::endl;
 
 
   }
@@ -252,20 +255,20 @@ void QwHelicityDecoder::EncodeEventData(std::vector<UInt_t> &buffer)
 void QwHelicityDecoder::Print() const
 {
   QwOut << "===========================\n"
-	<< "This event: Event#, Pattern#, PatternPhase#="
-	<< fEventNumber << ", "
-	<< fPatternNumber << ", "
-	<< fPatternPhaseNumber << QwLog::endl;
+        << "This event: Event#, Pattern#, PatternPhase#="
+        << fEventNumber << ", "
+        << fPatternNumber << ", "
+        << fPatternPhaseNumber << QwLog::endl;
   QwOut << "Previous event: Event#, Pattern#, PatternPhase#="
-	<< fEventNumberOld << ", "
-	<< fPatternNumberOld << ", "
-	<< fPatternPhaseNumberOld << QwLog::endl;
+        << fEventNumberOld << ", "
+        << fPatternNumberOld << ", "
+        << fPatternPhaseNumberOld << QwLog::endl;
   QwOut << "delta = \n(fEventNumberOld)-(fMaxPatternPhase)x(fPatternNumberOld)-(fPatternPhaseNumberOld)= "
-	<< ((fEventNumberOld)-(fMaxPatternPhase)*(fPatternNumberOld)-(fPatternPhaseNumberOld)) << QwLog::endl;
+        << ((fEventNumberOld)-(fMaxPatternPhase)*(fPatternNumberOld)-(fPatternPhaseNumberOld)) << QwLog::endl;
   QwOut << "Helicity Reported, Delayed, Actual ="
-	<< fHelicityReported << ","
-	<< fHelicityDelayed << ","
-	<< fHelicityActual << QwLog::endl;
+        << fHelicityReported << ","
+        << fHelicityDelayed << ","
+        << fHelicityActual << QwLog::endl;
   QwOut << "===" << QwLog::endl;
   return;
 }
@@ -286,7 +289,7 @@ Int_t QwHelicityDecoder::LoadChannelMap(TString mapfile)
     //  so there is nothing to do in this loop.  We just need the one
     //  call to "ReadNextLine" to populate the list of key/vale pairs.
 
-    // std::cout << "in the loop: " << mapstr.GetLine() << std::endl;   
+    // std::cout << "in the loop: " << mapstr.GetLine() << std::endl;
     // RegisterRocBankMarker(mapstr);
   }
   //std::cout << "finished loop" << std::endl;
@@ -294,7 +297,7 @@ Int_t QwHelicityDecoder::LoadChannelMap(TString mapfile)
   //  Call "RegisterRocBankMarker" to record the ROC/Bank our data is in.
   RegisterRocBankMarker(mapstr);
 
-  //  If we have other key/values we want to use, we'd need to go though 
+  //  If we have other key/values we want to use, we'd need to go though
   //  them here to see if they were found in the mapfile.
   if (mapstr.PopValue("patternphase",value)) {
     fMaxPatternPhase=value;
@@ -316,7 +319,7 @@ Int_t QwHelicityDecoder::ProcessEvBuffer(UInt_t event_type, const ROCID_t roc_id
 {
 
   Bool_t lkDEBUG = kFALSE;
-  //std::cout << " roc id = " << roc_id << "bank id = " << bank_id << std::endl; 
+  //std::cout << " roc id = " << roc_id << "bank id = " << bank_id << std::endl;
   Int_t index = GetSubbankIndex(roc_id,bank_id);
   //std::cout << "index = " << index << std::endl;
   if (index >= 0 && num_words > 0) {
@@ -327,11 +330,11 @@ Int_t QwHelicityDecoder::ProcessEvBuffer(UInt_t event_type, const ROCID_t roc_id
   uint32_t time_last = 0;
   uint32_t decoder_index = 0;
   uint32_t num_decoder_words = 1;
-  
+
   uint32_t slot_id_ev_hd = 0;
   uint32_t slot_id_dnv = 0;
   uint32_t slot_id_fill = 0;
-   
+
   uint32_t new_type;
   uint32_t type;
   uint32_t slot_id_hd;
@@ -351,184 +354,184 @@ Int_t QwHelicityDecoder::ProcessEvBuffer(UInt_t event_type, const ROCID_t roc_id
   if (num_words<fNumDecoderWords+4){
     std::cerr << "Not enough words in the bank:"<< std::endl;
     return kFALSE;
-    
-  } else 
+
+  } else
     for (size_t i=0; i<num_words; i++){
 
       data = buffer[i];
       if(decoder_index)             /* decoder type data word - set by decoder header word */
-	{
-	  type = 16;        /*  set decoder data words as type 16 */
-	  new_type = 0;
-	  if(decoder_index < num_decoder_words)
-	    {
-	      FillHDVariables(data, decoder_index - 1);
-	      if(lkDEBUG)
-		printf("%8X - decoder data(%d) = %d\n", data, (decoder_index - 1),
-		       data);
-	      decoder_index++;
-	    }
-	  else                      /* last decoder word */
+        {
+          type = 16;        /*  set decoder data words as type 16 */
+          new_type = 0;
+          if(decoder_index < num_decoder_words)
+            {
+              FillHDVariables(data, decoder_index - 1);
+              if(lkDEBUG)
+                printf("%8X - decoder data(%d) = %d\n", data, (decoder_index - 1),
+                       data);
+              decoder_index++;
+            }
+          else                      /* last decoder word */
 
-	    {
-	      FillHDVariables(data, decoder_index - 1);
-	      if(lkDEBUG)
-		printf("%8X - decoder data(%d) = %d\n", data, (decoder_index - 1),
-		       data);
-	      decoder_index = 0;
-	      num_decoder_words = 1;
-	    }
-	}
+            {
+              FillHDVariables(data, decoder_index - 1);
+              if(lkDEBUG)
+                printf("%8X - decoder data(%d) = %d\n", data, (decoder_index - 1),
+                       data);
+              decoder_index = 0;
+              num_decoder_words = 1;
+            }
+        }
       else                          /* normal typed word */
-	{
-	  if(data & 0x80000000)     /* data type defining word */
-	    {
-	      new_type = 1;
-	      type = (data & 0x78000000) >> 27;
-	    }
-	  else                      /* data type continuation word */
-	    {
-	      new_type = 0;
-	      type = type_last;
-	    }
-	  
-	  switch (type)
-	    {
-	    case 0:         /* BLOCK HEADER */
-	      slot_id_hd = (data & 0x7C00000) >> 22;
-	      mod_id_hd = (data & 0x3C0000) >> 18;
-	      n_evts = (data & 0x000FF);
-	      blk_num = (data & 0x3FF00) >> 8;
-	      if(lkDEBUG)
-		printf
-		  ("%8X - BLOCK HEADER - slot = %d  id = %d  n_evts = %d  n_blk = %d\n",
-		   data, slot_id_hd, mod_id_hd, n_evts,
-		   blk_num);
-	      break;
-	      
-	    case 1:         /* BLOCK TRAILER */
-	      slot_id_tr = (data & 0x7C00000) >> 22;
-	      n_words = (data & 0x3FFFFF);
-	      if(lkDEBUG)
-		printf("%8X - BLOCK TRAILER - slot = %d   n_words = %d\n",
-		       data, slot_id_tr, n_words);
-	      break;
-	      
-	    case 2:         /* EVENT HEADER */
-	      if(new_type)
-		{
-		  slot_id_ev_hd = (data & 0x07C00000) >> 22;
-		  evt_num_1 = (data & 0x00000FFF);
-		  trig_time = (data & 0x003FF000) >> 12;
-		  if(lkDEBUG)
-		    printf
-		      ("%8X - EVENT HEADER - slot = %d  evt_num = %d  trig_time = %d (%X)\n",
-		       data, slot_id_ev_hd, evt_num_1, trig_time,
-		       trig_time);
-		}
-	      break;
-	      
-	    case 3:         /* TRIGGER TIME */
-	      
-	      if(new_type)
-		{
-		  time_1 = (data & 0x7FFFFFF);
-		  if(lkDEBUG)
-		    printf("%8X - TRIGGER TIME 1 - time = %X\n", data,
-			   time_1);
-		  time_now = 1;
-		  time_last = 1;
-		}
-	      else
-		{
-		  if(time_last == 1)
-		    {
-		      time_2 = (data & 0xFFFFF);
-		      if(lkDEBUG)
-			printf("%8X - TRIGGER TIME 2 - time = %X\n", data,
-			       time_2);
-		      time_now = 2;
-		    }
-		  else if(lkDEBUG)
-		    printf("%8X - TRIGGER TIME - (ERROR)\n", data);
+        {
+          if(data & 0x80000000)     /* data type defining word */
+            {
+              new_type = 1;
+              type = (data & 0x78000000) >> 27;
+            }
+          else                      /* data type continuation word */
+            {
+              new_type = 0;
+              type = type_last;
+            }
 
-		  time_last = time_now;
-		}
+          switch (type)
+            {
+            case 0:         /* BLOCK HEADER */
+              slot_id_hd = (data & 0x7C00000) >> 22;
+              mod_id_hd = (data & 0x3C0000) >> 18;
+              n_evts = (data & 0x000FF);
+              blk_num = (data & 0x3FF00) >> 8;
+              if(lkDEBUG)
+                printf
+                  ("%8X - BLOCK HEADER - slot = %d  id = %d  n_evts = %d  n_blk = %d\n",
+                   data, slot_id_hd, mod_id_hd, n_evts,
+                   blk_num);
+              break;
+
+            case 1:         /* BLOCK TRAILER */
+              slot_id_tr = (data & 0x7C00000) >> 22;
+              n_words = (data & 0x3FFFFF);
+              if(lkDEBUG)
+                printf("%8X - BLOCK TRAILER - slot = %d   n_words = %d\n",
+                       data, slot_id_tr, n_words);
+              break;
+
+            case 2:         /* EVENT HEADER */
+              if(new_type)
+                {
+                  slot_id_ev_hd = (data & 0x07C00000) >> 22;
+                  evt_num_1 = (data & 0x00000FFF);
+                  trig_time = (data & 0x003FF000) >> 12;
+                  if(lkDEBUG)
+                    printf
+                      ("%8X - EVENT HEADER - slot = %d  evt_num = %d  trig_time = %d (%X)\n",
+                       data, slot_id_ev_hd, evt_num_1, trig_time,
+                       trig_time);
+                }
+              break;
+
+            case 3:         /* TRIGGER TIME */
+
+              if(new_type)
+                {
+                  time_1 = (data & 0x7FFFFFF);
+                  if(lkDEBUG)
+                    printf("%8X - TRIGGER TIME 1 - time = %X\n", data,
+                           time_1);
+                  time_now = 1;
+                  time_last = 1;
+                }
+              else
+                {
+                  if(time_last == 1)
+                    {
+                      time_2 = (data & 0xFFFFF);
+                      if(lkDEBUG)
+                        printf("%8X - TRIGGER TIME 2 - time = %X\n", data,
+                               time_2);
+                      time_now = 2;
+                    }
+                  else if(lkDEBUG)
+                    printf("%8X - TRIGGER TIME - (ERROR)\n", data);
+
+                  time_last = time_now;
+                }
           break;
-	  
-	    case 4:         /* UNDEFINED TYPE */
-	      if(lkDEBUG)
-		printf("%8X - UNDEFINED TYPE = %d\n", data, type);
-	      break;
-	      
-	    case 5:         /* UNDEFINED TYPE */
-	      if(lkDEBUG)
-		printf("%8X - UNDEFINED TYPE = %d\n", data, type);
-	      break;
-	      
-	    case 6:         /* UNDEFINED TYPE */
-	      if(lkDEBUG)
-		printf("%8X - UNDEFINED TYPE = %d\n", data, type);
-	      break;
-	      
-	    case 7:         /* UNDEFINED TYPE */
-	      if(lkDEBUG)
-		printf("%8X - UNDEFINED TYPE = %d\n", data, type);
-	      break;
 
-	    case 8:         /* DECODER HEADER */
-	      num_decoder_words = (data & 0x3F);    /* number of decoder words to follow */
-	      decoder_index = 1;    /* identify next word as a decoder data word */
-	      if(lkDEBUG)
-		printf("%8X - DECODER HEADER = %d  (NUM DECODER WORDS = %d)\n",
-		       data, type, num_decoder_words);
-	      break;
-	      
-	    case 9:         /* UNDEFINED TYPE */
-	      if(lkDEBUG)
-		printf("%8X - UNDEFINED TYPE = %d\n", data, type);
-	      break;
-	      
-	    case 10:                /* UNDEFINED TYPE */
-	      if(lkDEBUG)
-		printf("%8X - UNDEFINED TYPE = %d\n", data, type);
-	      break;
-	      
-	    case 11:                /* UNDEFINED TYPE */
-	      if(lkDEBUG)
-		printf("%8X - UNDEFINED TYPE = %d\n", data, type);
-	      break;
-	      
-	    case 12:                /* UNDEFINED TYPE */
-	      if(lkDEBUG)
-		printf("%8X - UNDEFINED TYPE = %d\n", data, type);
-	      break;
-	      
-	    case 13:                /* END OF EVENT */
-	      if(lkDEBUG)
-		printf("%8X - END OF EVENT = %d\n", data, type);
-	      break;
-	      
-	    case 14:                /* DATA NOT VALID (no data available) */
-	      slot_id_dnv = (data & 0x7C00000) >> 22;
-	      if(lkDEBUG)
-		printf("%8X - DATA NOT VALID = %d  slot = %d\n", data,
-		       type, slot_id_dnv);
-	      break;
-	      
-	    case 15:                /* FILLER WORD */
-	      slot_id_fill = (data & 0x7C00000) >> 22;
-	      if(lkDEBUG)
-		printf("%8X - FILLER WORD = %d  slot = %d\n", data, type,
-		       slot_id_fill);
-	      break;
-	    }
-	  
-	  type_last = type; /* save type of current data word */
-	  
-	}
+            case 4:         /* UNDEFINED TYPE */
+              if(lkDEBUG)
+                printf("%8X - UNDEFINED TYPE = %d\n", data, type);
+              break;
+
+            case 5:         /* UNDEFINED TYPE */
+              if(lkDEBUG)
+                printf("%8X - UNDEFINED TYPE = %d\n", data, type);
+              break;
+
+            case 6:         /* UNDEFINED TYPE */
+              if(lkDEBUG)
+                printf("%8X - UNDEFINED TYPE = %d\n", data, type);
+              break;
+
+            case 7:         /* UNDEFINED TYPE */
+              if(lkDEBUG)
+                printf("%8X - UNDEFINED TYPE = %d\n", data, type);
+              break;
+
+            case 8:         /* DECODER HEADER */
+              num_decoder_words = (data & 0x3F);    /* number of decoder words to follow */
+              decoder_index = 1;    /* identify next word as a decoder data word */
+              if(lkDEBUG)
+                printf("%8X - DECODER HEADER = %d  (NUM DECODER WORDS = %d)\n",
+                       data, type, num_decoder_words);
+              break;
+
+            case 9:         /* UNDEFINED TYPE */
+              if(lkDEBUG)
+                printf("%8X - UNDEFINED TYPE = %d\n", data, type);
+              break;
+
+            case 10:                /* UNDEFINED TYPE */
+              if(lkDEBUG)
+                printf("%8X - UNDEFINED TYPE = %d\n", data, type);
+              break;
+
+            case 11:                /* UNDEFINED TYPE */
+              if(lkDEBUG)
+                printf("%8X - UNDEFINED TYPE = %d\n", data, type);
+              break;
+
+            case 12:                /* UNDEFINED TYPE */
+              if(lkDEBUG)
+                printf("%8X - UNDEFINED TYPE = %d\n", data, type);
+              break;
+
+            case 13:                /* END OF EVENT */
+              if(lkDEBUG)
+                printf("%8X - END OF EVENT = %d\n", data, type);
+              break;
+
+            case 14:                /* DATA NOT VALID (no data available) */
+              slot_id_dnv = (data & 0x7C00000) >> 22;
+              if(lkDEBUG)
+                printf("%8X - DATA NOT VALID = %d  slot = %d\n", data,
+                       type, slot_id_dnv);
+              break;
+
+            case 15:                /* FILLER WORD */
+              slot_id_fill = (data & 0x7C00000) >> 22;
+              if(lkDEBUG)
+                printf("%8X - FILLER WORD = %d  slot = %d\n", data, type,
+                       slot_id_fill);
+              break;
+            }
+
+          type_last = type; /* save type of current data word */
+
+        }
     }
-  }    
+  }
   return 0;
 }
 
@@ -677,11 +680,11 @@ void  QwHelicityDecoder::FillHistograms()
       if (fHistograms[index]!=NULL)
         fHistograms[index]->Fill(fActualPatternPolarity);
       index+=1;
-      
+
       for (size_t i=0; i<fWord.size(); i++){
         if (fHistograms[index]!=NULL)
           fHistograms[index]->Fill(fWord[i].fValue);
-        index+=1;       
+        index+=1;
         QwDebug << "QwHelicityDecoder::FillHistograms " << fWord[i].fWordName << "=" << fWord[i].fValue << QwLog::endl;
       }
     }
@@ -726,7 +729,7 @@ void  QwHelicityDecoder::ConstructBranchAndVector(TTree *tree, TString &prefix, 
        basename = "hd_actual_helicity";    //predicted actual helicity before being delayed.
        values.push_back(basename, 'I');
        tree->Branch(basename, &(values.back<Double_t>()), basename+"/I");
-      
+
       basename = "hd_delayed_helicity";   //predicted delayed helicity
        values.push_back(basename, 'I');
        tree->Branch(basename, &(values.back<Double_t>()), basename+"/I");
@@ -758,7 +761,31 @@ void  QwHelicityDecoder::ConstructBranchAndVector(TTree *tree, TString &prefix, 
       basename = "hd_Reported_Pattern_Hel";
        values.push_back(basename, 'I');
        tree->Branch(basename, &(values.back<Double_t>()), basename+"/I");
-      //
+      //new time / status variables
+       basename = "hd_num_tstable_fall";
+      values.push_back(basename, 'I');
+      tree->Branch(basename, &(values.back<Double_t>()), basename+"/I");
+
+      basename = "hd_num_pair_sync";
+      values.push_back(basename, 'I');
+      tree->Branch(basename, &(values.back<Double_t>()), basename+"/I");
+
+      basename = "hd_time_since_tstable";
+      values.push_back(basename, 'I');
+      tree->Branch(basename, &(values.back<Double_t>()), basename+"/I");
+
+      basename = "hd_time_since_tsettle";
+      values.push_back(basename, 'I');
+      tree->Branch(basename, &(values.back<Double_t>()), basename+"/I");
+
+      basename = "hd_last_duration_tstable";
+      values.push_back(basename, 'I');
+      tree->Branch(basename, &(values.back<Double_t>()), basename+"/I");
+
+      basename = "hd_last_duration_tsettle";
+      values.push_back(basename, 'I');
+      tree->Branch(basename, &(values.back<Double_t>()), basename+"/I");
+
       for (size_t i=0; i<fWord.size(); i++)
         {
           basename = fWord[i].fWordName;
@@ -960,8 +987,16 @@ void  QwHelicityDecoder::FillTreeVector(QwRootTreeBranchVector &values) const
       values.SetValue(index++, fEventNumber);
       values.SetValue(index++, fEventPolarity);
       values.SetValue(index++, fReportedPatternHel);
+       // NEW TIME / STATUS VARIABLES
+      values.SetValue(index++, fNum_TStable_Fall);
+      values.SetValue(index++, fNum_Pair_Sync);
+      values.SetValue(index++, fTime_since_TStable);
+      values.SetValue(index++, fTime_since_TSettle);
+      values.SetValue(index++, fLast_Duration_TStable);
+      values.SetValue(index++, fLast_Duration_TSettle);
+
       for (size_t i=0; i<fWord.size(); i++)
-	values.SetValue(index++, fWord[i].fValue);
+        values.SetValue(index++, fWord[i].fValue);
     }
   else if(fHistoType==kHelSavePattern)
     {
@@ -972,7 +1007,7 @@ void  QwHelicityDecoder::FillTreeVector(QwRootTreeBranchVector &values) const
       values.SetValue(index++, fPatternNumber);
       values.SetValue(index++, fPatternSeed);
       for (size_t i=0; i<fWord.size(); i++){
-	values.SetValue(index++, fWord[i].fValue);
+        values.SetValue(index++, fWord[i].fValue);
       }
     }
 
@@ -984,8 +1019,8 @@ void QwHelicityDecoder::RunPredictor()
   Int_t ldebug = kFALSE;
 
   if(ldebug)  std::cout  << "Entering QwHelicityDecoder::RunPredictor for fEventNumber, " << fEventNumber
-			 << ", fPatternNumber, " << fPatternNumber
-			 <<  ", and fPatternPhaseNumber, " << fPatternPhaseNumber << std::endl;
+                         << ", fPatternNumber, " << fPatternNumber
+                         <<  ", and fPatternPhaseNumber, " << fPatternPhaseNumber << std::endl;
 
     /**Update the random seed if the new event is from a different pattern.
        Check the difference between old pattern number and the new one and
@@ -995,23 +1030,23 @@ void QwHelicityDecoder::RunPredictor()
       if((fPatternPhaseNumber==fMinPatternPhase)&& (fPatternNumber>=0)) {
         iseed_Delayed = fSeed_Reported & 0x7fffffff;
 
-	/** set the polarity of the current pattern to be equal to the reported helicity,*/
-	fDelayedPatternPolarity = fHelicityReported;
-	QwDebug << "QwHelicityDecoder:: CollectRandBits30:  delayedpatternpolarity =" << fDelayedPatternPolarity << QwLog::endl;
+        /** set the polarity of the current pattern to be equal to the reported helicity,*/
+        fDelayedPatternPolarity = fHelicityReported;
+        QwDebug << "QwHelicityDecoder:: CollectRandBits30:  delayedpatternpolarity =" << fDelayedPatternPolarity << QwLog::endl;
 
-	/** then use it as the delayed helicity, */
-	fHelicityDelayed = fDelayedPatternPolarity;
+        /** then use it as the delayed helicity, */
+        fHelicityDelayed = fDelayedPatternPolarity;
 
-	/**if the helicity is delayed by a positive number of patterns then loop the delayed ranseed backward to get the ranseed
-	   for the actual helicity */
-	if(fHelicityDelay >=0){
-	  iseed_Actual = iseed_Delayed;
-	  for(Int_t i=0; i<fHelicityDelay; i++) {
-	    /**, get the pattern polarity for the actual pattern using that actual ranseed.*/
-	    fPreviousPatternPolarity = fActualPatternPolarity;
-	    fActualPatternPolarity = GetRandbit30(iseed_Actual);
-	  }
-	} 
+        /**if the helicity is delayed by a positive number of patterns then loop the delayed ranseed backward to get the ranseed
+           for the actual helicity */
+        if(fHelicityDelay >=0){
+          iseed_Actual = iseed_Delayed;
+          for(Int_t i=0; i<fHelicityDelay; i++) {
+            /**, get the pattern polarity for the actual pattern using that actual ranseed.*/
+            fPreviousPatternPolarity = fActualPatternPolarity;
+            fActualPatternPolarity = GetRandbit30(iseed_Actual);
+          }
+        }
      }
     fHelicityActual  = fActualPatternPolarity ^ fEventPolarity;
     fHelicityDelayed = fDelayedPatternPolarity ^ fEventPolarity;
@@ -1019,10 +1054,10 @@ void QwHelicityDecoder::RunPredictor()
 
   if(ldebug){
     std::cout << "Predicted Polarity ::: Delayed ="
-	      << fDelayedPatternPolarity << " Actual ="
-	      << fActualPatternPolarity << "\n";
+              << fDelayedPatternPolarity << " Actual ="
+              << fActualPatternPolarity << "\n";
     std::cout << "Predicted Helicity ::: Delayed Helicity=" << fHelicityDelayed
-	      << " Actual Helicity=" << fHelicityActual << " Reported Helicity=" << fHelicityReported << "\n";
+              << " Actual Helicity=" << fHelicityActual << " Reported Helicity=" << fHelicityReported << "\n";
     QwError << "Exiting QwHelicityDecoder::RunPredictor " << QwLog::endl;
 
   }
@@ -1054,12 +1089,12 @@ void QwHelicityDecoder::SetHelicityDelay(Int_t delay)
     fHelicityDelay = delay;
     if(delay == 0){
       QwWarning << "QwHelicityDecoder : SetHelicityDelay ::  helicity delay is set to 0."
-		<< " Disabling helicity predictor and using reported helicity information." 
-		<< QwLog::endl;
+                << " Disabling helicity predictor and using reported helicity information."
+                << QwLog::endl;
       fUsePredictor = kFALSE;
     }
     else
-      fUsePredictor = kTRUE; 
+      fUsePredictor = kTRUE;
   }
   else
     QwError << "QwHelicityDecoder::SetHelicityDelay We cannot handle negative delay in the prediction of delayed helicity. Exiting.." << QwLog::endl;
@@ -1096,7 +1131,7 @@ VQwSubsystem&  QwHelicityDecoder::operator=  (VQwSubsystem *value)
       QwHelicityDecoder* input= dynamic_cast<QwHelicityDecoder*>(value);
 
       for(size_t i=0;i<input->fWord.size();i++)
-	this->fWord[i].fValue=input->fWord[i].fValue;
+        this->fWord[i].fValue=input->fWord[i].fValue;
       this->fHelicityActual = input->fHelicityActual;
       this->fPatternNumber  = input->fPatternNumber;
       this->fPatternSeed    = input->fPatternSeed;
@@ -1115,6 +1150,13 @@ VQwSubsystem&  QwHelicityDecoder::operator=  (VQwSubsystem *value)
       this->fIgnoreHelicity = input->fIgnoreHelicity;
       this->fEventPolarity = input->fEventPolarity;
       this->fReportedPatternHel = input->fReportedPatternHel;
+      //new time / status variables
+      this->fNum_TStable_Fall     = input->fNum_TStable_Fall;
+      this->fNum_Pair_Sync        = input->fNum_Pair_Sync;
+      this->fTime_since_TStable   = input->fTime_since_TStable;
+      this->fTime_since_TSettle   = input->fTime_since_TSettle;
+      this->fLast_Duration_TStable = input->fLast_Duration_TStable;
+      this->fLast_Duration_TSettle = input->fLast_Duration_TSettle;
 
       this->fErrorFlag = input->fErrorFlag;
       this->fEventNumberFirst     = input->fEventNumberFirst;
@@ -1125,8 +1167,8 @@ VQwSubsystem&  QwHelicityDecoder::operator=  (VQwSubsystem *value)
       this->fNumHelicityErrors    = input->fNumHelicityErrors;
 
       if(ldebug){
-	std::cout << "QwHelicityDecoder::operator = this->fPatternNumber=" << this->fPatternNumber << std::endl;
-	std::cout << "input->fPatternNumber=" << input->fPatternNumber << "\n";
+        std::cout << "QwHelicityDecoder::operator = this->fPatternNumber=" << this->fPatternNumber << std::endl;
+        std::cout << "input->fPatternNumber=" << input->fPatternNumber << "\n";
       }
     }
 
@@ -1138,7 +1180,7 @@ VQwSubsystem&  QwHelicityDecoder::operator+=  (VQwSubsystem *value)
   //  Bool_t localdebug=kFALSE;
   QwDebug << "Entering QwHelicityDecoder::operator+= adding " << value->GetName() << " to " << this->GetName() << " " << QwLog::endl;
 
-  //this routine is most likely to be called during the computatin of assymetry
+  //this routine is most likely to be called during the computation of asymmetry
   //this call doesn't make too much sense for this class so the following lines
   //are only use to put safe gards testing for example if the two instantiation indeed
   // refers to elements in the same pattern.
@@ -1152,11 +1194,11 @@ void QwHelicityDecoder::CheckPatternNum(VQwSubsystem *value)
   //  Bool_t localdebug=kFALSE;
   if(Compare(value)) {
     QwHelicityDecoder* input= dynamic_cast<QwHelicityDecoder*>(value);
-    QwDebug << "QwHelicityDecoder::MergeCounters: this->fPatternNumber=" << this->fPatternNumber 
-	    << ", input->fPatternNumber=" << input->fPatternNumber << QwLog::endl;
+    QwDebug << "QwHelicityDecoder::MergeCounters: this->fPatternNumber=" << this->fPatternNumber
+            << ", input->fPatternNumber=" << input->fPatternNumber << QwLog::endl;
 
     this->fErrorFlag |= input->fErrorFlag;
-    
+
     //  Make sure the pattern number and poalrity agree!
     if(this->fPatternNumber!=input->fPatternNumber)
       this->fPatternNumber=-999999;
@@ -1178,7 +1220,7 @@ void QwHelicityDecoder::MergeCounters(VQwSubsystem *value)
       std::min(fEventNumber, input->fEventNumber);
     for (size_t i=0; i<fWord.size(); i++) {
       fWord[i].fValue =  (fWord[i].fValue == 0) ? input->fWord[i].fValue :
-	std::min( fWord[i].fValue, input->fWord[i].fValue);
+        std::min( fWord[i].fValue, input->fWord[i].fValue);
     }
   }
 }
@@ -1197,7 +1239,7 @@ void  QwHelicityDecoder::AccumulateRunningSum(VQwSubsystem* value, Int_t count, 
     QwHelicityDecoder* input = dynamic_cast<QwHelicityDecoder*>(value);
     fPatternNumber = (fPatternNumber <=0 ) ? input->fPatternNumber :
       std::min(fPatternNumber, input->fPatternNumber);
-    //  Keep track of the various error quantities, so we can print 
+    //  Keep track of the various error quantities, so we can print
     //  them at the end.
     fNumMissedGates       = input->fNumMissedGates;
     fNumMissedEventBlocks = input->fNumMissedEventBlocks;

--- a/Parity/src/QwWords.cc
+++ b/Parity/src/QwWords.cc
@@ -1,0 +1,156 @@
+#include "QwWords.h"
+#include "QwRootFile.h"
+#include <algorithm>
+
+QwWords::QwWords(TString const& name)
+: VQwSubsystem(name)
+, VQwSubsystemParity(name) {}
+
+QwWords::QwWords(QwWords const& other)
+: VQwSubsystem(other)
+, VQwSubsystemParity(other)
+, fWords(other.fWords)
+, fTreeArrayIndex(other.fTreeArrayIndex) {}
+
+Int_t QwWords::LoadChannelMap(TString mapfile)
+{
+	// Open the Param file
+	QwParameterFile mapstr(mapfile.Data());
+  	mapstr.EnableGreediness();
+  	mapstr.SetCommentChars("!");
+
+  	fDetectorMaps.insert(mapstr.GetParamFileNameContents());
+
+  	while (mapstr.ReadNextLine())  {
+  		// This sets fCurrentROC_ID and fCurrentBank_ID
+		RegisterRocBankMarker(mapstr);
+		mapstr.TrimComment();       // Remove everything after a comment character.
+		mapstr.TrimWhitespace();    // Get rid of leading and trailing whitespace
+    	if (mapstr.LineIsEmpty())  continue;
+		
+		//  Break this line into tokens to process it.
+		TString modtype = mapstr.GetTypedNextToken<TString>();
+		UInt_t  modnum  = mapstr.GetTypedNextToken<UInt_t>();
+		UInt_t  channum = mapstr.GetTypedNextToken<UInt_t>();
+		TString dettype = mapstr.GetTypedNextToken<TString>();
+		TString name    = mapstr.GetTypedNextToken<TString>();
+		modtype.ToUpper();
+		dettype.ToUpper();
+
+		if(modtype != "WORD") {
+			QwError << "Unrecognized module type " << modtype << QwLog::endl;
+			continue;
+		}
+		// Register data channel type
+		Int_t subbank = GetSubbankIndex();
+        QwVerbose << "Registering " << modtype << " " << name
+                  << std::hex
+                  << " in ROC 0x" << fCurrentROC_ID << ", bank 0x" << fCurrentBank_ID
+                  << std::dec
+                  << " at mod " << modnum << ", chan " << channum
+                  << QwLog::endl;
+		fWords.emplace_back( QwWord{subbank, 0, modtype, name, dettype, -1} );
+	}
+	return 0;
+}
+
+VQwSubsystem&  QwWords::operator=  (VQwSubsystem *value) 
+{
+	if(Compare(value))
+	{
+		VQwSubsystem::operator=(value);
+		QwWords* input = dynamic_cast<QwWords*>(value);
+		fWords = input->fWords;
+		fTreeArrayIndex = input->fTreeArrayIndex;
+	}
+	return *this;
+}
+
+VQwSubsystem&  QwWords::operator+= (VQwSubsystem *value)
+{
+	if(Compare(value)){
+		QwWords* input = dynamic_cast<QwWords*>(value);
+		std::transform(fWords.cbegin(), fWords.cend(),
+					   input->fWords.cbegin(), fWords.begin(), 
+					   std::plus<>{});
+	}
+	return *this;
+}
+
+VQwSubsystem&  QwWords::operator-= (VQwSubsystem *value)
+{
+	if(Compare(value)){
+		QwWords* input = dynamic_cast<QwWords*>(value);
+		std::transform(fWords.cbegin(), fWords.cend(),
+					   input->fWords.cbegin(), fWords.begin(),
+					   std::minus<>{});
+	}
+	return *this;
+}
+
+
+void  QwWords::ClearEventData()
+{
+	for(auto & word : fWords) word.ClearEventData();
+}
+
+Int_t QwWords::ProcessEvBuffer(const ROCID_t roc_id, const BankID_t bank_id, UInt_t *buffer, UInt_t num_words)
+{
+	UInt_t words_read = 0;
+
+	// Get the subbank index (or -1 when no match)
+	Int_t subbank = GetSubbankIndex(roc_id, bank_id);
+	if (subbank >= 0 && num_words > 0) {
+		words_read++;
+		for(std::size_t i = 0; i < fWords.size(); i++)
+			fWords[i].fValue = buffer[i];
+		words_read = num_words;
+	}
+
+	return words_read;
+}
+
+void  QwWords::ConstructBranchAndVector(TTree *tree, TString &prefix, QwRootTreeBranchVector &values)
+{
+	TString basename;
+	fTreeArrayIndex  = values.size();
+	for (size_t i=0; i<fWords.size(); i++) {
+		basename = prefix(0, (prefix.First("|") >= 0)? prefix.First("|"): prefix.Length());
+		basename += fWords[i].fWordName;
+		values.push_back(basename.Data(), 'I');
+		tree->Branch(basename, &(values[fTreeArrayIndex + i]), values.LeafList(fTreeArrayIndex + i).c_str());
+	}
+
+}
+
+void QwWords::FillTreeVector(QwRootTreeBranchVector &values) const 
+{
+
+	std::size_t index = fTreeArrayIndex;
+	for (auto& word : fWords){
+		QwMessage << index << ") Setting " << word.fWordName << " = " << word.fValue << '\n';
+		values.SetValue(index++, word.fValue);
+	}
+}
+
+#ifdef HAS_RNTUPLE_SUPPORT
+void QwWords::ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& model, TString& prefix, std::vector<Double_t>& values, std::vector<std::shared_ptr<Double_t>>& fieldPtrs)
+{
+	TString basename;
+	fTreeArrayIndex  = values.size();
+	for (auto const& word : fWords) {
+		basename = prefix(0, (prefix.First("|") >= 0)? prefix.First("|"): prefix.Length());
+		basename += word.fWordName;
+		values.push_back(0.0);
+		fieldPtrs.push_back(model->MakeField<Double_t>(basename.Data()));
+	}
+}
+
+void QwWords::FillNTupleVector(std::vector<Double_t>& values) const
+{
+  size_t index = fTreeArrayIndex;
+  for (auto& word : fWords){
+    values[index++] = word.fValue;
+  }
+}
+#endif // HAS_RNTUPLE_SUPPORT

--- a/Parity/src/QwWords.cc
+++ b/Parity/src/QwWords.cc
@@ -32,10 +32,8 @@ Int_t QwWords::LoadChannelMap(TString mapfile)
 		TString modtype = mapstr.GetTypedNextToken<TString>();
 		UInt_t  modnum  = mapstr.GetTypedNextToken<UInt_t>();
 		UInt_t  channum = mapstr.GetTypedNextToken<UInt_t>();
-		TString dettype = mapstr.GetTypedNextToken<TString>();
 		TString name    = mapstr.GetTypedNextToken<TString>();
 		modtype.ToUpper();
-		dettype.ToUpper();
 
 		if(modtype != "WORD") {
 			QwError << "Unrecognized module type " << modtype << QwLog::endl;
@@ -49,7 +47,7 @@ Int_t QwWords::LoadChannelMap(TString mapfile)
                   << std::dec
                   << " at mod " << modnum << ", chan " << channum
                   << QwLog::endl;
-		fWords.emplace_back( QwWord{subbank, 0, modtype, name, dettype, -1} );
+		fWords.emplace_back( QwWord{subbank, 0, modtype, name, "", -1} );
 	}
 	return 0;
 }
@@ -61,7 +59,6 @@ VQwSubsystem&  QwWords::operator=  (VQwSubsystem *value)
 		VQwSubsystem::operator=(value);
 		QwWords* input = dynamic_cast<QwWords*>(value);
 		fWords = input->fWords;
-		fTreeArrayIndex = input->fTreeArrayIndex;
 	}
 	return *this;
 }
@@ -110,7 +107,79 @@ Int_t QwWords::ProcessEvBuffer(const ROCID_t roc_id, const BankID_t bank_id, UIn
 	return words_read;
 }
 
-void  QwWords::ConstructBranchAndVector(TTree *tree, TString &prefix, QwRootTreeBranchVector &values)
+void QwWords::ProcessEvent()
+{
+	// Do post-processing here
+	// By Default, we have none
+	return;
+}
+
+Bool_t QwWords::ApplySingleEventCuts()
+{
+	// Apply cuts here
+	// By Default, we have none
+	return true;
+}
+
+UInt_t QwWords::GetEventcutErrorFlag()
+{
+	// Return errors here
+	// By default, we have none
+	return 0;
+}
+void QwWords::AccumulateRunningSum(VQwSubsystem* value, Int_t count, Int_t ErrorMask)
+{
+	// No-op
+	return;
+}
+Bool_t QwWords::CheckForBurpFail(const VQwSubsystem *subsys)
+{
+	// Check for Burb failure
+	// By default, we succeed
+	return kFALSE;
+}
+
+void QwWords::DeaccumulateRunningSum(VQwSubsystem* value, Int_t ErrorMask)
+{
+	// No-op
+	return;
+}
+
+void QwWords::IncrementErrorCounters()
+{
+	// No-op
+	return;
+}
+void QwWords::Scale(Double_t factor)
+{
+	// No-op
+	return;
+}
+
+void QwWords::UpdateErrorFlag(const VQwSubsystem *ev_error)
+{
+	// No-op
+	return;
+}
+
+void QwWords::Ratio(VQwSubsystem *numer, VQwSubsystem *denom)
+{
+	// No-op
+	return;
+}
+
+void QwWords::CalculateRunningAverage()
+{
+	// No-op
+	return;
+}
+
+void QwWords::PrintErrorCounters() const
+{
+	// No-op
+	return;
+}
+void QwWords::ConstructBranchAndVector(TTree *tree, TString &prefix, QwRootTreeBranchVector &values)
 {
 	TString basename;
 	fTreeArrayIndex  = values.size();
@@ -126,9 +195,8 @@ void  QwWords::ConstructBranchAndVector(TTree *tree, TString &prefix, QwRootTree
 void QwWords::FillTreeVector(QwRootTreeBranchVector &values) const 
 {
 
-	std::size_t index = fTreeArrayIndex;
+	int index = fTreeArrayIndex;
 	for (auto& word : fWords){
-		QwMessage << index << ") Setting " << word.fWordName << " = " << word.fValue << '\n';
 		values.SetValue(index++, word.fValue);
 	}
 }
@@ -148,7 +216,7 @@ void QwWords::ConstructNTupleAndVector(std::unique_ptr<ROOT::RNTupleModel>& mode
 
 void QwWords::FillNTupleVector(std::vector<Double_t>& values) const
 {
-  size_t index = fTreeArrayIndex;
+  int index = fTreeArrayIndex;
   for (auto& word : fWords){
     values[index++] = word.fValue;
   }


### PR DESCRIPTION
# Background

`class QwWord`, defined in Analysis/include/QwWord, is our word-level data manipulation class. This class is used to inside QwHelicityBase, derived helicity classes, and the QwBeamMod class to handle individual words in the data stream. 

A common word that we inject into our data stream are the so called scandata words and/or cleandata. These words are particularly helpful for offline analysis, and a lot of our pre-existing analysis scripts use these words as cut parameters. 

On VxWorks systems, the scandata words were injected into the HD data bank and decoded as part of the HD subsystem. The new HelicityDecoder class no longer decodes these words and we are likely moving to storing these new words into their own data bank. Therefore, it has been discussed on generalizing our handling of individual data words into a QwWords subsystem. 

# Draft PR
This PR implements a barebones QwWord subsystem, QwWords. I say barebones as numerous members functions inherited from VQwSubsystemParity are left as no ops or will throw if called. Those functions require further specialization. This draft PR serves as a basis for discussion. 

# Discussion

### Q1: What do we want to see from such a subsystem?
The idea is to generalize our handling of QwWord elements. Are we wanting to then create derived classes from a QwWords subsystem that adds those specializations mentioned above? For elements like QwBeamMod which use QwWords extensively, how are we wanting to decouple the implementation? Are we wanting to create a new heirarchy chain -- eg are we wanting QwBeamMod to inherit from the QwWords subsystem? 

### Q2: How do we want to handle mul tree output for QwWords?
As of now, the mul & pr tree output:
```
*............................................................................*
*Br   29 :asym_cleanword : asym_cleanword/I                                  *
*Entries :    11826 : Total  Size=      48065 bytes  File Size  =        421 *
*Baskets :        3 : Basket Size=      16000 bytes  Compression= 112.93     *
*............................................................................*
*Br   30 :asym_word1 : asym_word1/I                                          *
*Entries :    11826 : Total  Size=      48037 bytes  File Size  =        395 *
*Baskets :        3 : Basket Size=      16000 bytes  Compression= 120.33     *
*............................................................................*
*Br   31 :asym_word2 : asym_word2/I                                          *
*Entries :    11826 : Total  Size=      48037 bytes  File Size  =        368 *
*Baskets :        3 : Basket Size=      16000 bytes  Compression= 129.16     *
*............................................................................*
*Br   32 :asym_word3 : asym_word3/I                                          *
*Entries :    11826 : Total  Size=      48037 bytes  File Size  =        368 *
*Baskets :        3 : Basket Size=      16000 bytes  Compression= 129.16     *
*............................................................................*
*Br   33 :asym_word4 : asym_word4/I                                          *
*Entries :    11826 : Total  Size=      48037 bytes  File Size  =        368 *
*Baskets :        3 : Basket Size=      16000 bytes  Compression= 129.16     *
*............................................................................*
```

For scandata words, it would be ideal to have 
```
mul->Draw("asym_bcm0l02:scandata1", "cleandata")
```
 and the `asym_` & `yield_` prefixes are pointless. For this particular instance, we could introduce logic similar to `QwhelicityDecoder::SetHistoTreeSave(const TString &prefix);`; but on other systems, maybe an `asym_` branch is desired?

### Q3: Do we even care for this to be general?
The goal on the onset is to support the scandata words. Do we want this subsystem to be hyper-specific to the scandata bank(s)? 

#### Test Output
A test evio file with these scandata words can be found here on aonl1
```
aonl1:/cache/halla/moller12gev/integrating_data/moller_integrating_1626.evio.0
```
and the parameter files can be found in 
[test_files.tar.gz](https://github.com/user-attachments/files/31153082/test_files.tar.gz)
