### PR TITLE
Cleanup: Remove unused  Coda_Clean(Scan)Data words

### DIFF
--- a/Analysis/include/QwSubsystemArray.h
+++ b/Analysis/include/QwSubsystemArray.h
@@ -89,14 +89,6 @@ class QwSubsystemArray:
   /// \brief Get the internal record of the CODA event type
   UInt_t GetCodaEventType() const { return fCodaEventType; };
 
-  /// \brief Set the internal record of the CODA event number
-  void SetCleanParameters(Double_t cleanparameter[3])
-  {
-    fCleanParameter[0] = cleanparameter[0];
-    fCleanParameter[1] = cleanparameter[1];
-    fCleanParameter[2] = cleanparameter[2];
-  };
-
   /// \brief Set event type mask
   void   SetEventTypeMask(const UInt_t mask) { fEventTypeMask = mask; };
   /// \brief Get event type mask
@@ -278,7 +270,6 @@ class QwSubsystemArray:
   UInt_t fCodaEventNumber;   ///< CODA event number as provided by QwEventBuffer
   UInt_t fCodaEventType;     ///< CODA event type as provided by QwEventBuffer
 
-  Double_t fCleanParameter[3];
   UInt_t fEventTypeMask;   ///< Mask of event types
   Bool_t fHasDataLoaded;   ///< Has this array gotten data to be processed?
 

--- a/Analysis/src/QwEventBuffer.cc
+++ b/Analysis/src/QwEventBuffer.cc
@@ -905,20 +905,6 @@ Bool_t QwEventBuffer::FillSubsystemData(QwSubsystemArray &subsystems)
     //  After trying the data in each subsystem, bump the
     //  fWordsSoFar to move to the next bank.
 
-                // TODO:
-                // What is special about this subbank?
-    if( decoder->GetROC() == 0 && decoder->GetSubbankTag()==0x6101) {
-      //std::cout << "ProcessEventBuffer: ROC="<<GetROC()<<", SubbankTag="<< GetSubbankTag()<<", FragLength="<<GetFragLength() <<std::endl;
-      fCleanParameter[0]=localbuff[decoder->GetWordsSoFar()+decoder->GetFragLength()-4];//clean data
-      fCleanParameter[1]=localbuff[decoder->GetWordsSoFar()+decoder->GetFragLength()-3];//scan data 1
-      fCleanParameter[2]=localbuff[decoder->GetWordsSoFar()+decoder->GetFragLength()-2];//scan data 2
-      //std::cout << "ProcessEventBuffer: ROC="<<GetROC()<<", SubbankTag="<< GetSubbankTag()
-      //                <<", FragLength="<<GetFragLength() << " " <<fCleanParameter[0]<< " " <<fCleanParameter[1]<< " " <<fCleanParameter[2]<<std::endl;
-
-    }
-
-    subsystems.SetCleanParameters(fCleanParameter);
-
     std::size_t nmarkers = CheckForMarkerWords(subsystems);
     if (nmarkers>0) {
       //  There are markerwords for this ROC/Bank

--- a/Analysis/src/QwSubsystemArray.cc
+++ b/Analysis/src/QwSubsystemArray.cc
@@ -562,15 +562,9 @@ void  QwSubsystemArray::ConstructBranchAndVector(
   // FillTreeVector().
   values.push_back("CodaEventNumber", 'i');
   values.push_back("CodaEventType", 'i');
-  values.push_back("Coda_CleanData", 'D');
-  values.push_back("Coda_ScanData1", 'D');
-  values.push_back("Coda_ScanData2", 'D');
   if (prefix == "" || prefix.Index("yield_") == 0) {
     tree->Branch("CodaEventNumber",&(values[fTreeArrayIndex]),"CodaEventNumber/i");
     tree->Branch("CodaEventType",&(values[fTreeArrayIndex+1]),"CodaEventType/i");
-    tree->Branch("Coda_CleanData",&(values[fTreeArrayIndex+2]),"Coda_CleanData/D");
-    tree->Branch("Coda_ScanData1",&(values[fTreeArrayIndex+3]),"Coda_ScanData1/D");
-    tree->Branch("Coda_ScanData2",&(values[fTreeArrayIndex+4]),"Coda_ScanData2/D");
   }
   for (iterator subsys = begin(); subsys != end(); ++subsys) {
     VQwSubsystem* subsys_ptr = dynamic_cast<VQwSubsystem*>(subsys->get());
@@ -691,20 +685,11 @@ void QwSubsystemArray::ConstructNTupleAndVector(
   if (prefix == "" || prefix.Index("yield_") == 0) {
     auto eventNumField = model->MakeField<Double_t>("CodaEventNumber");
     auto eventTypeField = model->MakeField<Double_t>("CodaEventType");
-    auto cleanDataField = model->MakeField<Double_t>("Coda_CleanData");
-    auto scanData1Field = model->MakeField<Double_t>("Coda_ScanData1");
-    auto scanData2Field = model->MakeField<Double_t>("Coda_ScanData2");
 
     fieldPtrs.push_back(eventNumField);
     fieldPtrs.push_back(eventTypeField);
-    fieldPtrs.push_back(cleanDataField);
-    fieldPtrs.push_back(scanData1Field);
-    fieldPtrs.push_back(scanData2Field);
   } else {
     // Still reserve space but don't create duplicate fields
-    fieldPtrs.push_back(nullptr);
-    fieldPtrs.push_back(nullptr);
-    fieldPtrs.push_back(nullptr);
     fieldPtrs.push_back(nullptr);
     fieldPtrs.push_back(nullptr);
   }

--- a/Analysis/src/QwSubsystemArray.cc
+++ b/Analysis/src/QwSubsystemArray.cc
@@ -20,7 +20,7 @@
  * Create a subsystem array based on the configuration option 'detectors'
  */
 QwSubsystemArray::QwSubsystemArray(QwOptions& options, CanContainFn myCanContain)
-: fCleanParameter{0,0,0},fEventTypeMask(0x0),fnCanContain(myCanContain)
+: fEventTypeMask(0x0),fnCanContain(myCanContain)
 {
   ProcessOptionsToplevel(options);
   QwParameterFile detectors(fSubsystemsMapFile.c_str());
@@ -47,8 +47,6 @@ QwSubsystemArray::QwSubsystemArray(const QwSubsystemArray& source)
   fSubsystemsDisabledByName(source.fSubsystemsDisabledByName),
   fSubsystemsDisabledByType(source.fSubsystemsDisabledByType)
 {
-  for (size_t i = 0; i < 3; i++)
-    fCleanParameter[i] = source.fCleanParameter[i];
 
   // Make copies of all subsystems rather than copying just the pointers
   for (const_iterator subsys = source.begin(); subsys != source.end(); ++subsys) {
@@ -647,9 +645,6 @@ void QwSubsystemArray::FillTreeVector(QwRootTreeBranchVector &values) const
   size_t index = fTreeArrayIndex;
   values.SetValue(index++, this->GetCodaEventNumber());
   values.SetValue(index++, this->GetCodaEventType());
-  values.SetValue(index++, this->fCleanParameter[0]);
-  values.SetValue(index++, this->fCleanParameter[1]);
-  values.SetValue(index++, this->fCleanParameter[2]);
 
   // Fill the subsystem data
   for (const_iterator subsys = begin(); subsys != end(); ++subsys) {
@@ -713,9 +708,6 @@ void QwSubsystemArray::FillNTupleVector(std::vector<Double_t>& values) const
   size_t index = fTreeArrayIndex;
   values[index++] = this->GetCodaEventNumber();
   values[index++] = this->GetCodaEventType();
-  values[index++] = this->fCleanParameter[0];
-  values[index++] = this->fCleanParameter[1];
-  values[index++] = this->fCleanParameter[2];
 
   // Fill the subsystem data
   for (const_iterator subsys = begin(); subsys != end(); ++subsys) {

--- a/Parity/src/QwHelicity.cc
+++ b/Parity/src/QwHelicity.cc
@@ -593,9 +593,6 @@ void QwHelicity::EncodeEventData(std::vector<UInt_t> &buffer)
     if (fHelicityDelayed == 1)    userbit |= 0x40000000;
 
     // Write the words to the buffer
-    localbuffer.push_back(0x1); // cleandata
-    localbuffer.push_back(0xa); // scandata1
-    localbuffer.push_back(0xa); // scandata2
     localbuffer.push_back(0x0); // scalerheader
     localbuffer.push_back(0x20); // scalercounter (32)
     localbuffer.push_back(userbit); // userbit


### PR DESCRIPTION
# PR
Related to #312 . It looks like we have historically stored cleandata and scandata words in a dedicated subbank, 0x6101. This likely predates our current usage of clean(scan)data that was managed by the QwHelicity class. 

## Note: 

The clean(scan)data functionality  has been removed from our QwHelicity subsystem, but the mock data still inserted clean(scan)data words. This PR removes those extraneous words as well.